### PR TITLE
Create shared DefaultFuncs variable

### DIFF
--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -1,0 +1,9 @@
+package templates
+
+import (
+	"github.com/prometheus/alertmanager/template"
+)
+
+var (
+	DefaultFuncs = template.DefaultFuncs
+)


### PR DESCRIPTION
This pull request creates a shared `DefaultFuncs` variable that we can use in Alerting. The first use case for this will be adding the `join` function to custom labels and annotations.