### PR TITLE
Fix formatting of the error in receveris factory

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -87,7 +87,7 @@ func (e ReceiverInitError) Error() string {
 		name = fmt.Sprintf("%q ", e.Cfg.Name)
 	}
 
-	s := fmt.Sprintf("failed to validate receiver %s of type %q: %s", name, e.Cfg.Type, e.Reason)
+	s := fmt.Sprintf("failed to validate receiver %sof type %q: %s", name, e.Cfg.Type, e.Reason)
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %s", s, e.Err.Error())
 	}


### PR DESCRIPTION
In #49 we accidentally broke the format of the errors, and it broke some tests in Grafana. This to return the previous format where the space is added if name is not empty (few line above)