### PR TITLE
Shadow both `PostableAlerts` and `PostableAlert`

### DIFF
--- a/alerting/alerts.go
+++ b/alerting/alerts.go
@@ -27,6 +27,8 @@ type GettableAlert = amv2.GettableAlert
 type AlertGroups = amv2.AlertGroups
 type AlertGroup = amv2.AlertGroup
 type Receiver = amv2.Receiver
+type PostableAlerts = amv2.PostableAlerts
+type PostableAlert = amv2.PostableAlert
 
 func (am *GrafanaAlertmanager) GetAlerts(active, silenced, inhibited bool, filter []string, receivers string) (GettableAlerts, error) {
 	var (


### PR DESCRIPTION
We need them to do the conversion between the alert type in Grafana and the Alertmanager.