### PR TITLE
Allow Grafana Alertmanager to return current running receivers

### DIFF
--- a/alerting/grafana_alertmanager.go
+++ b/alerting/grafana_alertmanager.go
@@ -130,6 +130,7 @@ type Route = config.Route
 type Integration = notify.Integration
 type DispatcherLimits = dispatch.Limits
 type Notifier = notify.Notifier
+type NotifyReceiver = notify.Receiver
 
 // Configuration is an interface for accessing Alertmanager configuration.
 type Configuration interface {
@@ -271,7 +272,7 @@ func (am *GrafanaAlertmanager) StopAndWait() {
 
 // GetReceivers returns the receivers configured as part of the current configuration.
 // It is safe to call concurrently.
-func (am *GrafanaAlertmanager) GetReceivers() []*notify.Receiver {
+func (am *GrafanaAlertmanager) GetReceivers() []*NotifyReceiver {
 	am.reloadConfigMtx.RLock()
 	defer am.reloadConfigMtx.RUnlock()
 

--- a/alerting/grafana_alertmanager.go
+++ b/alerting/grafana_alertmanager.go
@@ -269,6 +269,17 @@ func (am *GrafanaAlertmanager) StopAndWait() {
 	am.wg.Wait()
 }
 
+// GetReceivers returns the receivers configured as part of the current configuration.
+// It is safe to call concurrently.
+func (am *GrafanaAlertmanager) GetReceivers() []*notify.Receiver {
+	am.reloadConfigMtx.RLock()
+	defer am.reloadConfigMtx.RUnlock()
+
+	return am.receivers
+}
+
+// ConfigHash returns the hash of the current running configuration.
+// It is not safe to call without a lock.
 func (am *GrafanaAlertmanager) ConfigHash() [16]byte {
 	return am.configHash
 }


### PR DESCRIPTION
At runtime, these receivers are important to know the information of what was sent when (or if it failed).