### PR TITLE
Alerting: Add support for expr in notification templates

### DIFF
--- a/alerting/models/labels.go
+++ b/alerting/models/labels.go
@@ -24,6 +24,7 @@ const (
 	// StateReasonAnnotation is the name of the annotation that explains the difference between evaluation state and alert state (i.e. changing state when NoData or Error).
 	StateReasonAnnotation = GrafanaReservedLabelPrefix + "state_reason"
 
+	ExprsAnnotation       = "__exprs__"
 	ValuesAnnotation      = "__values__"
 	ValueStringAnnotation = "__value_string__"
 )

--- a/alerting/notifier/channels/default_template.go
+++ b/alerting/notifier/channels/default_template.go
@@ -16,8 +16,8 @@ const (
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 
-{{ define "__text_values_list" }}{{ $len := len .Values }}{{ if $len }}{{ $first := gt $len 1 }}{{ range $refID, $value := .Values -}}
-{{ $refID }}={{ $value }}{{ if $first }}, {{ end }}{{ $first = false }}{{ end -}}
+{{ define "__text_values_list" }}{{ $exprs := .Exprs }}{{ $numValues := len .Values }}{{ if $numValues }}{{ $first := gt $numValues 1 }}{{ range $refID, $value := .Values -}}
+{{ $refID }}={{ $value }}{{ if $expr := index $exprs $refID }} {{ $expr }}{{ end }}{{ if $first }}, {{ end }}{{ $first = false }}{{ end -}}
 {{ else }}[no value]{{ end }}{{ end }}
 
 {{ define "__text_alert_list" }}{{ range . }}

--- a/alerting/notifier/channels/default_template_test.go
+++ b/alerting/notifier/channels/default_template_test.go
@@ -17,9 +17,18 @@ func TestDefaultTemplateString(t *testing.T) {
 	alerts := []*types.Alert{
 		{ // Firing with dashboard and panel ID.
 			Alert: model.Alert{
-				Labels: model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Labels: model.LabelSet{
+					"alertname": "alert1",
+					"lbl1":      "val1",
+				},
 				Annotations: model.LabelSet{
-					"ann1": "annv1", "__orgId__": "1", "__dashboardUid__": "dbuid123", "__panelId__": "puid123", "__values__": "{\"A\": 1234}", "__value_string__": "1234",
+					"ann1":             "annv1",
+					"__orgId__":        "1",
+					"__dashboardUid__": "dbuid123",
+					"__panelId__":      "puid123",
+					"__exprs__":        "{\"A\": \"rate(metric[5m])\"}",
+					"__values__":       "{\"A\": 1234}",
+					"__value_string__": "1234",
 				},
 				StartsAt:     time.Now(),
 				EndsAt:       time.Now().Add(1 * time.Hour),
@@ -27,17 +36,32 @@ func TestDefaultTemplateString(t *testing.T) {
 			},
 		}, { // Firing without dashboard and panel ID.
 			Alert: model.Alert{
-				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-				Annotations:  model.LabelSet{"ann1": "annv2", "__values__": "{\"A\": 1234}", "__value_string__": "1234"},
+				Labels: model.LabelSet{
+					"alertname": "alert1",
+					"lbl1":      "val2",
+				},
+				Annotations: model.LabelSet{
+					"ann1":             "annv2",
+					"__values__":       "{\"A\": 1234}",
+					"__value_string__": "1234",
+				},
 				StartsAt:     time.Now(),
 				EndsAt:       time.Now().Add(2 * time.Hour),
 				GeneratorURL: "http://localhost/alert2",
 			},
 		}, { // Resolved with dashboard and panel ID.
 			Alert: model.Alert{
-				Labels: model.LabelSet{"alertname": "alert1", "lbl1": "val3"},
+				Labels: model.LabelSet{
+					"alertname": "alert1",
+					"lbl1":      "val3",
+				},
 				Annotations: model.LabelSet{
-					"ann1": "annv3", "__orgId__": "1", "__dashboardUid__": "dbuid456", "__panelId__": "puid456", "__values__": "{\"A\": 1234}", "__value_string__": "1234",
+					"ann1":             "annv3",
+					"__orgId__":        "1",
+					"__dashboardUid__": "dbuid456",
+					"__panelId__":      "puid456",
+					"__values__":       "{\"A\": 1234}",
+					"__value_string__": "1234",
 				},
 				StartsAt:     time.Now().Add(-1 * time.Hour),
 				EndsAt:       time.Now().Add(-30 * time.Minute),
@@ -45,8 +69,15 @@ func TestDefaultTemplateString(t *testing.T) {
 			},
 		}, { // Resolved without dashboard and panel ID.
 			Alert: model.Alert{
-				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val4"},
-				Annotations:  model.LabelSet{"ann1": "annv4", "__values__": "{\"A\": 1234}", "__value_string__": "1234"},
+				Labels: model.LabelSet{
+					"alertname": "alert1",
+					"lbl1":      "val4",
+				},
+				Annotations: model.LabelSet{
+					"ann1":             "annv4",
+					"__values__":       "{\"A\": 1234}",
+					"__value_string__": "1234",
+				},
 				StartsAt:     time.Now().Add(-2 * time.Hour),
 				EndsAt:       time.Now().Add(-3 * time.Hour),
 				GeneratorURL: "http://localhost/alert4",
@@ -90,7 +121,7 @@ func TestDefaultTemplateString(t *testing.T) {
 			templateString: DefaultMessageEmbed,
 			expected: `**Firing**
 
-Value: A=1234
+Value: A=1234 rate(metric[5m])
 Labels:
  - alertname = alert1
  - lbl1 = val1
@@ -138,7 +169,7 @@ Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matc
 			templateString: `{{ template "teams.default.message" .}}`,
 			expected: `**Firing**
 
-Value: A=1234
+Value: A=1234 rate(metric[5m])
 Labels:
  - alertname = alert1
  - lbl1 = val1

--- a/alerting/notifier/channels/template_data.go
+++ b/alerting/notifier/channels/template_data.go
@@ -28,6 +28,7 @@ type ExtendedAlert struct {
 	SilenceURL    string             `json:"silenceURL"`
 	DashboardURL  string             `json:"dashboardURL"`
 	PanelURL      string             `json:"panelURL"`
+	Exprs         map[string]string  `json:"exprs"`
 	Values        map[string]float64 `json:"values"`
 	ValueString   string             `json:"valueString"` // TODO: Remove in Grafana 10
 	ImageURL      string             `json:"imageURL,omitempty"`
@@ -110,11 +111,18 @@ func extendAlert(alert template.Alert, externalURL string, logger Logger) *Exten
 	}
 
 	if alert.Annotations != nil {
+		if s, ok := alert.Annotations[models.ExprsAnnotation]; ok {
+			if err := json.Unmarshal([]byte(s), &extended.Exprs); err != nil {
+				logger.Warn("failed to unmarshal exprs annotation", "error", err)
+			}
+		}
+
 		if s, ok := alert.Annotations[models.ValuesAnnotation]; ok {
 			if err := json.Unmarshal([]byte(s), &extended.Values); err != nil {
 				logger.Warn("failed to unmarshal values annotation", "error", err)
 			}
 		}
+
 		// TODO: Remove in Grafana 10
 		extended.ValueString = alert.Annotations[models.ValueStringAnnotation]
 	}


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/56457 we added support for templating values in notification templates, including updating the default template:

```
**Firing**

Value: A=1
Labels:
 - alertname = Test
 - grafana_folder = General Alerting
Annotations:
Source: http://localhost:3000/alerting/grafana/wXZdwwVVz/view
Silence: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTest&matcher=grafana_folder%3DGeneral+Alerting
```

This pull request build on that previous work to now support expressions too:

```
**Firing**

Value: A=1 rate(metric[5m])
Labels:
 - alertname = Test
 - grafana_folder = General Alerting
Annotations:
Source: http://localhost:3000/alerting/grafana/wXZdwwVVz/view
Silence: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTest&matcher=grafana_folder%3DGeneral+Alerting
```