### PR TITLE
Extract configudation validation from constructor and unify names of all fixed urls of notifiers

### DIFF
--- a/receivers/alertmanager/config.go
+++ b/receivers/alertmanager/config.go
@@ -1,0 +1,53 @@
+package alertmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/alerting/receivers"
+)
+
+type Config struct {
+	URLs     []*url.URL
+	User     string
+	Password string
+}
+
+func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+	var settings struct {
+		URL      receivers.CommaSeparatedStrings `json:"url,omitempty" yaml:"url,omitempty"`
+		User     string                          `json:"basicAuthUser,omitempty" yaml:"basicAuthUser,omitempty"`
+		Password string                          `json:"basicAuthPassword,omitempty" yaml:"basicAuthPassword,omitempty"`
+	}
+	err := json.Unmarshal(fc.Config.Settings, &settings)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+
+	urls := make([]*url.URL, 0, len(settings.URL))
+	for _, uS := range settings.URL {
+		uS = strings.TrimSpace(uS)
+		if uS == "" {
+			continue
+		}
+		uS = strings.TrimSuffix(uS, "/") + "/api/v1/alerts"
+		u, err := url.Parse(uS)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid url property in settings: %w", err)
+		}
+		urls = append(urls, u)
+	}
+	if len(settings.URL) == 0 || len(urls) == 0 {
+		return Config{}, errors.New("could not find url property in settings")
+	}
+	settings.Password = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "basicAuthPassword", settings.Password)
+	return Config{
+		URLs:     urls,
+		User:     settings.User,
+		Password: settings.Password,
+	}, nil
+}

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	NotifyURL string = "https://notify-api.line.me/api/notify"
+	// APIURL is a URL where the notification payload is sent
+	APIURL string = "https://notify-api.line.me/api/notify"
 )
 
 // Notifier is responsible for sending
