### PR TITLE
Make `ProcessNotifierError` public

### DIFF
--- a/alerting/receivers.go
+++ b/alerting/receivers.go
@@ -136,7 +136,7 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 				Name:   next.Config.Name,
 				UID:    next.Config.UID,
 				Status: status,
-				Error:  processNotifierError(next.Config, next.Error),
+				Error:  ProcessNotifierError(next.Config, next.Error),
 			})
 			m[next.ReceiverName] = tmp
 		}
@@ -268,7 +268,7 @@ func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time
 	return alert
 }
 
-func processNotifierError(config *GrafanaReceiver, err error) error {
+func ProcessNotifierError(config *GrafanaReceiver, err error) error {
 	if err == nil {
 		return nil
 	}

--- a/alerting/receivers_test.go
+++ b/alerting/receivers_test.go
@@ -50,7 +50,7 @@ func TestProcessNotifierError(t *testing.T) {
 		require.Equal(t, ReceiverTimeoutError{
 			Receiver: r,
 			Err:      context.DeadlineExceeded,
-		}, processNotifierError(r, context.DeadlineExceeded))
+		}, ProcessNotifierError(r, context.DeadlineExceeded))
 	})
 
 	t.Run("assert ReceiverTimeoutError is returned for *url.Error timeout", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestProcessNotifierError(t *testing.T) {
 		require.Equal(t, ReceiverTimeoutError{
 			Receiver: r,
 			Err:      urlError,
-		}, processNotifierError(r, urlError))
+		}, ProcessNotifierError(r, urlError))
 	})
 
 	t.Run("assert unknown error is returned unmodified", func(t *testing.T) {
@@ -75,6 +75,6 @@ func TestProcessNotifierError(t *testing.T) {
 			UID:  "uid",
 		}
 		err := errors.New("this is an error")
-		require.Equal(t, err, processNotifierError(r, err))
+		require.Equal(t, err, ProcessNotifierError(r, err))
 	})
 }


### PR DESCRIPTION
It is needed as part of the API (and its tests) on Grafana.

fixes #39 