### PR TITLE
Allow the BuildReceiverIntegrationsFunc to be injected as part of the config

### DIFF
--- a/alerting/grafana_alertmanager.go
+++ b/alerting/grafana_alertmanager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/grafana/alerting/alerting/models"
 	"net/url"
 	"regexp"
 	"sync"
@@ -403,7 +404,7 @@ func (am *GrafanaAlertmanager) PutAlerts(postableAlerts amv2.PostableAlerts) err
 		}
 
 		for k, v := range a.Labels {
-			if len(v) == 0 { // Skip empty labels.
+			if len(v) == 0 || k == models.NamespaceUIDLabel { // Skip empty and namespace UID labels.
 				continue
 			}
 

--- a/alerting/grafana_alertmanager.go
+++ b/alerting/grafana_alertmanager.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/grafana/alerting/alerting/models"
 	"net/url"
 	"regexp"
 	"sync"
 	"time"
 	"unicode/utf8"
+
+	"github.com/grafana/alerting/alerting/models"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"


### PR DESCRIPTION
Also backports a very small change to skip the `NamespaceUIDLabel` when processing alerts.