### PR TITLE
Alerting: Separate exprs in default template

### DIFF
--- a/alerting/notifier/channels/default_template.go
+++ b/alerting/notifier/channels/default_template.go
@@ -16,12 +16,14 @@ const (
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 
-{{ define "__text_values_list" }}{{ $exprs := .Exprs }}{{ $numValues := len .Values }}{{ if $numValues }}{{ $first := true }}{{ range $refID, $value := .Values -}}
-{{ if $first }}{{ $first = false }}{{ else }}, {{ end }}{{ $refID }}={{ $value }}{{ if $expr := index $exprs $refID }} {{ $expr }}{{ end }}{{ end -}}
+{{ define "__text_values_list" }}{{ if len .Values }}{{ $first := true }}{{ range $refID, $value := .Values -}}
+{{ if $first }}{{ $first = false }}{{ else }}, {{ end }}{{ $refID }}={{ $value }}{{ end -}}
 {{ else }}[no value]{{ end }}{{ end }}
 
 {{ define "__text_alert_list" }}{{ range . }}
-Value: {{ template "__text_values_list" . }}
+{{ if .Exprs }}Exprs:
+{{ range $refID, $expr := .Exprs }} - {{ $refID }} = {{ $expr }}
+{{ end }}{{ end }}Value: {{ template "__text_values_list" . }}
 Labels:
 {{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
 {{ end }}Annotations:
@@ -42,7 +44,9 @@ Labels:
 
 
 {{ define "__teams_text_alert_list" }}{{ range . }}
-Value: {{ template "__text_values_list" . }}
+{{ if .Exprs }}Exprs:
+{{ range $refID, $expr := .Exprs }} - {{ $refID }} = {{ $expr }}
+{{ end }}{{end }}Value: {{ template "__text_values_list" . }}
 Labels:
 {{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
 {{ end }}

--- a/alerting/notifier/channels/default_template_test.go
+++ b/alerting/notifier/channels/default_template_test.go
@@ -121,7 +121,9 @@ func TestDefaultTemplateString(t *testing.T) {
 			templateString: DefaultMessageEmbed,
 			expected: `**Firing**
 
-Value: A=1234 rate(metric[5m])
+Exprs:
+ - A = rate(metric[5m])
+Value: A=1234
 Labels:
  - alertname = alert1
  - lbl1 = val1
@@ -169,7 +171,9 @@ Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matc
 			templateString: `{{ template "teams.default.message" .}}`,
 			expected: `**Firing**
 
-Value: A=1234 rate(metric[5m])
+Exprs:
+ - A = rate(metric[5m])
+Value: A=1234
 Labels:
  - alertname = alert1
  - lbl1 = val1


### PR DESCRIPTION
This pull request changes the default template to show `Exprs` separate from `Value`, as `Exprs` can be quite verbose.

Before this change:

``` 
Value: A=1234 sum(rate(metric[5m])), B=5678 mean(A)
```

After this change:

```
Exprs:
 - A = sum(rate(metric(5m))
 - B = mean(A)
Value: A=1234, B=5678
```

