### PR TITLE
Use custom Number deserialization in pushover and webhook

### DIFF
--- a/receivers/number.go
+++ b/receivers/number.go
@@ -5,13 +5,17 @@ import (
 	"strings"
 )
 
+// OptionalNumber represents a string that may be a number. It implements a special JSON decoder to accept either a string or a number.
+// The difference from json.Number implementation is that it supports empty string. The json.Number fails if the field is an empty string.
+// The reason we need this is that some notifiers used to accept strings as numbers (even invalid and empty strings), and treated all non-numbers as 0 (see simplejson).
+// This implementation will not allow invalid strings but still more relaxed than json.Number or int64. It will be removed in the future
 type OptionalNumber string
 
 func (o OptionalNumber) String() string {
 	return string(o)
 }
 
-// Int64 returns the number as an int64.
+// Int64 returns the number as an int64. If string is empty, it returns 0.
 func (o OptionalNumber) Int64() (int64, error) {
 	if string(o) == "" {
 		return 0, nil

--- a/receivers/number.go
+++ b/receivers/number.go
@@ -1,0 +1,26 @@
+package receivers
+
+import (
+	"strconv"
+	"strings"
+)
+
+type OptionalNumber string
+
+func (o OptionalNumber) String() string {
+	return string(o)
+}
+
+// Int64 returns the number as an int64.
+func (o OptionalNumber) Int64() (int64, error) {
+	if string(o) == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(string(o), 10, 64)
+}
+
+func (o *OptionalNumber) UnmarshalJSON(bytes []byte) error {
+	str := string(bytes)
+	*o = OptionalNumber(strings.Trim(str, "\""))
+	return nil
+}

--- a/receivers/number_test.go
+++ b/receivers/number_test.go
@@ -1,0 +1,57 @@
+package receivers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNumberDecode(t *testing.T) {
+	type Data struct {
+		Num OptionalNumber `json:"num"`
+	}
+
+	tests := []struct {
+		name          string
+		json          string
+		expected      int64
+		expectedError string
+	}{
+		{
+			name:     "empty string =  0",
+			json:     `{ "num" : ""} `,
+			expected: 0,
+		},
+		{
+			name:          "invalid string =  0",
+			json:          `{ "num" : "test"} `,
+			expected:      0,
+			expectedError: `parsing "test": invalid syntax`,
+		},
+		{
+			name:     "can parse number",
+			json:     `{ "num" : 12345555555} `,
+			expected: 12345555555,
+		},
+		{
+			name:     "can parse number as string",
+			json:     `{ "num" : "12345555555" } `,
+			expected: 12345555555,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := Data{}
+			require.NoError(t, json.Unmarshal([]byte(test.json), &actual))
+			num, err := actual.Num.Int64()
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, num)
+		})
+	}
+}