@@ -54,7 +55,7 @@ func (ln *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	form.Add("message", body)
 
 	cmd := &receivers.SendWebhookSettings{
-		URL:        NotifyURL,
+		URL:        APIURL,
 		HTTPMethod: "POST",
 		HTTPHeader: map[string]string{
 			"Authorization": fmt.Sprintf("Bearer %s", ln.settings.Token),

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// APIURL is a URL where the notification payload is sent
-	APIURL string = "https://notify-api.line.me/api/notify"
+	APIURL = "https://notify-api.line.me/api/notify"
 )
 
 // Notifier is responsible for sending

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	// APIURL is a URL where the notification payload is sent
+	// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
 	APIURL = "https://notify-api.line.me/api/notify"
 )
 

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -29,7 +29,8 @@ const (
 
 var (
 	knownSeverity = map[string]struct{}{DefaultSeverity: {}, "error": {}, "warning": {}, "info": {}}
-	eventAPIURL   = "https://events.pagerduty.com/v2/enqueue"
+	// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+	APIURL = "https://events.pagerduty.com/v2/enqueue"
 )
 
 // Notifier is responsible for sending
@@ -80,7 +81,7 @@ func (pn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 
 	pn.log.Info("notifying Pagerduty", "event_type", eventType)
 	cmd := &receivers.SendWebhookSettings{
-		URL:        eventAPIURL,
+		URL:        APIURL,
 		Body:       string(body),
 		HTTPMethod: "POST",
 		HTTPHeader: map[string]string{

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -29,7 +29,7 @@ const (
 
 var (
 	knownSeverity = map[string]struct{}{DefaultSeverity: {}, "error": {}, "warning": {}, "info": {}}
-	// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+	// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
 	APIURL = "https://events.pagerduty.com/v2/enqueue"
 )
 

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -32,7 +32,8 @@ const (
 )
 
 var (
-	Endpoint = "https://api.pushover.net/1/messages.json"
+	// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+	APIURL = "https://api.pushover.net/1/messages.json"
 )
 
 // Notifier is responsible for sending
@@ -71,7 +72,7 @@ func (pn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	}
 
 	cmd := &receivers.SendWebhookSettings{
-		URL:        Endpoint,
+		URL:        APIURL,
 		HTTPMethod: "POST",
 		HTTPHeader: headers,
 		Body:       uploadBody.String(),

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+	// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
 	APIURL = "https://api.pushover.net/1/messages.json"
 )
 

--- a/receivers/slack/config.go
+++ b/receivers/slack/config.go
@@ -1,10 +1,16 @@
 package slack
 
 import (
-	"github.com/grafana/alerting/receivers"
-)
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
 
-const FooterIconURL = "https://grafana.com/static/assets/img/fav32.png"
+	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/templates"
+)
 
 type Config struct {
 	EndpointURL    string                          `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
@@ -19,4 +25,50 @@ type Config struct {
 	MentionChannel string                          `json:"mentionChannel,omitempty" yaml:"mentionChannel,omitempty"`
 	MentionUsers   receivers.CommaSeparatedStrings `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty"`
 	MentionGroups  receivers.CommaSeparatedStrings `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
+}
+
+func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
+	decryptFunc := factoryConfig.DecryptFunc
+	var settings Config
+	err := json.Unmarshal(factoryConfig.Config.Settings, &settings)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+
+	if settings.EndpointURL == "" {
+		settings.EndpointURL = APIURL
+	}
+	slackURL := decryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "url", settings.URL)
+	if slackURL == "" {
+		slackURL = settings.EndpointURL
+	}
+
+	apiURL, err := url.Parse(slackURL)
+	if err != nil {
+		return Config{}, fmt.Errorf("invalid URL %q", slackURL)
+	}
+	settings.URL = apiURL.String()
+
+	settings.Recipient = strings.TrimSpace(settings.Recipient)
+	if settings.Recipient == "" && settings.URL == APIURL {
+		return Config{}, errors.New("recipient must be specified when using the Slack chat API")
+	}
+	if settings.MentionChannel != "" && settings.MentionChannel != "here" && settings.MentionChannel != "channel" {
+		return Config{}, fmt.Errorf("invalid value for mentionChannel: %q", settings.MentionChannel)
+	}
+	settings.Token = decryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "token", settings.Token)
+	if settings.Token == "" && settings.URL == APIURL {
+		return Config{}, errors.New("token must be specified when using the Slack chat API")
+	}
+	if settings.Username == "" {
+		settings.Username = "Grafana"
+	}
+	if settings.Text == "" {
+		settings.Text = templates.DefaultMessageEmbed
+	}
+	if settings.Title == "" {
+		settings.Title = templates.DefaultMessageTitleEmbed
+	}
+
+	return settings, nil
 }

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -37,7 +37,7 @@ const (
 	footerIconURL               = "https://grafana.com/static/assets/img/fav32.png"
 )
 
-// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
 var APIURL = "https://slack.com/api/chat.postMessage"
 
 var (

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -37,6 +37,9 @@ const (
 	footerIconURL               = "https://grafana.com/static/assets/img/fav32.png"
 )
 
+// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+var APIURL = "https://slack.com/api/chat.postMessage"
+
 var (
 	slackClient = &http.Client{
 		Timeout: time.Second * 30,
@@ -52,8 +55,6 @@ var (
 		},
 	}
 )
-
-var APIEndpoint = "https://slack.com/api/chat.postMessage"
 
 type sendFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (string, error)
 
@@ -389,7 +390,7 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (stri
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("User-Agent", "Grafana")
 	if sn.settings.Token == "" {
-		if sn.settings.URL == APIEndpoint {
+		if sn.settings.URL == APIURL {
 			panic("Token should be set when using the Slack chat API")
 		}
 		sn.log.Debug("Looks like we are using an incoming webhook, no Authorization header required")

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -66,7 +66,7 @@ type AdaptiveCardsAttachment struct {
 	ContentURL  string       `json:"contentUrl,omitempty"`
 }
 
-// AdapativeCard repesents an Adaptive Card.
+// AdaptiveCard repesents an Adaptive Card.
 // https://adaptivecards.io/explorer/AdaptiveCard.html
 type AdaptiveCard struct {
 	Body    []AdaptiveCardItem
@@ -203,7 +203,7 @@ type AdaptiveCardActionItem interface {
 	MarshalJSON() ([]byte, error)
 }
 
-// AdapativeCardOpenURLActionItem is an Action.OpenUrl action.
+// AdaptiveCardOpenURLActionItem is an Action.OpenUrl action.
 type AdaptiveCardOpenURLActionItem struct {
 	IconURL string
 	Title   string

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	// APIURL is a URL where the notification payload is sent
+	// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
 	APIURL = "https://api.telegram.org/bot%s/%s"
 )
 

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -19,6 +19,7 @@ import (
 )
 
 var (
+	// APIURL is a URL where the notification payload is sent
 	APIURL = "https://api.telegram.org/bot%s/%s"
 )
 

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+	// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
 	APIURL = "https://msgapi.threema.ch/send_simple"
 )
 

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	BaseURL = "https://msgapi.threema.ch/send_simple"
+	// APIURL is a URL where the notification payload is sent. Public variable because to be able to override in integration tests
+	APIURL = "https://msgapi.threema.ch/send_simple"
 )
 
 // Notifier is responsible for sending
@@ -58,7 +59,7 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	data.Set("text", tn.buildMessage(ctx, as...))
 
 	cmd := &receivers.SendWebhookSettings{
-		URL:        BaseURL,
+		URL:        APIURL,
 		Body:       data.Encode(),
 		HTTPMethod: "POST",
 		HTTPHeader: map[string]string{


### PR DESCRIPTION
- Extract settings validation code from the constructor for alertmanager and slack notifiers
- Rename all fixed API URLs of notifiers to `APIURL` (we apparently override them in Grafana for tests)