### PR TITLE
Alerting: Fix comma separated values in default template

### DIFF
--- a/alerting/notifier/channels/default_template.go
+++ b/alerting/notifier/channels/default_template.go
@@ -16,8 +16,8 @@ const (
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 
-{{ define "__text_values_list" }}{{ $exprs := .Exprs }}{{ $numValues := len .Values }}{{ if $numValues }}{{ $first := gt $numValues 1 }}{{ range $refID, $value := .Values -}}
-{{ $refID }}={{ $value }}{{ if $expr := index $exprs $refID }} {{ $expr }}{{ end }}{{ if $first }}, {{ end }}{{ $first = false }}{{ end -}}
+{{ define "__text_values_list" }}{{ $exprs := .Exprs }}{{ $numValues := len .Values }}{{ if $numValues }}{{ $first := true }}{{ range $refID, $value := .Values -}}
+{{ if $first }}{{ $first = false }}{{ else }}, {{ end }}{{ $refID }}={{ $value }}{{ if $expr := index $exprs $refID }} {{ $expr }}{{ end }}{{ end -}}
 {{ else }}[no value]{{ end }}{{ end }}
 
 {{ define "__text_alert_list" }}{{ range . }}

--- a/alerting/notifier/channels/default_template_test.go
+++ b/alerting/notifier/channels/default_template_test.go
@@ -42,7 +42,7 @@ func TestDefaultTemplateString(t *testing.T) {
 				},
 				Annotations: model.LabelSet{
 					"ann1":             "annv2",
-					"__values__":       "{\"A\": 1234}",
+					"__values__":       "{\"A\": 1234, \"B\": 5678, \"C\": 9}",
 					"__value_string__": "1234",
 				},
 				StartsAt:     time.Now(),
@@ -132,7 +132,7 @@ Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matc
 Dashboard: http://localhost/grafana/d/dbuid123?orgId=1
 Panel: http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123
 
-Value: A=1234
+Value: A=1234, B=5678, C=9
 Labels:
  - alertname = alert1
  - lbl1 = val2
@@ -187,7 +187,7 @@ Panel: [http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123](http://lo
 
 
 
-Value: A=1234
+Value: A=1234, B=5678, C=9
 Labels:
  - alertname = alert1
  - lbl1 = val2


### PR DESCRIPTION
This commit fixes a bug in the default template where values after the first value would not be comma separated. For example:

```
A=1234, B=5678, C=9
```

would have been:

```
A=1234, B=5678C=9
```