--- a/receivers/pushover/config.go
+++ b/receivers/pushover/config.go
@@ -28,18 +28,18 @@ type Config struct {
 func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
 	settings := Config{}
 	rawSettings := struct {
-		UserKey          string      `json:"userKey,omitempty" yaml:"userKey,omitempty"`
-		APIToken         string      `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
-		AlertingPriority json.Number `json:"priority,omitempty" yaml:"priority,omitempty"`
-		OKPriority       json.Number `json:"okPriority,omitempty" yaml:"okPriority,omitempty"`
-		Retry            json.Number `json:"retry,omitempty" yaml:"retry,omitempty"`
-		Expire           json.Number `json:"expire,omitempty" yaml:"expire,omitempty"`
-		Device           string      `json:"device,omitempty" yaml:"device,omitempty"`
-		AlertingSound    string      `json:"sound,omitempty" yaml:"sound,omitempty"`
-		OKSound          string      `json:"okSound,omitempty" yaml:"okSound,omitempty"`
-		Upload           *bool       `json:"uploadImage,omitempty" yaml:"uploadImage,omitempty"`
-		Title            string      `json:"title,omitempty" yaml:"title,omitempty"`
-		Message          string      `json:"message,omitempty" yaml:"message,omitempty"`
+		UserKey          string                   `json:"userKey,omitempty" yaml:"userKey,omitempty"`
+		APIToken         string                   `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
+		AlertingPriority receivers.OptionalNumber `json:"priority,omitempty" yaml:"priority,omitempty"`
+		OKPriority       receivers.OptionalNumber `json:"okPriority,omitempty" yaml:"okPriority,omitempty"`
+		Retry            receivers.OptionalNumber `json:"retry,omitempty" yaml:"retry,omitempty"`
+		Expire           receivers.OptionalNumber `json:"expire,omitempty" yaml:"expire,omitempty"`
+		Device           string                   `json:"device,omitempty" yaml:"device,omitempty"`
+		AlertingSound    string                   `json:"sound,omitempty" yaml:"sound,omitempty"`
+		OKSound          string                   `json:"okSound,omitempty" yaml:"okSound,omitempty"`
+		Upload           *bool                    `json:"uploadImage,omitempty" yaml:"uploadImage,omitempty"`
+		Title            string                   `json:"title,omitempty" yaml:"title,omitempty"`
+		Message          string                   `json:"message,omitempty" yaml:"message,omitempty"`
 	}{}
 
 	err := json.Unmarshal(fc.Config.Settings, &rawSettings)

--- a/receivers/pushover/pushover_test.go
+++ b/receivers/pushover/pushover_test.go
@@ -187,6 +187,48 @@ func TestPushoverNotifier(t *testing.T) {
 			expMsgError: nil,
 		},
 		{
+			name: "Integer fields as empty strings",
+			settings: `{
+					"userKey": "<userKey>",
+					"apiToken": "<apiToken>",
+					"device": "device",
+					"priority": "",
+					"okpriority": "",
+					"retry": "",
+					"expire": "",
+					"sound": "echo",
+					"oksound": "magic",
+					"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved"
+				}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
+					},
+				},
+			},
+			expMsg: map[string]string{
+				"user":       "<userKey>",
+				"token":      "<apiToken>",
+				"priority":   "0",
+				"sound":      "echo",
+				"title":      "[FIRING:2]  ",
+				"url":        "http://localhost/alerting/list",
+				"url_title":  "Show alert rule",
+				"message":    "2 alerts are firing, 0 are resolved",
+				"attachment": "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\b\x04\x00\x00\x00\xb5\x1c\f\x02\x00\x00\x00\vIDATx\xdacd`\x00\x00\x00\x06\x00\x020\x81\xd0/\x00\x00\x00\x00IEND\xaeB`\x82",
+				"html":       "1",
+				"device":     "device",
+			},
+			expMsgError: nil,
+		},
+		{
 			name: "Missing user key",
 			settings: `{
 				"apiToken": "<apiToken>"

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -30,15 +30,15 @@ type Config struct {
 func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
 	settings := Config{}
 	rawSettings := struct {
-		URL                      string      `json:"url,omitempty" yaml:"url,omitempty"`
-		HTTPMethod               string      `json:"httpMethod,omitempty" yaml:"httpMethod,omitempty"`
-		MaxAlerts                json.Number `json:"maxAlerts,omitempty" yaml:"maxAlerts,omitempty"`
-		AuthorizationScheme      string      `json:"authorization_scheme,omitempty" yaml:"authorization_scheme,omitempty"`
-		AuthorizationCredentials string      `json:"authorization_credentials,omitempty" yaml:"authorization_credentials,omitempty"`
-		User                     string      `json:"username,omitempty" yaml:"username,omitempty"`
-		Password                 string      `json:"password,omitempty" yaml:"password,omitempty"`
-		Title                    string      `json:"title,omitempty" yaml:"title,omitempty"`
-		Message                  string      `json:"message,omitempty" yaml:"message,omitempty"`
+		URL                      string                   `json:"url,omitempty" yaml:"url,omitempty"`
+		HTTPMethod               string                   `json:"httpMethod,omitempty" yaml:"httpMethod,omitempty"`
+		MaxAlerts                receivers.OptionalNumber `json:"maxAlerts,omitempty" yaml:"maxAlerts,omitempty"`
+		AuthorizationScheme      string                   `json:"authorization_scheme,omitempty" yaml:"authorization_scheme,omitempty"`
+		AuthorizationCredentials string                   `json:"authorization_credentials,omitempty" yaml:"authorization_credentials,omitempty"`
+		User                     string                   `json:"username,omitempty" yaml:"username,omitempty"`
+		Password                 string                   `json:"password,omitempty" yaml:"password,omitempty"`
+		Title                    string                   `json:"title,omitempty" yaml:"title,omitempty"`
+		Message                  string                   `json:"message,omitempty" yaml:"message,omitempty"`
 	}{}
 
 	err := json.Unmarshal(factoryConfig.Config.Settings, &rawSettings)


### PR DESCRIPTION
The `json.Number` implementation fails if the field is an empty string. However, that may be the case when the configuration was created in Grafana 8 and wasn't changed since then.

This PR implements a custom OptionalNumber to support empty strings.