### PR TITLE
Refactor receivers to stop depending on `apimodels`

### DIFF
--- a/alerting/receivers_test.go
+++ b/alerting/receivers_test.go
@@ -7,13 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
 
 func TestInvalidReceiverError_Error(t *testing.T) {
 	e := InvalidReceiverError{
-		Receiver: &definitions.PostableGrafanaReceiver{
+		Receiver: &GrafanaReceiver{
 			Name: "test",
 			UID:  "uid",
 		},
@@ -24,7 +22,7 @@ func TestInvalidReceiverError_Error(t *testing.T) {
 
 func TestReceiverTimeoutError_Error(t *testing.T) {
 	e := ReceiverTimeoutError{
-		Receiver: &definitions.PostableGrafanaReceiver{
+		Receiver: &GrafanaReceiver{
 			Name: "test",
 			UID:  "uid",
 		},
@@ -45,7 +43,7 @@ func (e timeoutError) Timeout() bool {
 
 func TestProcessNotifierError(t *testing.T) {
 	t.Run("assert ReceiverTimeoutError is returned for context deadline exceeded", func(t *testing.T) {
-		r := &definitions.PostableGrafanaReceiver{
+		r := &GrafanaReceiver{
 			Name: "test",
 			UID:  "uid",
 		}
@@ -56,7 +54,7 @@ func TestProcessNotifierError(t *testing.T) {
 	})
 
 	t.Run("assert ReceiverTimeoutError is returned for *url.Error timeout", func(t *testing.T) {
-		r := &definitions.PostableGrafanaReceiver{
+		r := &GrafanaReceiver{
 			Name: "test",
 			UID:  "uid",
 		}
@@ -72,7 +70,7 @@ func TestProcessNotifierError(t *testing.T) {
 	})
 
 	t.Run("assert unknown error is returned unmodified", func(t *testing.T) {
-		r := &definitions.PostableGrafanaReceiver{
+		r := &GrafanaReceiver{
 			Name: "test",
 			UID:  "uid",
 		}


### PR DESCRIPTION
To make sure we avoid circular dependencies, alerting needs to not depend on Grafana (it'll be the other way around - Grafana depends on Alerting).

This refactor removes the dependency from `apimodels` to do just that.

**This should break the tests and the linter due to a couple of missing functions but they would be immediately fixed on my next PR - I've chosen to split to make it easier to review**