### PR TITLE
Move VictorOps from Grafana repository

### DIFF
--- a/alerting/notifier/channels/factory.go
+++ b/alerting/notifier/channels/factory.go
@@ -12,7 +12,9 @@ import (
 type GetDecryptedValueFn func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string
 
 type FactoryConfig struct {
-	Config              *NotificationChannelConfig
+	Config *NotificationChannelConfig
+	// Used by some receivers to include as part of the source
+	GrafanaBuildVersion string
 	NotificationService NotificationSender
 	DecryptFunc         GetDecryptedValueFn
 	ImageStore          ImageStore
@@ -22,7 +24,7 @@ type FactoryConfig struct {
 }
 
 func NewFactoryConfig(config *NotificationChannelConfig, notificationService NotificationSender,
-	decryptFunc GetDecryptedValueFn, template *template.Template, imageStore ImageStore, loggerFactory LoggerFactory) (FactoryConfig, error) {
+	decryptFunc GetDecryptedValueFn, template *template.Template, imageStore ImageStore, loggerFactory LoggerFactory, buildVersion string) (FactoryConfig, error) {
 	if config.Settings == nil {
 		return FactoryConfig{}, errors.New("no settings supplied")
 	}
@@ -38,6 +40,7 @@ func NewFactoryConfig(config *NotificationChannelConfig, notificationService Not
 	return FactoryConfig{
 		Config:              config,
 		NotificationService: notificationService,
+		GrafanaBuildVersion: buildVersion,
 		DecryptFunc:         decryptFunc,
 		Template:            template,
 		ImageStore:          imageStore,

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -115,7 +115,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON.Set("entity_id", groupKey.Hash())
 	bodyJSON.Set("entity_display_name", tmpl(DefaultMessageTitleEmbed))
 	bodyJSON.Set("timestamp", time.Now().Unix())
-	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
+	bodyJSON.Set("state_message", tmpl(DefaultMessageEmbed))
 	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
 
 	_ = withStoredImages(ctx, vn.log, vn.images,

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -139,7 +138,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	}
 
 	_ = withStoredImages(ctx, vn.log, vn.images,
-		func(index int, image ngmodels.Image) error {
+		func(index int, image Image) error {
 			if image.URL != "" {
 				bodyJSON["image_url"] = image.URL
 				return ErrImagesDone

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/alerting"
 	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -32,7 +31,7 @@ const (
 func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template) (*VictoropsNotifier, error) {
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
-		return nil, alerting.ValidationError{Reason: "Could not find victorops url property in settings"}
+		return nil, receiverInitError{Cfg: *model, Reason: "could not find victorops url property in settings"}
 	}
 
 	return &VictoropsNotifier{

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -44,7 +44,7 @@ func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template
 			Settings:              model.Settings,
 		}),
 		URL:         url,
-		MessageType: strings.ToUpper(model.Settings.Get("messageType").MustString()),
+		MessageType: model.Settings.Get("messageType").MustString(),
 		log:         log.New("alerting.notifier.victorops"),
 		tmpl:        t,
 	}, nil
@@ -65,7 +65,10 @@ type VictoropsNotifier struct {
 func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	vn.log.Debug("Executing victorops notification", "notification", vn.Name)
 
-	messageType := vn.MessageType
+	var tmplErr error
+	tmpl, _ := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
+
+	messageType := strings.ToUpper(tmpl(vn.MessageType))
 	if messageType == "" {
 		messageType = victoropsAlertStateCritical
 	}
@@ -73,9 +76,6 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	if alerts.Status() == model.AlertResolved {
 		messageType = victoropsAlertStateRecovery
 	}
-
-	var tmplErr error
-	tmpl, _ := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
 
 	groupKey, err := notify.ExtractGroupKey(ctx)
 	if err != nil {
@@ -93,6 +93,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	ruleURL := joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)
 	bodyJSON.Set("alert_url", ruleURL)
 
+	u := tmpl(vn.URL)
 	if tmplErr != nil {
 		vn.log.Debug("failed to template VictorOps message", "err", tmplErr.Error())
 	}
@@ -102,7 +103,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 		return false, err
 	}
 	cmd := &models.SendWebhookSync{
-		Url:  vn.URL,
+		Url:  u,
 		Body: string(b),
 	}
 

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -31,6 +31,8 @@ const (
 type victorOpsSettings struct {
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
 	MessageType string `json:"messageType,omitempty" yaml:"messageType,omitempty"`
+	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 func buildVictorOpsSettings(fc FactoryConfig) (victorOpsSettings, error) {
@@ -44,6 +46,12 @@ func buildVictorOpsSettings(fc FactoryConfig) (victorOpsSettings, error) {
 	}
 	if settings.MessageType == "" {
 		settings.MessageType = victoropsAlertStateCritical
+	}
+	if settings.Title == "" {
+		settings.Title = DefaultMessageTitleEmbed
+	}
+	if settings.Description == "" {
+		settings.Description = DefaultMessageEmbed
 	}
 	return settings, nil
 }
@@ -101,15 +109,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	var tmplErr error
 	tmpl, _ := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
 
-	messageType := strings.ToUpper(tmpl(vn.settings.MessageType))
-	if messageType == "" {
-		vn.log.Warn("expansion of message type template resulted in an empty string. Using fallback", "fallback", victoropsAlertStateCritical, "template", vn.settings.MessageType)
-		messageType = victoropsAlertStateCritical
-	}
-	alerts := types.Alerts(as...)
-	if alerts.Status() == model.AlertResolved {
-		messageType = victoropsAlertStateRecovery
-	}
+	messageType := buildMessageType(vn.log, tmpl, vn.settings.MessageType, as...)
 
 	groupKey, err := notify.ExtractGroupKey(ctx)
 	if err != nil {
@@ -119,9 +119,9 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON := map[string]interface{}{
 		"message_type":        messageType,
 		"entity_id":           groupKey.Hash(),
-		"entity_display_name": tmpl(DefaultMessageTitleEmbed),
+		"entity_display_name": tmpl(vn.settings.Title),
 		"timestamp":           time.Now().Unix(),
-		"state_message":       tmpl(DefaultMessageEmbed),
+		"state_message":       tmpl(vn.settings.Description),
 		"monitoring_tool":     "Grafana v" + setting.BuildVersion,
 	}
 
@@ -168,4 +168,15 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 
 func (vn *VictoropsNotifier) SendResolved() bool {
 	return !vn.GetDisableResolveMessage()
+}
+
+func buildMessageType(l log.Logger, tmpl func(string) string, msgType string, as ...*types.Alert) string {
+	if types.Alerts(as...).Status() == model.AlertResolved {
+		return victoropsAlertStateRecovery
+	}
+	if messageType := strings.ToUpper(tmpl(msgType)); messageType != "" {
+		return messageType
+	}
+	l.Warn("expansion of message type template resulted in an empty string. Using fallback", "fallback", victoropsAlertStateCritical, "template", msgType)
+	return victoropsAlertStateCritical
 }

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -76,13 +75,7 @@ func NewVictoropsNotifier(fc FactoryConfig) (*VictoropsNotifier, error) {
 		return nil, err
 	}
 	return &VictoropsNotifier{
-		Base: NewBase(&models.AlertNotification{
-			Uid:                   fc.Config.UID,
-			Name:                  fc.Config.Name,
-			Type:                  fc.Config.Type,
-			DisableResolveMessage: fc.Config.DisableResolveMessage,
-			Settings:              fc.Config.Settings,
-		}),
+		Base:     NewBase(fc.Config),
 		log:      log.New("alerting.notifier.victorops"),
 		images:   fc.ImageStore,
 		ns:       fc.NotificationService,

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -76,7 +75,7 @@ func NewVictoropsNotifier(fc FactoryConfig) (*VictoropsNotifier, error) {
 	}
 	return &VictoropsNotifier{
 		Base:     NewBase(fc.Config),
-		log:      log.New("alerting.notifier.victorops"),
+		log:      fc.Logger,
 		images:   fc.ImageStore,
 		ns:       fc.NotificationService,
 		tmpl:     fc.Template,
@@ -89,7 +88,7 @@ func NewVictoropsNotifier(fc FactoryConfig) (*VictoropsNotifier, error) {
 // Victorops specifications (http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)
 type VictoropsNotifier struct {
 	*Base
-	log      log.Logger
+	log      Logger
 	images   ImageStore
 	ns       WebhookSender
 	tmpl     *template.Template
@@ -169,7 +168,7 @@ func (vn *VictoropsNotifier) SendResolved() bool {
 	return !vn.GetDisableResolveMessage()
 }
 
-func buildMessageType(l log.Logger, tmpl func(string) string, msgType string, as ...*types.Alert) string {
+func buildMessageType(l Logger, tmpl func(string) string, msgType string, as ...*types.Alert) string {
 	if types.Alerts(as...).Status() == model.AlertResolved {
 		return victoropsAlertStateRecovery
 	}

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -100,7 +99,7 @@ type VictoropsNotifier struct {
 	*Base
 	log      log.Logger
 	images   ImageStore
-	ns       notifications.WebhookSender
+	ns       WebhookSender
 	tmpl     *template.Template
 	settings victorOpsSettings
 }
@@ -161,12 +160,12 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	if err != nil {
 		return false, err
 	}
-	cmd := &models.SendWebhookSync{
+	cmd := &SendWebhookSettings{
 		Url:  u,
 		Body: string(b),
 	}
 
-	if err := vn.ns.SendWebhookSync(ctx, cmd); err != nil {
+	if err := vn.ns.SendWebhook(ctx, cmd); err != nil {
 		vn.log.Error("failed to send notification", "error", err, "webhook", vn.Name)
 		return false, err
 	}

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -127,7 +127,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 
 	if tmplErr != nil {
 		vn.log.Warn("failed to expand message template. "+
-			"", "err", tmplErr.Error())
+			"", "error", tmplErr.Error())
 		tmplErr = nil
 	}
 
@@ -145,7 +145,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 
 	u := tmpl(vn.settings.URL)
 	if tmplErr != nil {
-		vn.log.Info("failed to expand URL template", "err", tmplErr.Error(), "fallback", vn.settings.URL)
+		vn.log.Info("failed to expand URL template", "error", tmplErr.Error(), "fallback", vn.settings.URL)
 		u = vn.settings.URL
 	}
 
@@ -159,7 +159,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	}
 
 	if err := vn.ns.SendWebhookSync(ctx, cmd); err != nil {
-		vn.log.Error("failed to send notification", "err", err, "webhook", vn.Name)
+		vn.log.Error("failed to send notification", "error", err, "webhook", vn.Name)
 		return false, err
 	}
 

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	gokit_log "github.com/go-kit/kit/log"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -75,9 +74,11 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 		messageType = victoropsAlertStateRecovery
 	}
 
-	data := notify.GetTemplateData(ctx, vn.tmpl, as, gokit_log.NewNopLogger())
 	var tmplErr error
-	tmpl := notify.TmplText(vn.tmpl, data, &tmplErr)
+	tmpl, _, err := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
+	if err != nil {
+		return false, err
+	}
 
 	groupKey, err := notify.ExtractGroupKey(ctx)
 	if err != nil {

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -28,6 +28,10 @@ const (
 // NewVictoropsNotifier creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
 func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template) (*VictoropsNotifier, error) {
+	if model.Settings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
 		return nil, receiverInitError{Cfg: *model, Reason: "could not find victorops url property in settings"}

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -2,7 +2,6 @@ package channels
 
 import (
 	"context"
-	"path"
 	"strings"
 	"time"
 
@@ -92,7 +91,12 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON.Set("timestamp", time.Now().Unix())
 	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
 	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
-	bodyJSON.Set("alert_url", path.Join(vn.tmpl.ExternalURL.String(), "/alerting/list"))
+
+	ruleURL, err := joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list")
+	if err != nil {
+		return false, err
+	}
+	bodyJSON.Set("alert_url", ruleURL)
 
 	b, err := bodyJSON.MarshalJSON()
 	if err != nil {

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -1,0 +1,116 @@
+package channels
+
+import (
+	"context"
+	"path"
+	"strings"
+	"time"
+
+	gokit_log "github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const (
+	// victoropsAlertStateCritical - Victorops uses "CRITICAL" string to indicate "Alerting" state
+	victoropsAlertStateCritical = "CRITICAL"
+
+	// victoropsAlertStateRecovery - VictorOps "RECOVERY" message type
+	victoropsAlertStateRecovery = "RECOVERY"
+)
+
+// NewVictoropsNotifier creates an instance of VictoropsNotifier that
+// handles posting notifications to Victorops REST API
+func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template) (*VictoropsNotifier, error) {
+	url := model.Settings.Get("url").MustString()
+	if url == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find victorops url property in settings"}
+	}
+
+	return &VictoropsNotifier{
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		URL:         url,
+		MessageType: strings.ToUpper(model.Settings.Get("messageType").MustString()),
+		log:         log.New("alerting.notifier.victorops"),
+		tmpl:        t,
+	}, nil
+}
+
+// VictoropsNotifier defines URL property for Victorops REST API
+// and handles notification process by formatting POST body according to
+// Victorops specifications (http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)
+type VictoropsNotifier struct {
+	old_notifiers.NotifierBase
+	URL         string
+	MessageType string
+	log         log.Logger
+	tmpl        *template.Template
+}
+
+// Notify sends notification to Victorops via POST to URL endpoint
+func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	vn.log.Debug("Executing victorops notification", "notification", vn.Name)
+
+	messageType := vn.MessageType
+	if messageType == "" {
+		messageType = victoropsAlertStateCritical
+	}
+	alerts := types.Alerts(as...)
+	if alerts.Status() == model.AlertResolved {
+		messageType = victoropsAlertStateRecovery
+	}
+
+	data := notify.GetTemplateData(ctx, vn.tmpl, as, gokit_log.NewNopLogger())
+	var tmplErr error
+	tmpl := notify.TmplText(vn.tmpl, data, &tmplErr)
+
+	groupKey, err := notify.ExtractGroupKey(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	bodyJSON := simplejson.New()
+	bodyJSON.Set("message_type", messageType)
+	bodyJSON.Set("entity_id", groupKey.Hash())
+	bodyJSON.Set("entity_display_name", tmpl(`{{ template "default.title" . }}`))
+	bodyJSON.Set("timestamp", time.Now().Unix())
+	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
+	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
+	bodyJSON.Set("alert_url", path.Join(vn.tmpl.ExternalURL.String(), "/alerting/list"))
+
+	b, err := bodyJSON.MarshalJSON()
+	if err != nil {
+		return false, err
+	}
+	cmd := &models.SendWebhookSync{
+		Url:  vn.URL,
+		Body: string(b),
+	}
+
+	if err := bus.DispatchCtx(ctx, cmd); err != nil {
+		vn.log.Error("Failed to send Victorops notification", "error", err, "webhook", vn.Name)
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (vn *VictoropsNotifier) SendResolved() bool {
+	return !vn.GetDisableResolveMessage()
+}

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -109,7 +109,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 		Body: string(b),
 	}
 
-	if err := bus.DispatchCtx(ctx, cmd); err != nil {
+	if err := bus.Dispatch(ctx, cmd); err != nil {
 		vn.log.Error("Failed to send Victorops notification", "error", err, "webhook", vn.Name)
 		return false, err
 	}

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -35,7 +34,7 @@ func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template
 	}
 
 	return &VictoropsNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+		Base: NewBase(&models.AlertNotification{
 			Uid:                   model.UID,
 			Name:                  model.Name,
 			Type:                  model.Type,
@@ -53,7 +52,7 @@ func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template
 // and handles notification process by formatting POST body according to
 // Victorops specifications (http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)
 type VictoropsNotifier struct {
-	old_notifiers.NotifierBase
+	*Base
 	URL         string
 	MessageType string
 	log         log.Logger

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -87,7 +87,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON := simplejson.New()
 	bodyJSON.Set("message_type", messageType)
 	bodyJSON.Set("entity_id", groupKey.Hash())
-	bodyJSON.Set("entity_display_name", tmpl(`{{ template "default.title" . }}`))
+	bodyJSON.Set("entity_display_name", tmpl(DefaultMessageTitleEmbed))
 	bodyJSON.Set("timestamp", time.Now().Unix())
 	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
 	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
@@ -97,7 +97,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 
 	u := tmpl(vn.URL)
 	if tmplErr != nil {
-		vn.log.Debug("failed to template VictorOps message", "err", tmplErr.Error())
+		vn.log.Warn("failed to template VictorOps message", "err", tmplErr.Error())
 	}
 
 	b, err := bodyJSON.MarshalJSON()

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -118,9 +118,15 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	ruleURL := joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)
 	bodyJSON.Set("alert_url", ruleURL)
 
-	u := tmpl(vn.URL)
 	if tmplErr != nil {
 		vn.log.Warn("failed to template VictorOps message", "err", tmplErr.Error())
+		tmplErr = nil
+	}
+
+	u := tmpl(vn.URL)
+	if tmplErr != nil {
+		vn.log.Info("failed to template VictorOps URL", "err", tmplErr.Error(), "fallback", vn.URL)
+		u = vn.URL
 	}
 
 	b, err := bodyJSON.MarshalJSON()

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -40,7 +41,7 @@ func VictorOpsFactory(fc FactoryConfig) (NotificationChannel, error) {
 			Cfg:    *fc.Config,
 		}
 	}
-	return NewVictoropsNotifier(cfg, fc.NotificationService, fc.Template), nil
+	return NewVictoropsNotifier(cfg, fc.ImageStore, fc.NotificationService, fc.Template), nil
 }
 
 func NewVictorOpsConfig(config *NotificationChannelConfig) (*VictorOpsConfig, error) {
@@ -57,7 +58,7 @@ func NewVictorOpsConfig(config *NotificationChannelConfig) (*VictorOpsConfig, er
 
 // NewVictoropsNotifier creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
-func NewVictoropsNotifier(config *VictorOpsConfig, ns notifications.WebhookSender, t *template.Template) *VictoropsNotifier {
+func NewVictoropsNotifier(config *VictorOpsConfig, images ImageStore, ns notifications.WebhookSender, t *template.Template) *VictoropsNotifier {
 	return &VictoropsNotifier{
 		Base: NewBase(&models.AlertNotification{
 			Uid:                   config.UID,
@@ -69,6 +70,7 @@ func NewVictoropsNotifier(config *VictorOpsConfig, ns notifications.WebhookSende
 		URL:         config.URL,
 		MessageType: config.MessageType,
 		log:         log.New("alerting.notifier.victorops"),
+		images:      images,
 		ns:          ns,
 		tmpl:        t,
 	}
@@ -82,6 +84,7 @@ type VictoropsNotifier struct {
 	URL         string
 	MessageType string
 	log         log.Logger
+	images      ImageStore
 	ns          notifications.WebhookSender
 	tmpl        *template.Template
 }
@@ -114,6 +117,15 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON.Set("timestamp", time.Now().Unix())
 	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
 	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
+
+	_ = withStoredImages(ctx, vn.log, vn.images,
+		func(index int, image *ngmodels.Image) error {
+			if image != nil && image.URL != "" {
+				bodyJSON.Set("image_url", image.URL)
+				return ErrImagesDone
+			}
+			return nil
+		}, as...)
 
 	ruleURL := joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)
 	bodyJSON.Set("alert_url", ruleURL)

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -119,8 +119,8 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
 
 	_ = withStoredImages(ctx, vn.log, vn.images,
-		func(index int, image *ngmodels.Image) error {
-			if image != nil && image.URL != "" {
+		func(index int, image ngmodels.Image) error {
+			if image.URL != "" {
 				bodyJSON.Set("image_url", image.URL)
 				return ErrImagesDone
 			}

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -2,7 +2,9 @@ package channels
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -11,7 +13,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -27,53 +28,58 @@ const (
 	victoropsAlertStateRecovery = "RECOVERY"
 )
 
-type VictorOpsConfig struct {
-	*NotificationChannelConfig
-	URL         string
-	MessageType string
+type victorOpsSettings struct {
+	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
+	MessageType string `json:"messageType,omitempty" yaml:"messageType,omitempty"`
+}
+
+func buildVictorOpsSettings(fc FactoryConfig) (victorOpsSettings, error) {
+	settings := victorOpsSettings{}
+	err := fc.Config.unmarshalSettings(&settings)
+	if err != nil {
+		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if settings.URL == "" {
+		return settings, errors.New("could not find victorops url property in settings")
+	}
+	if settings.MessageType == "" {
+		settings.MessageType = victoropsAlertStateCritical
+	}
+	return settings, nil
 }
 
 func VictorOpsFactory(fc FactoryConfig) (NotificationChannel, error) {
-	cfg, err := NewVictorOpsConfig(fc.Config)
+	notifier, err := NewVictoropsNotifier(fc)
 	if err != nil {
 		return nil, receiverInitError{
 			Reason: err.Error(),
 			Cfg:    *fc.Config,
 		}
 	}
-	return NewVictoropsNotifier(cfg, fc.ImageStore, fc.NotificationService, fc.Template), nil
-}
-
-func NewVictorOpsConfig(config *NotificationChannelConfig) (*VictorOpsConfig, error) {
-	url := config.Settings.Get("url").MustString()
-	if url == "" {
-		return nil, errors.New("could not find victorops url property in settings")
-	}
-	return &VictorOpsConfig{
-		NotificationChannelConfig: config,
-		URL:                       url,
-		MessageType:               config.Settings.Get("messageType").MustString(),
-	}, nil
+	return notifier, nil
 }
 
 // NewVictoropsNotifier creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
-func NewVictoropsNotifier(config *VictorOpsConfig, images ImageStore, ns notifications.WebhookSender, t *template.Template) *VictoropsNotifier {
+func NewVictoropsNotifier(fc FactoryConfig) (*VictoropsNotifier, error) {
+	settings, err := buildVictorOpsSettings(fc)
+	if err != nil {
+		return nil, err
+	}
 	return &VictoropsNotifier{
 		Base: NewBase(&models.AlertNotification{
-			Uid:                   config.UID,
-			Name:                  config.Name,
-			Type:                  config.Type,
-			DisableResolveMessage: config.DisableResolveMessage,
-			Settings:              config.Settings,
+			Uid:                   fc.Config.UID,
+			Name:                  fc.Config.Name,
+			Type:                  fc.Config.Type,
+			DisableResolveMessage: fc.Config.DisableResolveMessage,
+			Settings:              fc.Config.Settings,
 		}),
-		URL:         config.URL,
-		MessageType: config.MessageType,
-		log:         log.New("alerting.notifier.victorops"),
-		images:      images,
-		ns:          ns,
-		tmpl:        t,
-	}
+		log:      log.New("alerting.notifier.victorops"),
+		images:   fc.ImageStore,
+		ns:       fc.NotificationService,
+		tmpl:     fc.Template,
+		settings: settings,
+	}, nil
 }
 
 // VictoropsNotifier defines URL property for Victorops REST API
@@ -81,23 +87,23 @@ func NewVictoropsNotifier(config *VictorOpsConfig, images ImageStore, ns notific
 // Victorops specifications (http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)
 type VictoropsNotifier struct {
 	*Base
-	URL         string
-	MessageType string
-	log         log.Logger
-	images      ImageStore
-	ns          notifications.WebhookSender
-	tmpl        *template.Template
+	log      log.Logger
+	images   ImageStore
+	ns       notifications.WebhookSender
+	tmpl     *template.Template
+	settings victorOpsSettings
 }
 
 // Notify sends notification to Victorops via POST to URL endpoint
 func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
-	vn.log.Debug("executing victorops notification", "notification", vn.Name)
+	vn.log.Debug("sending notification", "notification", vn.Name)
 
 	var tmplErr error
 	tmpl, _ := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
 
-	messageType := strings.ToUpper(tmpl(vn.MessageType))
+	messageType := strings.ToUpper(tmpl(vn.settings.MessageType))
 	if messageType == "" {
+		vn.log.Warn("expansion of message type template resulted in an empty string. Using fallback", "fallback", victoropsAlertStateCritical, "template", vn.settings.MessageType)
 		messageType = victoropsAlertStateCritical
 	}
 	alerts := types.Alerts(as...)
@@ -110,38 +116,40 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 		return false, err
 	}
 
-	bodyJSON := simplejson.New()
-	bodyJSON.Set("message_type", messageType)
-	bodyJSON.Set("entity_id", groupKey.Hash())
-	bodyJSON.Set("entity_display_name", tmpl(DefaultMessageTitleEmbed))
-	bodyJSON.Set("timestamp", time.Now().Unix())
-	bodyJSON.Set("state_message", tmpl(DefaultMessageEmbed))
-	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
+	bodyJSON := map[string]interface{}{
+		"message_type":        messageType,
+		"entity_id":           groupKey.Hash(),
+		"entity_display_name": tmpl(DefaultMessageTitleEmbed),
+		"timestamp":           time.Now().Unix(),
+		"state_message":       tmpl(DefaultMessageEmbed),
+		"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+	}
+
+	if tmplErr != nil {
+		vn.log.Warn("failed to expand message template. "+
+			"", "err", tmplErr.Error())
+		tmplErr = nil
+	}
 
 	_ = withStoredImages(ctx, vn.log, vn.images,
 		func(index int, image ngmodels.Image) error {
 			if image.URL != "" {
-				bodyJSON.Set("image_url", image.URL)
+				bodyJSON["image_url"] = image.URL
 				return ErrImagesDone
 			}
 			return nil
 		}, as...)
 
 	ruleURL := joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)
-	bodyJSON.Set("alert_url", ruleURL)
+	bodyJSON["alert_url"] = ruleURL
 
+	u := tmpl(vn.settings.URL)
 	if tmplErr != nil {
-		vn.log.Warn("failed to template VictorOps message", "err", tmplErr.Error())
-		tmplErr = nil
+		vn.log.Info("failed to expand URL template", "err", tmplErr.Error(), "fallback", vn.settings.URL)
+		u = vn.settings.URL
 	}
 
-	u := tmpl(vn.URL)
-	if tmplErr != nil {
-		vn.log.Info("failed to template VictorOps URL", "err", tmplErr.Error(), "fallback", vn.URL)
-		u = vn.URL
-	}
-
-	b, err := bodyJSON.MarshalJSON()
+	b, err := json.Marshal(bodyJSON)
 	if err != nil {
 		return false, err
 	}
@@ -151,7 +159,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	}
 
 	if err := vn.ns.SendWebhookSync(ctx, cmd); err != nil {
-		vn.log.Error("Failed to send Victorops notification", "err", err, "webhook", vn.Name)
+		vn.log.Error("failed to send notification", "err", err, "webhook", vn.Name)
 		return false, err
 	}
 

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -12,8 +12,6 @@ import (
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 // https://help.victorops.com/knowledge-base/incident-fields-glossary/ - 20480 characters.
@@ -74,12 +72,13 @@ func NewVictoropsNotifier(fc FactoryConfig) (*VictoropsNotifier, error) {
 		return nil, err
 	}
 	return &VictoropsNotifier{
-		Base:     NewBase(fc.Config),
-		log:      fc.Logger,
-		images:   fc.ImageStore,
-		ns:       fc.NotificationService,
-		tmpl:     fc.Template,
-		settings: settings,
+		Base:       NewBase(fc.Config),
+		log:        fc.Logger,
+		images:     fc.ImageStore,
+		ns:         fc.NotificationService,
+		tmpl:       fc.Template,
+		settings:   settings,
+		appVersion: fc.GrafanaBuildVersion,
 	}, nil
 }
 
@@ -88,11 +87,12 @@ func NewVictoropsNotifier(fc FactoryConfig) (*VictoropsNotifier, error) {
 // Victorops specifications (http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)
 type VictoropsNotifier struct {
 	*Base
-	log      Logger
-	images   ImageStore
-	ns       WebhookSender
-	tmpl     *template.Template
-	settings victorOpsSettings
+	log        Logger
+	images     ImageStore
+	ns         WebhookSender
+	tmpl       *template.Template
+	settings   victorOpsSettings
+	appVersion string
 }
 
 // Notify sends notification to Victorops via POST to URL endpoint
@@ -120,7 +120,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 		"entity_display_name": tmpl(vn.settings.Title),
 		"timestamp":           time.Now().Unix(),
 		"state_message":       stateMessage,
-		"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+		"monitoring_tool":     "Grafana v" + vn.appVersion,
 	}
 
 	if tmplErr != nil {

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -88,7 +88,7 @@ type VictoropsNotifier struct {
 
 // Notify sends notification to Victorops via POST to URL endpoint
 func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
-	vn.log.Debug("Executing victorops notification", "notification", vn.Name)
+	vn.log.Debug("executing victorops notification", "notification", vn.Name)
 
 	var tmplErr error
 	tmpl, _ := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
@@ -139,7 +139,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	}
 
 	if err := vn.ns.SendWebhookSync(ctx, cmd); err != nil {
-		vn.log.Error("Failed to send Victorops notification", "error", err, "webhook", vn.Name)
+		vn.log.Error("Failed to send Victorops notification", "err", err, "webhook", vn.Name)
 		return false, err
 	}
 

--- a/alerting/notifier/channels/victorops.go
+++ b/alerting/notifier/channels/victorops.go
@@ -138,7 +138,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 			return nil
 		}, as...)
 
-	ruleURL := joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)
+	ruleURL := joinURLPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)
 	bodyJSON["alert_url"] = ruleURL
 
 	u := tmpl(vn.settings.URL)
@@ -152,7 +152,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 		return false, err
 	}
 	cmd := &SendWebhookSettings{
-		Url:  u,
+		URL:  u,
 		Body: string(b),
 	}
 

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -105,6 +105,31 @@ func TestVictoropsNotifier(t *testing.T) {
 			},
 			expMsgError: nil,
 		}, {
+			name:     "Custom title and description",
+			settings: `{"url": "http://localhost", "title": "Alerts firing: {{ len .Alerts.Firing }}", "description": "customDescription"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"alert_url":           "http://localhost/alerting/list",
+				"entity_display_name": "Alerts firing: 2",
+				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"message_type":        "CRITICAL",
+				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"state_message":       "customDescription",
+			},
+			expMsgError: nil,
+		}, {
 			name:     "Missing field in template",
 			settings: `{"url": "http://localhost", "messageType": "custom template {{ .NotAField }} bad template"}`,
 			alerts: []*types.Alert{

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -188,8 +187,7 @@ func TestVictoropsNotifier(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
-			require.NoError(t, err)
+			settingsJSON := json.RawMessage(c.settings)
 
 			m := &NotificationChannelConfig{
 				Name:     "victorops_testing",
@@ -230,10 +228,11 @@ func TestVictoropsNotifier(t *testing.T) {
 			require.NotEmpty(t, webhookSender.Webhook.Url)
 
 			// Remove the non-constant timestamp
-			j, err := simplejson.NewJson([]byte(webhookSender.Webhook.Body))
+			data := make(map[string]interface{})
+			err = json.Unmarshal([]byte(webhookSender.Webhook.Body), &data)
 			require.NoError(t, err)
-			j.Del("timestamp")
-			b, err := j.MarshalJSON()
+			delete(data, "timestamp")
+			b, err := json.Marshal(data)
 			require.NoError(t, err)
 			body := string(b)
 

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -204,6 +204,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				NotificationService: webhookSender,
 				ImageStore:          images,
 				Template:            tmpl,
+				Logger:              &FakeLogger{},
 			}
 
 			pn, err := NewVictoropsNotifier(fc)

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -38,7 +38,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
 					},
 				},
 			},
@@ -48,7 +48,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
 			  "monitoring_tool": "Grafana v",
-			  "state_message": "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \n\n\n\n\n"
+			  "state_message": "**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n"
 			}`,
 			expInitError: nil,
 			expMsgError:  nil,
@@ -74,7 +74,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
 			  "monitoring_tool": "Grafana v",
-			  "state_message": "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSource: \n\n\n\n\n"
+			  "state_message": "**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n"
 			}`,
 			expInitError: nil,
 			expMsgError:  nil,

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -173,7 +173,15 @@ func TestVictoropsNotifier(t *testing.T) {
 			}
 
 			webhookSender := mockNotificationService()
-			cfg, err := NewVictorOpsConfig(m)
+
+			fc := FactoryConfig{
+				Config:              m,
+				NotificationService: webhookSender,
+				ImageStore:          images,
+				Template:            tmpl,
+			}
+
+			pn, err := NewVictoropsNotifier(fc)
 			if c.expInitError != "" {
 				require.Error(t, err)
 				require.Equal(t, c.expInitError, err.Error())
@@ -183,7 +191,6 @@ func TestVictoropsNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewVictoropsNotifier(cfg, images, webhookSender, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -47,7 +47,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
 			  "monitoring_tool": "Grafana v",
-			  "state_message": "**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n"
+			  "state_message": "**Firing**\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n"
 			}`,
 			expMsgError: nil,
 		}, {
@@ -72,7 +72,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
 			  "monitoring_tool": "Grafana v",
-			  "state_message": "**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n"
+			  "state_message": "**Firing**\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n"
 			}`,
 			expMsgError: nil,
 		}, {

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -43,7 +43,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				},
 			},
 			expMsg: `{
-			  "alert_url": "http:/localhost/alerting/list",
+			  "alert_url": "http://localhost/alerting/list",
 			  "entity_display_name": "[FIRING:1]  (val1)",
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
@@ -69,7 +69,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				},
 			},
 			expMsg: `{
-			  "alert_url": "http:/localhost/alerting/list",
+			  "alert_url": "http://localhost/alerting/list",
 			  "entity_display_name": "[FIRING:2]  ",
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -1,0 +1,136 @@
+package channels
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func TestVictoropsNotifier(t *testing.T) {
+	tmpl := templateForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	cases := []struct {
+		name         string
+		settings     string
+		alerts       []*types.Alert
+		expMsg       string
+		expInitError error
+		expMsgError  error
+	}{
+		{
+			name:     "One alert",
+			settings: `{"url": "http://localhost"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				},
+			},
+			expMsg: `{
+			  "alert_url": "http:/localhost/alerting/list",
+			  "entity_display_name": "[FIRING:1]  (val1)",
+			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+			  "message_type": "CRITICAL",
+			  "monitoring_tool": "Grafana v",
+			  "state_message": "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \n\n\n\n\n"
+			}`,
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:     "Multiple alerts",
+			settings: `{"url": "http://localhost"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: `{
+			  "alert_url": "http:/localhost/alerting/list",
+			  "entity_display_name": "[FIRING:2]  ",
+			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+			  "message_type": "CRITICAL",
+			  "monitoring_tool": "Grafana v",
+			  "state_message": "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSource: \n\n\n\n\n"
+			}`,
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:         "Error in initing, no URL",
+			settings:     `{}`,
+			expInitError: alerting.ValidationError{Reason: "Could not find victorops url property in settings"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
+			require.NoError(t, err)
+
+			m := &NotificationChannelConfig{
+				Name:     "victorops_testing",
+				Type:     "victorops",
+				Settings: settingsJSON,
+			}
+
+			pn, err := NewVictoropsNotifier(m, tmpl)
+			if c.expInitError != nil {
+				require.Error(t, err)
+				require.Equal(t, c.expInitError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			body := ""
+			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+				body = webhook.Body
+				return nil
+			})
+
+			ctx := notify.WithGroupKey(context.Background(), "alertname")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+			ok, err := pn.Notify(ctx, c.alerts...)
+			if c.expMsgError != nil {
+				require.False(t, ok)
+				require.Error(t, err)
+				require.Equal(t, c.expMsgError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			// Remove the non-constant timestamp
+			j, err := simplejson.NewJson([]byte(body))
+			require.NoError(t, err)
+			j.Del("timestamp")
+			b, err := j.MarshalJSON()
+			require.NoError(t, err)
+			body = string(b)
+
+			require.JSONEq(t, c.expMsg, body)
+		})
+	}
+}

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -47,7 +47,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"message_type":        "CRITICAL",
 				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
-				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 			},
 			expMsgError: nil,
 		}, {
@@ -72,7 +72,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"message_type":        "CRITICAL",
 				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
-				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n",
+				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
 			},
 			expMsgError: nil,
 		}, {

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -104,7 +104,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.AddHandler("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -47,7 +47,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
 			  "monitoring_tool": "Grafana v",
-			  "state_message": "**Firing**\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n"
+			  "state_message": "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n"
 			}`,
 			expMsgError: nil,
 		}, {
@@ -72,7 +72,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 			  "message_type": "CRITICAL",
 			  "monitoring_tool": "Grafana v",
-			  "state_message": "**Firing**\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n"
+			  "state_message": "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n"
 			}`,
 			expMsgError: nil,
 		}, {

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -76,6 +76,81 @@ func TestVictoropsNotifier(t *testing.T) {
 			},
 			expMsgError: nil,
 		}, {
+			name:     "Custom message",
+			settings: `{"url": "http://localhost", "messageType": "Alerts firing: {{ len .Alerts.Firing }}"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"alert_url":           "http://localhost/alerting/list",
+				"entity_display_name": "[FIRING:2]  ",
+				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"message_type":        "ALERTS FIRING: 2",
+				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
+			},
+			expMsgError: nil,
+		}, {
+			name:     "Missing field in template",
+			settings: `{"url": "http://localhost", "messageType": "custom template {{ .NotAField }} bad template"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"alert_url":           "http://localhost/alerting/list",
+				"entity_display_name": "",
+				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"message_type":        "CUSTOM TEMPLATE ",
+				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"state_message":       "",
+			},
+			expMsgError: nil,
+		}, {
+			name:     "Invalid template",
+			settings: `{"url": "http://localhost", "messageType": "custom template {{ {.NotAField }} bad template"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"alert_url":           "http://localhost/alerting/list",
+				"entity_display_name": "",
+				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"message_type":        "CRITICAL",
+				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"state_message":       "",
+			},
+			expMsgError: nil,
+		}, {
 			name:         "Error in initing, no URL",
 			settings:     `{}`,
 			expInitError: `could not find victorops url property in settings`,
@@ -114,6 +189,8 @@ func TestVictoropsNotifier(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.True(t, ok)
+
+			require.NotEmpty(t, webhookSender.Webhook.Url)
 
 			// Remove the non-constant timestamp
 			j, err := simplejson.NewJson([]byte(webhookSender.Webhook.Body))

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -39,7 +39,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 					},
 				},
 			},
@@ -60,12 +60,12 @@ func TestVictoropsNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -18,6 +18,8 @@ import (
 func TestVictoropsNotifier(t *testing.T) {
 	tmpl := templateForTests(t)
 
+	images := newFakeImageStore(2)
+
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
@@ -31,13 +33,13 @@ func TestVictoropsNotifier(t *testing.T) {
 		expMsgError  error
 	}{
 		{
-			name:     "One alert",
+			name:     "A single alert with image",
 			settings: `{"url": "http://localhost"}`,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
 					},
 				},
 			},
@@ -45,24 +47,25 @@ func TestVictoropsNotifier(t *testing.T) {
 				"alert_url":           "http://localhost/alerting/list",
 				"entity_display_name": "[FIRING:1]  (val1)",
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"image_url":           "https://www.example.com/test-image-1.jpg",
 				"message_type":        "CRITICAL",
 				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
 				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 			},
 			expMsgError: nil,
 		}, {
-			name:     "Multiple alerts",
+			name:     "Multiple alerts with images",
 			settings: `{"url": "http://localhost"}`,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
 					},
 				},
 			},
@@ -70,6 +73,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"alert_url":           "http://localhost/alerting/list",
 				"entity_display_name": "[FIRING:2]  ",
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"image_url":           "https://www.example.com/test-image-1.jpg",
 				"message_type":        "CRITICAL",
 				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
 				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
@@ -179,7 +183,7 @@ func TestVictoropsNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewVictoropsNotifier(cfg, webhookSender, tmpl)
+			pn := NewVictoropsNotifier(cfg, images, webhookSender, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -78,7 +78,7 @@ func TestVictoropsNotifier(t *testing.T) {
 		}, {
 			name:         "Error in initing, no URL",
 			settings:     `{}`,
-			expInitError: `failed to validate receiver "victorops_testing" of type "victorops": could not find victorops url property in settings`,
+			expInitError: `could not find victorops url property in settings`,
 		},
 	}
 
@@ -94,7 +94,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			}
 
 			webhookSender := mockNotificationService()
-			pn, err := NewVictoropsNotifier(m, webhookSender, tmpl)
+			cfg, err := NewVictorOpsConfig(m)
 			if c.expInitError != "" {
 				require.Error(t, err)
 				require.Equal(t, c.expInitError, err.Error())
@@ -104,6 +104,7 @@ func TestVictoropsNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+			pn := NewVictoropsNotifier(cfg, webhookSender, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -3,6 +3,8 @@ package channels
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"net/url"
 	"testing"
 
@@ -10,8 +12,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestVictoropsNotifier(t *testing.T) {
@@ -22,6 +22,7 @@ func TestVictoropsNotifier(t *testing.T) {
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
+	version := fmt.Sprintf("%d.0.0", rand.Uint64())
 
 	cases := []struct {
 		name         string
@@ -48,7 +49,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"image_url":           "https://www.example.com/test-image-1.jpg",
 				"message_type":        "CRITICAL",
-				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"monitoring_tool":     "Grafana v" + version,
 				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 			},
 			expMsgError: nil,
@@ -74,7 +75,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"image_url":           "https://www.example.com/test-image-1.jpg",
 				"message_type":        "CRITICAL",
-				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"monitoring_tool":     "Grafana v" + version,
 				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
 			},
 			expMsgError: nil,
@@ -99,7 +100,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_display_name": "[FIRING:2]  ",
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"message_type":        "ALERTS FIRING: 2",
-				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"monitoring_tool":     "Grafana v" + version,
 				"state_message":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
 			},
 			expMsgError: nil,
@@ -124,7 +125,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_display_name": "Alerts firing: 2",
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"message_type":        "CRITICAL",
-				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"monitoring_tool":     "Grafana v" + version,
 				"state_message":       "customDescription",
 			},
 			expMsgError: nil,
@@ -149,7 +150,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_display_name": "",
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"message_type":        "CUSTOM TEMPLATE ",
-				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"monitoring_tool":     "Grafana v" + version,
 				"state_message":       "",
 			},
 			expMsgError: nil,
@@ -174,7 +175,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				"entity_display_name": "",
 				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"message_type":        "CRITICAL",
-				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"monitoring_tool":     "Grafana v" + version,
 				"state_message":       "",
 			},
 			expMsgError: nil,
@@ -203,6 +204,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				ImageStore:          images,
 				Template:            tmpl,
 				Logger:              &FakeLogger{},
+				GrafanaBuildVersion: version,
 			}
 
 			pn, err := NewVictoropsNotifier(fc)

--- a/alerting/notifier/channels/victorops_test.go
+++ b/alerting/notifier/channels/victorops_test.go
@@ -225,7 +225,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, ok)
 
-			require.NotEmpty(t, webhookSender.Webhook.Url)
+			require.NotEmpty(t, webhookSender.Webhook.URL)
 
 			// Remove the non-constant timestamp
 			data := make(map[string]interface{})
@@ -236,9 +236,9 @@ func TestVictoropsNotifier(t *testing.T) {
 			require.NoError(t, err)
 			body := string(b)
 
-			expJson, err := json.Marshal(c.expMsg)
+			expJSON, err := json.Marshal(c.expMsg)
 			require.NoError(t, err)
-			require.JSONEq(t, string(expJson), body)
+			require.JSONEq(t, string(expJSON), body)
 		})
 	}
 }


### PR DESCRIPTION
This PR moves receiver VictorOPS from Grafan to alerting repository keeping a history of all changes in the files.

NOTE:

1. I dropped commit https://github.com/grafana/grafana/commit/f0cabe14d5cfd7968c1a82ff716dec808d27b64c because it updates the files to refer to the imported package. 

2. This notifier uses the Grafana build version in the request sent to API. The build version was taken from a package variable in the settings that is not available anymore. I replaced it with a new field of FactoryConfig.

3. Starting with commit https://github.com/grafana/alerting/pull/25/commits/09b5a5a9f6ad31a832daf24d9ae29e596c358103 are changes that I added to this code.