### PR TITLE
Create config tests for each receiver

### DIFF
--- a/receivers/alertmanager/config_test.go
+++ b/receivers/alertmanager/config_test.go
@@ -1,0 +1,136 @@
+package alertmanager
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find url property in settings`,
+		}, {
+			name: "Error in initing: invalid URL",
+			settings: `{
+				"url": "://alertmanager.com"
+			}`,
+			expectedInitError: `invalid url property in settings: parse "://alertmanager.com/api/v1/alerts": missing protocol scheme`,
+		},
+		{
+			name: "Error in initing: empty URL",
+			settings: `{
+				"url": ""
+			}`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name: "Error in initing: null URL",
+			settings: `{
+				"url": null
+			}`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name: "Error in initing: one of multiple URLs is invalid",
+			settings: `{
+				"url": "https://alertmanager-01.com,://url"
+			}`,
+			expectedInitError: "invalid url property in settings: parse \"://url/api/v1/alerts\": missing protocol scheme",
+		}, {
+			name: "Single URL",
+			settings: `{
+				"url": "https://alertmanager-01.com"
+			}`,
+			expectedConfig: Config{
+				URLs: []*url.URL{
+					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+				},
+				User:     "",
+				Password: "",
+			},
+		},
+		{
+			name: "Comma-separated URLs",
+			settings: `{
+				"url": "https://alertmanager-01.com/,https://alertmanager-02.com,,https://alertmanager-03.com"
+			}`,
+			expectedConfig: Config{
+				URLs: []*url.URL{
+					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+					testing2.ParseURLUnsafe("https://alertmanager-02.com/api/v1/alerts"),
+					testing2.ParseURLUnsafe("https://alertmanager-03.com/api/v1/alerts"),
+				},
+				User:     "",
+				Password: "",
+			},
+		},
+		{
+			name: "User and password plain",
+			settings: `{
+				"url": "https://alertmanager-01.com",
+				"basicAuthUser": "grafana",
+				"basicAuthPassword": "admin"
+			}`,
+			expectedConfig: Config{
+				URLs: []*url.URL{
+					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+				},
+				User:     "grafana",
+				Password: "admin",
+			},
+		},
+		{
+			name: "User and password from secrets",
+			settings: `{
+				"url": "https://alertmanager-01.com",
+				"basicAuthUser": "grafana",
+				"basicAuthPassword": "admin"
+			}`,
+			secrets: map[string][]byte{
+				"basicAuthPassword": []byte("grafana-admin"),
+			},
+			expectedConfig: Config{
+				URLs: []*url.URL{
+					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+				},
+				User:     "grafana",
+				Password: "grafana-admin",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secrets,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			sn, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+
+			require.Equal(t, c.expectedConfig.User, sn.User)
+			require.Equal(t, c.expectedConfig.Password, sn.Password)
+			require.EqualValues(t, c.expectedConfig.URLs, sn.URLs)
+		})
+	}
+}

--- a/receivers/dinding/config_test.go
+++ b/receivers/dinding/config_test.go
@@ -1,0 +1,91 @@
+package dinding
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name:              "Error if URL is empty",
+			settings:          `{ "url": "" }`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost"}`,
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: defaultDingdingMsgType,
+				Title:       templates.DefaultMessageTitleEmbed,
+				Message:     templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "All empty fields = minimal valid configuration",
+			settings: `{"url": "http://localhost", "message": "", "title": "", "msgType": ""}`,
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: defaultDingdingMsgType,
+				Title:       templates.DefaultMessageTitleEmbed,
+				Message:     templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Custom config with multiple alerts",
+			settings: `{
+				"url": "http://localhost",
+				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
+                "title": "Alerts firing: {{ len .Alerts.Firing }}",
+				"msgType": "actionCard"
+			}`,
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: "actionCard",
+				Title:       "Alerts firing: {{ len .Alerts.Firing }}",
+				Message:     "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings: json.RawMessage(c.settings),
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/dinding/config_test.go
+++ b/receivers/dinding/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/discord/config_test.go
+++ b/receivers/discord/config_test.go
@@ -1,0 +1,88 @@
+package discord
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find webhook url property in settings`,
+		},
+		{
+			name:              "Error if URL is empty",
+			settings:          `{ "url": "" }`,
+			expectedInitError: `could not find webhook url property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost"}`,
+			expectedConfig: Config{
+				Title:              templates.DefaultMessageTitleEmbed,
+				Message:            templates.DefaultMessageEmbed,
+				AvatarURL:          "",
+				WebhookURL:         "http://localhost",
+				UseDiscordUsername: false,
+			},
+		},
+		{
+			name:     "All empty fields = minimal valid configuration",
+			settings: `{"url": "http://localhost", "title": "", "message": "", "avatar_url" : "", "use_discord_username": null}`,
+			expectedConfig: Config{
+				Title:              templates.DefaultMessageTitleEmbed,
+				Message:            templates.DefaultMessageEmbed,
+				AvatarURL:          "",
+				WebhookURL:         "http://localhost",
+				UseDiscordUsername: false,
+			},
+		},
+		{
+			name:     "Extracts all fields",
+			settings: `{"url": "http://localhost", "title": "test-title", "message": "test-message", "avatar_url" : "http://avatar", "use_discord_username": true}`,
+			expectedConfig: Config{
+				Title:              "test-title",
+				Message:            "test-message",
+				AvatarURL:          "http://avatar",
+				WebhookURL:         "http://localhost",
+				UseDiscordUsername: true,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings: json.RawMessage(c.settings),
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/discord/config_test.go
+++ b/receivers/discord/config_test.go
@@ -21,7 +21,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -21,7 +21,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -1,0 +1,106 @@
+package email
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find addresses in settings`,
+		},
+		{
+			name:              "Error if URL is empty",
+			settings:          `{ "addresses": "" }`,
+			expectedInitError: `could not find addresses in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"addresses": "test@grafana.com"}`,
+			expectedConfig: Config{
+				SingleEmail: false,
+				Addresses: []string{
+					"test@grafana.com",
+				},
+				Message: "",
+				Subject: templates.DefaultMessageTitleEmbed,
+			},
+		},
+		{
+			name:     "Multiple addresses with different delimiters",
+			settings: `{"addresses": "test@grafana.com,test2@grafana.com;test3@grafana.com\ntest4@granafa.com"}`,
+			expectedConfig: Config{
+				SingleEmail: false,
+				Addresses: []string{
+					"test@grafana.com",
+					"test2@grafana.com",
+					"test3@grafana.com",
+					"test4@granafa.com",
+				},
+				Message: "",
+				Subject: templates.DefaultMessageTitleEmbed,
+			},
+		},
+		{
+			name:     "All empty fields = minimal valid configuration",
+			settings: `{"addresses": "test@grafana.com", "subject": "", "message": "", "singleEmail": null}`,
+			expectedConfig: Config{
+				SingleEmail: false,
+				Addresses: []string{
+					"test@grafana.com",
+				},
+				Message: "",
+				Subject: templates.DefaultMessageTitleEmbed,
+			},
+		},
+		{
+			name:     "Extracts all fields",
+			settings: `{"addresses": "test@grafana.com", "subject": "test-subject", "message": "test-message", "singleEmail": true}`,
+			expectedConfig: Config{
+				SingleEmail: true,
+				Addresses: []string{
+					"test@grafana.com",
+				},
+				Message: "test-message",
+				Subject: "test-subject",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings: json.RawMessage(c.settings),
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/googlechat/config_test.go
+++ b/receivers/googlechat/config_test.go
@@ -21,7 +21,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/googlechat/config_test.go
+++ b/receivers/googlechat/config_test.go
@@ -1,0 +1,82 @@
+package googlechat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name:              "Error if URL is empty",
+			settings:          `{ "url": "" }`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost"}`,
+			expectedConfig: Config{
+				Title:   templates.DefaultMessageTitleEmbed,
+				Message: templates.DefaultMessageEmbed,
+				URL:     "http://localhost",
+			},
+		},
+		{
+			name:     "All empty fields = minimal valid configuration",
+			settings: `{"url": "http://localhost", "title": "", "message": "", "avatar_url" : "", "use_discord_username": null}`,
+			expectedConfig: Config{
+				Title:   templates.DefaultMessageTitleEmbed,
+				Message: templates.DefaultMessageEmbed,
+				URL:     "http://localhost",
+			},
+		},
+		{
+			name:     "Extracts all fields",
+			settings: `{"url": "http://localhost", "title": "test-title", "message": "test-message", "avatar_url" : "http://avatar", "use_discord_username": true}`,
+			expectedConfig: Config{
+				Title:   "test-title",
+				Message: "test-message",
+				URL:     "http://localhost",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings: json.RawMessage(c.settings),
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/kafka/config_test.go
+++ b/receivers/kafka/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/kafka/config_test.go
+++ b/receivers/kafka/config_test.go
@@ -1,0 +1,193 @@
+package kafka
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find kafka rest proxy endpoint property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"kafkaRestProxy": "http://localhost", "kafkaTopic" : "test-topic"}`,
+			expectedConfig: Config{
+				Endpoint:       "http://localhost",
+				Topic:          "test-topic",
+				Description:    templates.DefaultMessageTitleEmbed,
+				Details:        templates.DefaultMessageEmbed,
+				Username:       "",
+				Password:       "",
+				APIVersion:     apiVersionV2,
+				KafkaClusterID: "",
+			},
+		},
+		{
+			name:              "Error if Endpoint is empty",
+			settings:          `{ "kafkaTopic" : "test-topic" }`,
+			expectedInitError: `could not find kafka rest proxy endpoint property in settings`,
+		},
+		{
+			name:              "Error if Topic is empty",
+			settings:          `{ "kafkaRestProxy": "http://localhost" }`,
+			expectedInitError: `could not find kafka topic property in settings`,
+		},
+		{
+			name:     "Should trim leading slash from endpoint",
+			settings: `{"kafkaRestProxy": "http://localhost/", "kafkaTopic" : "test-topic"}`,
+			expectedConfig: Config{
+				Endpoint:       "http://localhost",
+				Topic:          "test-topic",
+				Description:    templates.DefaultMessageTitleEmbed,
+				Details:        templates.DefaultMessageEmbed,
+				Username:       "",
+				Password:       "",
+				APIVersion:     apiVersionV2,
+				KafkaClusterID: "",
+			},
+		},
+		{
+			name:     "Should decrypt password",
+			settings: `{"kafkaRestProxy": "http://localhost/", "kafkaTopic" : "test-topic"}`,
+			secureSettings: map[string][]byte{
+				"password": []byte("test-password"),
+			},
+			expectedConfig: Config{
+				Endpoint:       "http://localhost",
+				Topic:          "test-topic",
+				Description:    templates.DefaultMessageTitleEmbed,
+				Details:        templates.DefaultMessageEmbed,
+				Username:       "",
+				Password:       "test-password",
+				APIVersion:     apiVersionV2,
+				KafkaClusterID: "",
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"kafkaRestProxy": "http://localhost/", 
+				"kafkaTopic" : "test-topic", 
+				"description" : "", 
+				"details": "", 
+				"username": "", 
+				"password": "", 
+				"apiVersion": "", 
+				"kafkaClusterId": ""
+			}`,
+			expectedConfig: Config{
+				Endpoint:       "http://localhost",
+				Topic:          "test-topic",
+				Description:    templates.DefaultMessageTitleEmbed,
+				Details:        templates.DefaultMessageEmbed,
+				Username:       "",
+				Password:       "",
+				APIVersion:     apiVersionV2,
+				KafkaClusterID: "",
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"kafkaRestProxy": "http://localhost/", 
+				"kafkaTopic" : "test-topic", 
+				"description" : "test-description", 
+				"details": "test-details", 
+				"username": "test-user", 
+				"password": "password", 
+				"apiVersion": "v2", 
+				"kafkaClusterId": "12345"
+			}`,
+			expectedConfig: Config{
+				Endpoint:       "http://localhost",
+				Topic:          "test-topic",
+				Description:    "test-description",
+				Details:        "test-details",
+				Username:       "test-user",
+				Password:       "password",
+				APIVersion:     "v2",
+				KafkaClusterID: "12345",
+			},
+		},
+		{
+			name: "Should override password from secrets",
+			settings: `{
+				"kafkaRestProxy": "http://localhost/", 
+				"kafkaTopic" : "test-topic", 
+				"password": "password" 
+			}`,
+			secureSettings: map[string][]byte{
+				"password": []byte("test-password"),
+			},
+			expectedConfig: Config{
+				Endpoint:       "http://localhost",
+				Topic:          "test-topic",
+				Description:    templates.DefaultMessageTitleEmbed,
+				Details:        templates.DefaultMessageEmbed,
+				Username:       "",
+				Password:       "test-password",
+				APIVersion:     apiVersionV2,
+				KafkaClusterID: "",
+			},
+		},
+		{
+			name: "Error if api version is unknown",
+			settings: `{
+				"kafkaRestProxy": "http://localhost/", 
+				"kafkaTopic" : "test-topic", 
+				"apiVersion": "test-1235" 
+			}`,
+			expectedInitError: "unsupported api version: test-1235",
+		},
+		{
+			name: "Error if clusterId is not specified for api version 3",
+			settings: `{
+				"kafkaRestProxy": "http://localhost/", 
+				"kafkaTopic" : "test-topic", 
+				"apiVersion": "v3" 
+			}`,
+			expectedInitError: "kafka cluster id must be provided when using api version 3",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/line/config_test.go
+++ b/receivers/line/config_test.go
@@ -1,0 +1,112 @@
+package line
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find token in settings`,
+		},
+		{
+			name:              "Error if Token is empty",
+			settings:          `{ "token": "" }`,
+			expectedInitError: `could not find token in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"token": "test"}`,
+			expectedConfig: Config{
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+				Token:       "test",
+			},
+		},
+		{
+			name:     "Should override token from secure settings",
+			settings: `{"token": "test"}`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+				Token:       "test-token",
+			},
+		},
+		{
+			name:     "Should set token from secure settings",
+			settings: `{}`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+				Token:       "test-token",
+			},
+		},
+		{
+			name:     "All empty fields = minimal valid configuration",
+			settings: `{"token": "", "title": "", "description": "" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+				Token:       "test-token",
+			},
+		},
+		{
+			name:           "Extracts all fields",
+			settings:       `{"token": "test", "title": "test-title", "description": "test-description" }`,
+			secureSettings: map[string][]byte{},
+			expectedConfig: Config{
+				Title:       "test-title",
+				Description: "test-description",
+				Token:       "test",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/line/config_test.go
+++ b/receivers/line/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -1,0 +1,217 @@
+package opsgenie
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find api key property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"apiKey": "test-api-key" }`,
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendTags,
+			},
+		},
+		{
+			name:     "Minimal valid configuration from secrets",
+			settings: `{ }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendTags,
+			},
+		},
+		{
+			name:     "Should overwrite token from secrets",
+			settings: `{ "apiKey": "test" }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendTags,
+			},
+		},
+		{
+			name:     "Send tags as tags",
+			settings: `{ "sendTagsAs" : "tags" }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendTags,
+			},
+		},
+		{
+			name:     "Send tags as details",
+			settings: `{ "sendTagsAs" : "details" }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendDetails,
+			},
+		},
+		{
+			name:     "Send tags as both",
+			settings: `{ "sendTagsAs" : "both" }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendBoth,
+			},
+		},
+		{
+			name:     "Error if send tags is not known",
+			settings: `{ "sendTagsAs" : "test-tags" }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedInitError: `invalid value for sendTagsAs: "test-tags"`,
+		},
+		{
+			name:     "Should use default message if all spaces",
+			settings: `{ "message" : " " }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendTags,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			settings: `{
+				"apiKey": "", 
+				"apiUrl" : "", 
+				"message" : "", 
+				"description": "", 
+				"autoClose": null, 
+				"overridePriority": null, 
+				"sendTagsAs": ""
+			}`,
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           DefaultAlertsURL,
+				Message:          templates.DefaultMessageTitleEmbed,
+				Description:      "",
+				AutoClose:        true,
+				OverridePriority: true,
+				SendTagsAs:       SendTags,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			settings: `{
+				"apiUrl" : "http://localhost", 
+				"message" : "test-message", 
+				"description": "test-description", 
+				"autoClose": false, 
+				"overridePriority": false, 
+				"sendTagsAs": "both"
+			}`,
+			expectedConfig: Config{
+				APIKey:           "test-api-key",
+				APIUrl:           "http://localhost",
+				Message:          "test-message",
+				Description:      "test-description",
+				AutoClose:        false,
+				OverridePriority: false,
+				SendTagsAs:       "both",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/pagerduty/config.go
+++ b/receivers/pagerduty/config.go
@@ -18,6 +18,19 @@ const (
 	DefaultClient   = "Grafana"
 )
 
+func defaultCustomDetails() map[string]string {
+	return map[string]string{
+		"firing":       `{{ template "__text_alert_list" .Alerts.Firing }}`,
+		"resolved":     `{{ template "__text_alert_list" .Alerts.Resolved }}`,
+		"num_firing":   `{{ .Alerts.Firing | len }}`,
+		"num_resolved": `{{ .Alerts.Resolved | len }}`,
+	}
+}
+
+var getHostname = func() (string, error) {
+	return os.Hostname()
+}
+
 type Config struct {
 	Key           string            `json:"integrationKey,omitempty" yaml:"integrationKey,omitempty"`
 	Severity      string            `json:"severity,omitempty" yaml:"severity,omitempty"`
@@ -43,12 +56,7 @@ func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
 		return nil, errors.New("could not find integration key property in settings")
 	}
 
-	settings.CustomDetails = map[string]string{
-		"firing":       `{{ template "__text_alert_list" .Alerts.Firing }}`,
-		"resolved":     `{{ template "__text_alert_list" .Alerts.Resolved }}`,
-		"num_firing":   `{{ .Alerts.Firing | len }}`,
-		"num_resolved": `{{ .Alerts.Resolved | len }}`,
-	}
+	settings.CustomDetails = defaultCustomDetails()
 
 	if settings.Severity == "" {
 		settings.Severity = DefaultSeverity
@@ -72,7 +80,7 @@ func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
 		settings.ClientURL = "{{ .ExternalURL }}"
 	}
 	if settings.Source == "" {
-		source, err := os.Hostname()
+		source, err := getHostname()
 		if err != nil {
 			source = settings.Client
 		}

--- a/receivers/pagerduty/config_test.go
+++ b/receivers/pagerduty/config_test.go
@@ -34,7 +34,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/pagerduty/config_test.go
+++ b/receivers/pagerduty/config_test.go
@@ -1,0 +1,233 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	hostName := "Grafana-TEST-host"
+	provideHostName := func() (string, error) {
+		return hostName, nil
+	}
+	original := getHostname
+	t.Cleanup(func() {
+		getHostname = original
+	})
+	getHostname = provideHostName
+
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+		hostnameOverride  func() (string, error)
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find integration key property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"integrationKey": "test-api-key" }`,
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      DefaultSeverity,
+				CustomDetails: defaultCustomDetails(),
+				Class:         DefaultClass,
+				Component:     "Grafana",
+				Group:         DefaultGroup,
+				Summary:       templates.DefaultMessageTitleEmbed,
+				Source:        hostName,
+				Client:        DefaultClient,
+				ClientURL:     "{{ .ExternalURL }}",
+			},
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{}`,
+			secureSettings: map[string][]byte{
+				"integrationKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      DefaultSeverity,
+				CustomDetails: defaultCustomDetails(),
+				Class:         DefaultClass,
+				Component:     "Grafana",
+				Group:         DefaultGroup,
+				Summary:       templates.DefaultMessageTitleEmbed,
+				Source:        hostName,
+				Client:        DefaultClient,
+				ClientURL:     "{{ .ExternalURL }}",
+			},
+		},
+		{
+			name:     "Should overwrite token from secrets",
+			settings: `{ "integrationKey": "test" }`,
+			secureSettings: map[string][]byte{
+				"integrationKey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      DefaultSeverity,
+				CustomDetails: defaultCustomDetails(),
+				Class:         DefaultClass,
+				Component:     "Grafana",
+				Group:         DefaultGroup,
+				Summary:       templates.DefaultMessageTitleEmbed,
+				Source:        hostName,
+				Client:        DefaultClient,
+				ClientURL:     "{{ .ExternalURL }}",
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			secureSettings: map[string][]byte{
+				"integrationKey": []byte("test-api-key"),
+			},
+			settings: `{
+				"integrationKey": "", 
+				"severity" : "", 
+				"class" : "", 
+				"component": "", 
+				"group": "", 
+				"summary": "", 
+				"source": "",
+				"client" : "",
+				"client_url": ""
+			}`,
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      DefaultSeverity,
+				CustomDetails: defaultCustomDetails(),
+				Class:         DefaultClass,
+				Component:     "Grafana",
+				Group:         DefaultGroup,
+				Summary:       templates.DefaultMessageTitleEmbed,
+				Source:        hostName,
+				Client:        DefaultClient,
+				ClientURL:     "{{ .ExternalURL }}",
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			secureSettings: map[string][]byte{
+				"integrationKey": []byte("test-api-key"),
+			},
+			settings: `{
+				"integrationKey": "", 
+				"severity" : "test-severity", 
+				"class" : "test-class", 
+				"component": "test-component", 
+				"group": "test-group", 
+				"summary": "test-summary", 
+				"source": "test-source",
+				"client" : "test-client",
+				"client_url": "test-client-url"
+			}`,
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      "test-severity",
+				CustomDetails: defaultCustomDetails(),
+				Class:         "test-class",
+				Component:     "test-component",
+				Group:         "test-group",
+				Summary:       "test-summary",
+				Source:        "test-source",
+				Client:        "test-client",
+				ClientURL:     "test-client-url",
+			},
+		},
+		{
+			name: "Should ignore custom details",
+			secureSettings: map[string][]byte{
+				"integrationKey": []byte("test-api-key"),
+			},
+			settings: `{
+				"custom_details" : {
+					"test" : "test"
+				},
+				"CustomDetails" : {
+					"test" : "test"
+				}
+			}`,
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      DefaultSeverity,
+				CustomDetails: defaultCustomDetails(),
+				Class:         DefaultClass,
+				Component:     "Grafana",
+				Group:         DefaultGroup,
+				Summary:       templates.DefaultMessageTitleEmbed,
+				Source:        hostName,
+				Client:        DefaultClient,
+				ClientURL:     "{{ .ExternalURL }}",
+			},
+		},
+		{
+			name: "Source should fallback to client if hostname cannot be resolved",
+			secureSettings: map[string][]byte{
+				"integrationKey": []byte("test-api-key"),
+			},
+			settings: `{
+				"client" : "test-client"
+			}`,
+			hostnameOverride: func() (string, error) {
+				return "", errors.New("test")
+			},
+			expectedConfig: Config{
+				Key:           "test-api-key",
+				Severity:      DefaultSeverity,
+				CustomDetails: defaultCustomDetails(),
+				Class:         DefaultClass,
+				Component:     "Grafana",
+				Group:         DefaultGroup,
+				Summary:       templates.DefaultMessageTitleEmbed,
+				Source:        "test-client",
+				Client:        "test-client",
+				ClientURL:     "{{ .ExternalURL }}",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.hostnameOverride != nil {
+				getHostname = c.hostnameOverride
+				t.Cleanup(func() {
+					getHostname = provideHostName
+				})
+			}
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/pushover/config_test.go
+++ b/receivers/pushover/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/pushover/config_test.go
+++ b/receivers/pushover/config_test.go
@@ -1,0 +1,360 @@
+package pushover
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `user key not found`,
+		},
+		{
+			name:              "Error if userKey is missing",
+			settings:          `{ "apiToken" : "test-api-token" }`,
+			expectedInitError: `user key not found`,
+		},
+		{
+			name:              "Error if apiToken is missing",
+			settings:          `{ "userKey": "test-user-key" }`,
+			expectedInitError: `API token not found`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"userKey": "test-user-key", "apiToken" : "test-api-token" }`,
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Minimal valid configuration from secrets",
+			settings: `{ }`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Should overwrite token from secrets",
+			settings: `{"userKey": "test-", "apiToken" : "test-api" }`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"userKey": "",
+				"apiToken": "",
+				"priority": "",
+				"okPriority": "",
+				"retry": "",
+				"expire": "",
+				"device": "",
+				"sound": "",
+				"okSound": "",
+				"uploadImage": null,
+				"title": "",
+				"message": ""
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"priority": 1,
+				"okPriority": 2,
+				"retry": 555,
+				"expire": 333,
+				"device": "test-device",
+				"sound": "test-sound",
+				"okSound": "test-ok-sound",
+				"uploadImage": false,
+				"title": "test-title",
+				"message": "test-message"
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 1,
+				OkPriority:       2,
+				Retry:            555,
+				Expire:           333,
+				Device:           "test-device",
+				AlertingSound:    "test-sound",
+				OkSound:          "test-ok-sound",
+				Upload:           false,
+				Title:            "test-title",
+				Message:          "test-message",
+			},
+		},
+		{
+			name: "Should treat strings as numbers",
+			settings: `{
+				"priority": "1",
+				"okPriority": "2",
+				"retry": "555",
+				"expire": "333"
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 1,
+				OkPriority:       2,
+				Retry:            555,
+				Expire:           333,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Should fail if priority is not number",
+			settings: `{
+				"priority": "test"
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedInitError: `failed to convert alerting priority to integer`,
+		},
+		{
+			name: "Should fail if priority is not integer",
+			settings: `{
+				"priority": 123.23
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedInitError: `failed to convert alerting priority to integer`,
+		},
+		{
+			name: "Should fail if okPriority is not number",
+			settings: `{
+				"okPriority": "test-ok"
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedInitError: "failed to convert OK priority to integer",
+		},
+		{
+			name: "Should fail if okPriority is not integer",
+			settings: `{
+				"okPriority": 123.23
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedInitError: `failed to convert OK priority to integer`,
+		},
+		{
+			name: "Should fallback to 0 if retry is not number",
+			settings: `{
+				"retry": "test-retry"
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Should default to 0 if retry is not integer",
+			settings: `{
+				"retry": 123.44
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Should fallback to 0 if expire is not number",
+			settings: `{
+				"expire": "test-expire"
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Should default to 0 if expire is not integer",
+			settings: `{
+				"expire": 123.44
+			}`,
+			secureSettings: map[string][]byte{
+				"userKey":  []byte("test-user-key"),
+				"apiToken": []byte("test-api-token"),
+			},
+			expectedConfig: Config{
+				UserKey:          "test-user-key",
+				APIToken:         "test-api-token",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           true,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/sensugo/config_test.go
+++ b/receivers/sensugo/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/sensugo/config_test.go
+++ b/receivers/sensugo/config_test.go
@@ -1,0 +1,155 @@
+package sensugo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find URL property in settings`,
+		},
+		{
+			name:              "Error if url is missing",
+			settings:          `{ "apikey" : "test-api-key" }`,
+			expectedInitError: `could not find URL property in settings`,
+		},
+		{
+			name:              "Error if apikey is missing",
+			settings:          `{ "url": "http://localhost" }`,
+			expectedInitError: `could not find the API key property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost", "apikey" : "test-api-key" }`,
+			expectedConfig: Config{
+				URL:       "http://localhost",
+				Entity:    "",
+				Check:     "",
+				Namespace: "",
+				Handler:   "",
+				APIKey:    "test-api-key",
+				Message:   templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Minimal valid configuration from secrets",
+			settings: `{"url": "http://localhost" }`,
+			secureSettings: map[string][]byte{
+				"apikey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				URL:       "http://localhost",
+				Entity:    "",
+				Check:     "",
+				Namespace: "",
+				Handler:   "",
+				APIKey:    "test-api-key",
+				Message:   templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Should overwrite token from secrets",
+			settings: `{"url": "http://localhost", "apikey" : "test" }`,
+			secureSettings: map[string][]byte{
+				"apikey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				URL:       "http://localhost",
+				Entity:    "",
+				Check:     "",
+				Namespace: "",
+				Handler:   "",
+				APIKey:    "test-api-key",
+				Message:   templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"url": "http://localhost",  
+				"entity" : "",
+				"check" : "",
+				"namespace" : "",
+				"handler" : "",
+				"apikey" : "",
+				"message" : ""
+			}`,
+			secureSettings: map[string][]byte{
+				"apikey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				URL:       "http://localhost",
+				Entity:    "",
+				Check:     "",
+				Namespace: "",
+				Handler:   "",
+				APIKey:    "test-api-key",
+				Message:   templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"url": "http://localhost",  
+				"entity" : "test-entity",
+				"check" : "test-check",
+				"namespace" : "test-namespace",
+				"handler" : "test-handler",
+				"message" : "test-message"
+			}`,
+			secureSettings: map[string][]byte{
+				"apikey": []byte("test-api-key"),
+			},
+			expectedConfig: Config{
+				URL:       "http://localhost",
+				Entity:    "test-entity",
+				Check:     "test-check",
+				Namespace: "test-namespace",
+				Handler:   "test-handler",
+				APIKey:    "test-api-key",
+				Message:   "test-message",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -1,0 +1,276 @@
+package slack
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `recipient must be specified when using the Slack chat API`,
+		},
+		{
+			name:              "Error if default URL and recipient is missing",
+			settings:          `{ "token": "test-token"}`,
+			expectedInitError: `recipient must be specified when using the Slack chat API`,
+		},
+		{
+			name:              "Error if default URL and token is missing",
+			settings:          `{ "recipient" : "test-recipient" }`,
+			expectedInitError: `token must be specified when using the Slack chat API`,
+		},
+		{
+			name:     "Minimal valid configuration (ChatAPI)",
+			settings: `{ "recipient" : "test-recipient", "token": "test-token"}`,
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:     "Minimal valid configuration (ChatAPI) from secrets",
+			settings: `{ "recipient" : "test-recipient" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:     "Minimal valid configuration (WebhookAPI)",
+			settings: `{ "url" : "http://slack.local/some-webhook"}`,
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            "http://slack.local/some-webhook",
+				Token:          "",
+				Recipient:      "",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:     "Minimal valid configuration (WebhookAPI) from secrets",
+			settings: `{ }`,
+			secureSettings: map[string][]byte{
+				"url": []byte("http://slack.local/some-webhook"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            "http://slack.local/some-webhook",
+				Token:          "",
+				Recipient:      "",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:              "Should error if URL is not valid",
+			settings:          `{ "url" : "://slack.local/some-webhook"}`,
+			expectedInitError: `invalid URL "://slack.local/some-webhook"`,
+		},
+		{
+			name:     "Should error if URL from secrets is not valid ",
+			settings: `{ }`,
+			secureSettings: map[string][]byte{
+				"url": []byte("://slack.local/some-webhook"),
+			},
+			expectedInitError: `invalid URL "://slack.local/some-webhook"`,
+		},
+		{
+			name:     "Should overwrite token from secrets",
+			settings: `{"url": "http://localhost", "token": "test" }`,
+			secureSettings: map[string][]byte{
+				"url":   []byte("http://slack.local/some-webhook"),
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            "http://slack.local/some-webhook",
+				Token:          "test-token",
+				Recipient:      "",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:     "Should error if mention is not supported",
+			settings: `{ "recipient" : "test-recipient" , "mentionChannel": "test-channel" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedInitError: `invalid value for mentionChannel: "test-channel"`,
+		},
+		{
+			name:     "Should accept mention \"here\"",
+			settings: `{ "recipient" : "test-recipient" , "mentionChannel": "here" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "here",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:     "Should accept mention \"channel\"",
+			settings: `{ "recipient" : "test-recipient" , "mentionChannel": "channel" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "channel",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+		},
+		{
+			name:     "Should parse mentionUsers",
+			settings: `{ "recipient" : "test-recipient" , "mentionUsers": "user-1,user-2,user-3" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers: []string{
+					"user-1",
+					"user-2",
+					"user-3",
+				},
+				MentionGroups: nil,
+			},
+		},
+		{
+			name:     "Should parse mentionGroups",
+			settings: `{ "recipient" : "test-recipient" , "mentionGroups": "users-1,users-2,users-3" }`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups: []string{
+					"users-1",
+					"users-2",
+					"users-3",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/teams/config_test.go
+++ b/receivers/teams/config_test.go
@@ -21,7 +21,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/teams/config_test.go
+++ b/receivers/teams/config_test.go
@@ -1,0 +1,91 @@
+package teams
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find url property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost" }`,
+			expectedConfig: Config{
+				URL:          "http://localhost",
+				Message:      `{{ template "teams.default.message" .}}`,
+				Title:        templates.DefaultMessageTitleEmbed,
+				SectionTitle: "",
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"url": "http://localhost",  
+				"message" : "",
+				"title" : "",
+				"sectiontitle" : ""
+			}`,
+			expectedConfig: Config{
+				URL:          "http://localhost",
+				Message:      `{{ template "teams.default.message" .}}`,
+				Title:        templates.DefaultMessageTitleEmbed,
+				SectionTitle: "",
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"url": "http://localhost",  
+				"message" : "test-message",
+				"title" : "test-title",
+				"sectiontitle" : "test-second-title"
+			}`,
+			expectedConfig: Config{
+				URL:          "http://localhost",
+				Message:      `test-message`,
+				Title:        "test-title",
+				SectionTitle: "test-second-title",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings: json.RawMessage(c.settings),
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -1,0 +1,189 @@
+package telegram
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find Bot Token in settings`,
+		},
+		{
+			name:              "Error if bottoken is missing",
+			settings:          `{ "chatid" : "test-chat-id" }`,
+			expectedInitError: `could not find Bot Token in settings`,
+		},
+		{
+			name:              "Error if chatid is missing",
+			settings:          `{ "bottoken" : "12345" }`,
+			expectedInitError: `could not find Chat Id in settings`,
+		},
+
+		{
+			name:     "Minimal valid configuration",
+			settings: `{ "bottoken": "test-token", "chatid": "test-chat-id" }`,
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "test-chat-id",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            DefaultTelegramParseMode,
+				DisableNotifications: false,
+			},
+		},
+		{
+			name:     "Minimal valid configuration from secrets",
+			settings: `{"chatid": "test-chat-id" }`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "test-chat-id",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            DefaultTelegramParseMode,
+				DisableNotifications: false,
+			},
+		},
+		{
+			name:     "Should overwrite token from secrets",
+			settings: `{"bottoken": "token", "chatid" : "test-chat-id" }`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token-key"),
+			},
+			expectedConfig: Config{
+				BotToken:             "test-token-key",
+				ChatID:               "test-chat-id",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            DefaultTelegramParseMode,
+				DisableNotifications: false,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"chatid" :"chat-id",
+				"message" :"",
+				"parse_mode" :"",
+				"disable_notifications" : null
+			}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "chat-id",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            DefaultTelegramParseMode,
+				DisableNotifications: false,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"bottoken" :"test-token",
+				"chatid" :"12345678",
+				"message" :"test-message",
+				"parse_mode" :"html",
+				"disable_notifications" :true
+			}`,
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "12345678",
+				Message:              "test-message",
+				ParseMode:            "HTML",
+				DisableNotifications: true,
+			},
+		},
+		{
+			name:     "should fail if parse mode not supported",
+			settings: `{"chatid": "12345678", "parse_mode": "test" }`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedInitError: "unknown parse_mode",
+		},
+		{
+			name:     "should parse parse_mode (Markdown)",
+			settings: `{"chatid": "12345678", "parse_mode": "markdown" }`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "12345678",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            "Markdown",
+				DisableNotifications: false,
+			},
+		},
+		{
+			name:     "should parse parse_mode (MarkdownV2)",
+			settings: `{"chatid": "12345678", "parse_mode": "markdownv2" }`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "12345678",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            "MarkdownV2",
+				DisableNotifications: false,
+			},
+		},
+		{
+			name:     "should parse parse_mode (None)",
+			settings: `{"chatid": "12345678", "parse_mode": "None" }`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:             "test-token",
+				ChatID:               "12345678",
+				Message:              templates.DefaultMessageEmbed,
+				ParseMode:            "",
+				DisableNotifications: false,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/testing/testing.go
+++ b/receivers/testing/testing.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/logging"
+	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/templates"
+)
+
+func NewFactoryConfigForValidateConfigTesting(t *testing.T, m *receivers.NotificationChannelConfig) (receivers.FactoryConfig, error) {
+	tmpl := templates.ForTests(t)
+	tmpl.ExternalURL = ParseURLUnsafe("http://localhost")
+	return receivers.NewFactoryConfig(m, nil, DecryptForTesting, tmpl, &images.UnavailableImageStore{}, func(ctx ...interface{}) logging.Logger {
+		return &logging.FakeLogger{}
+	}, "1.2.3")
+}
+
+func ParseURLUnsafe(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func DecryptForTesting(_ context.Context, sjd map[string][]byte, key string, fallback string) string {
+	v, ok := sjd[key]
+	if !ok {
+		return fallback
+	}
+	return string(v)
+}

--- a/receivers/threema/config_test.go
+++ b/receivers/threema/config_test.go
@@ -1,0 +1,187 @@
+package threema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	var cases = []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find Threema Gateway ID in settings`,
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "12345678",
+				"api_secret": "test-secret"
+			}`,
+			expectedConfig: Config{
+				GatewayID:   "*1234567",
+				RecipientID: "12345678",
+				APISecret:   "test-secret",
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Minimal valid configuration from secrets",
+			settings: `{
+				"gateway_id": "*test123",
+				"recipient_id": "test1234"
+			}`,
+			secureSettings: map[string][]byte{
+				"api_secret": []byte("test-secret"),
+			},
+			expectedConfig: Config{
+				GatewayID:   "*test123",
+				RecipientID: "test1234",
+				APISecret:   "test-secret",
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Error if gateway_id is missing",
+			settings: `{
+				"recipient_id": "*test123",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: `could not find Threema Gateway ID in settings`,
+		},
+		{
+			name: "Error if recipient_id is missing",
+			settings: `{
+				"gateway_id": "*test123",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: `could not find Threema Recipient ID in settings`,
+		},
+		{
+			name: "Error if api_secret is missing",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "test1234"
+			}`,
+			expectedInitError: `could not find Threema API secret in settings`,
+		},
+		{
+			name: "Error if gateway does not start with *",
+			settings: `{
+				"gateway_id": "12345678",
+				"recipient_id": "test1234",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: "invalid Threema Gateway ID: Must start with a *",
+		},
+		{
+			name: "Error if gateway length is greater than 8",
+			settings: `{
+				"gateway_id": "*12345678",
+				"recipient_id": "test1234",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: "invalid Threema Gateway ID: Must be 8 characters long",
+		},
+		{
+			name: "Error if gateway length is less than 8",
+			settings: `{
+				"gateway_id": "*123456",
+				"recipient_id": "*1234567",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: "invalid Threema Gateway ID: Must be 8 characters long",
+		},
+		{
+			name: "Error if recipient_id length is greater than 8",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "123456789",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: "invalid Threema Recipient ID: Must be 8 characters long",
+		},
+		{
+			name: "Error if recipient_id length is less than 8",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "123456",
+				"api_secret": "test-secret"
+			}`,
+			expectedInitError: "invalid Threema Recipient ID: Must be 8 characters long",
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "test-rec",
+				"api_secret": "test-secret",
+				"title" : "",
+				"description": ""
+			}`,
+			expectedConfig: Config{
+				GatewayID:   "*1234567",
+				RecipientID: "test-rec",
+				APISecret:   "test-secret",
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "*1234567",
+				"api_secret": "test-secret",
+				"title" : "test-title",
+				"description": "test-description"
+			}`,
+			expectedConfig: Config{
+				GatewayID:   "*1234567",
+				RecipientID: "*1234567",
+				APISecret:   "test-secret",
+				Title:       "test-title",
+				Description: "test-description",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/threema/config_test.go
+++ b/receivers/threema/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/victorops/config_test.go
+++ b/receivers/victorops/config_test.go
@@ -21,7 +21,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/victorops/config_test.go
+++ b/receivers/victorops/config_test.go
@@ -1,0 +1,91 @@
+package victorops
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `could not find victorops url property in settings`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost" }`,
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: DefaultMessageType,
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"url" : "http://localhost",
+				"messageType" :"",
+				"title" :"",
+				"description" :""
+			}`,
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: DefaultMessageType,
+				Title:       templates.DefaultMessageTitleEmbed,
+				Description: templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"url" : "http://localhost",
+				"messageType" :"test-messagetype",
+				"title" :"test-title",
+				"description" :"test-description"
+			}`,
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: "test-messagetype",
+				Title:       "test-title",
+				Description: "test-description",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings: json.RawMessage(c.settings),
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/webex/config_test.go
+++ b/receivers/webex/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:     "Minimal valid configuration",

--- a/receivers/webex/config_test.go
+++ b/receivers/webex/config_test.go
@@ -1,0 +1,119 @@
+package webex
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{}`,
+			expectedConfig: Config{
+				Message: templates.DefaultMessageEmbed,
+				RoomID:  "",
+				APIURL:  DefaultAPIURL,
+				Token:   "",
+			},
+		},
+		{
+			name:              "Error if url is not valid",
+			settings:          `{ "api_url" : "ostgres://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require" }`,
+			expectedInitError: `invalid URL "ostgres://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require"`,
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"message" :"",  
+				"room_id" :"",
+				"api_url" :"",
+				"bot_token" :""
+			}`,
+			expectedConfig: Config{
+				Message: templates.DefaultMessageEmbed,
+				RoomID:  "",
+				APIURL:  DefaultAPIURL,
+				Token:   "",
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"message" :"test-message",  
+				"room_id" :"test-room-id",
+				"api_url" :"http://localhost",
+				"bot_token" :"12345"
+			}`,
+			expectedConfig: Config{
+				Message: "test-message",
+				RoomID:  "test-room-id",
+				APIURL:  "http://localhost",
+				Token:   "12345",
+			},
+		},
+		{
+			name:     "Extracts token from secrets",
+			settings: `{}`,
+			secureSettings: map[string][]byte{
+				"bot_token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				Message: templates.DefaultMessageEmbed,
+				RoomID:  "",
+				APIURL:  DefaultAPIURL,
+				Token:   "test-token",
+			},
+		},
+		{
+			name:     "Overrides token from secrets",
+			settings: `{ "bot_token": "12345" }`,
+			secureSettings: map[string][]byte{
+				"bot_token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				Message: templates.DefaultMessageEmbed,
+				RoomID:  "",
+				APIURL:  DefaultAPIURL,
+				Token:   "test-token",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, *actual)
+		})
+	}
+}

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -54,6 +54,7 @@ func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
 		rawSettings.HTTPMethod = http.MethodPost
 	}
 	settings.HTTPMethod = rawSettings.HTTPMethod
+	settings.AuthorizationScheme = rawSettings.AuthorizationScheme
 
 	if rawSettings.MaxAlerts != "" {
 		settings.MaxAlerts, _ = strconv.Atoi(rawSettings.MaxAlerts.String())

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -55,7 +55,6 @@ func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
 		rawSettings.HTTPMethod = http.MethodPost
 	}
 	settings.HTTPMethod = rawSettings.HTTPMethod
-	settings.AuthorizationScheme = rawSettings.AuthorizationScheme
 
 	if rawSettings.MaxAlerts != "" {
 		settings.MaxAlerts, _ = strconv.Atoi(rawSettings.MaxAlerts.String())

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -23,7 +23,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -1,0 +1,267 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secretSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `required field 'url' is not specified`,
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"url": "http://localhost" }`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			settings: `{
+				"url": "http://localhost",
+				"httpMethod": "",
+				"maxAlerts": "",
+				"authorization_scheme": "",
+				"authorization_credentials": "",
+				"username": "",
+				"password": "",
+				"title": "",
+				"message": ""		
+			}`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			settings: `{
+				"url": "http://localhost",
+				"httpMethod": "test-httpMethod",
+				"maxAlerts": "2",
+				"authorization_scheme": "basic",
+				"authorization_credentials": "",
+				"username": "test-user",
+				"password": "test-pass",
+				"title": "test-title",
+				"message": "test-message"		
+			}`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               "test-httpMethod",
+				MaxAlerts:                2,
+				AuthorizationScheme:      "basic",
+				AuthorizationCredentials: "",
+				User:                     "test-user",
+				Password:                 "test-pass",
+				Title:                    "test-title",
+				Message:                  "test-message",
+			},
+		},
+		{
+			name:     "should parse maxAlerts as string",
+			settings: `{"url": "http://localhost", "maxAlerts": "12" }`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                12,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should parse maxAlerts as number",
+			settings: `{"url": "http://localhost", "maxAlerts": 12 }`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                12,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should default to 0 if maxAlerts is not valid number",
+			settings: `{"url": "http://localhost", "maxAlerts": "test-max-alerts" }`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should extract username and password from secrets",
+			settings: `{"url": "http://localhost" }`,
+			secretSettings: map[string][]byte{
+				"username": []byte("test-user"),
+				"password": []byte("test-password"),
+			},
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "test-user",
+				Password:                 "test-password",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should override username and password from secrets",
+			settings: `{"url": "http://localhost", "username": "test", "password" : "test" }`,
+			secretSettings: map[string][]byte{
+				"username": []byte("test-user"),
+				"password": []byte("test-password"),
+			},
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "test-user",
+				Password:                 "test-password",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should extract authorization_credentials from secrets",
+			settings: `{"url": "http://localhost", "authorization_scheme" : "test-scheme" }`,
+			secretSettings: map[string][]byte{
+				"authorization_credentials": []byte("test-authorization_credentials"),
+			},
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "test-scheme",
+				AuthorizationCredentials: "test-authorization_credentials",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should override authorization_credentials from secrets",
+			settings: `{"url": "http://localhost", "authorization_scheme" : "test-scheme",  "authorization_credentials": "test" }`,
+			secretSettings: map[string][]byte{
+				"authorization_credentials": []byte("test-authorization_credentials"),
+			},
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "test-scheme",
+				AuthorizationCredentials: "test-authorization_credentials",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "should default authorization_scheme to Bearer if authorization_credentials specified",
+			settings: `{"url": "http://localhost" }`,
+			secretSettings: map[string][]byte{
+				"authorization_credentials": []byte("test-authorization_credentials"),
+			},
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "Bearer",
+				AuthorizationCredentials: "test-authorization_credentials",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "error if both credentials are specified",
+			settings: `{
+				"url": "http://localhost",
+				"authorization_scheme": "basic",
+				"authorization_credentials": "test-credentials",
+				"username": "test-user",
+				"password": "test-pass"
+			}`,
+			expectedInitError: "both HTTP Basic Authentication and Authorization Header are set, only 1 is permitted",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secretSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/wecom/config_test.go
+++ b/receivers/wecom/config_test.go
@@ -1,0 +1,236 @@
+package wecom
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	testing2 "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestValidateConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secureSettings    map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: `either url or secret is required`,
+		},
+		{
+			name:     "Minimal valid configuration (url)",
+			settings: `{ "url" : "http://localhost"}`,
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: weComEndpoint,
+				URL:         "http://localhost",
+				AgentID:     "",
+				CorpID:      "",
+				Secret:      "",
+				MsgType:     DefaultsgType,
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name:     "Minimal valid configuration (url) from secrets",
+			settings: `{}`,
+			secureSettings: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: weComEndpoint,
+				URL:         "http://localhost",
+				AgentID:     "",
+				CorpID:      "",
+				Secret:      "",
+				MsgType:     DefaultsgType,
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name:     "Minimal valid configuration (secret)",
+			settings: `{ "secret" : "test-secret", "agent_id" : "test-agent-id", "corp_id": "test-corp-id"}`,
+			expectedConfig: Config{
+				Channel:     "apiapp",
+				EndpointURL: weComEndpoint,
+				URL:         "",
+				AgentID:     "test-agent-id",
+				CorpID:      "test-corp-id",
+				Secret:      "test-secret",
+				MsgType:     DefaultsgType,
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name:     "Minimal valid configuration (secret) from secrets",
+			settings: `{ "agent_id" : "test-agent-id", "corp_id": "test-corp-id"}`,
+			secureSettings: map[string][]byte{
+				"secret": []byte("test-secret"),
+			},
+			expectedConfig: Config{
+				Channel:     "apiapp",
+				EndpointURL: weComEndpoint,
+				URL:         "",
+				AgentID:     "test-agent-id",
+				CorpID:      "test-corp-id",
+				Secret:      "test-secret",
+				MsgType:     DefaultsgType,
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name:     "should fallback to default if msgType is not known",
+			settings: `{ "msgtype": "test-msg-type"}`,
+			secureSettings: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: weComEndpoint,
+				URL:         "http://localhost",
+				AgentID:     "",
+				CorpID:      "",
+				Secret:      "",
+				MsgType:     DefaultsgType,
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name:     "should parse message type 'markdown'",
+			settings: `{ "msgtype": "markdown"}`,
+			secureSettings: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: weComEndpoint,
+				URL:         "http://localhost",
+				AgentID:     "",
+				CorpID:      "",
+				Secret:      "",
+				MsgType:     "markdown",
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name:     "should parse message type 'text'",
+			settings: `{ "msgtype": "text"}`,
+			secureSettings: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: weComEndpoint,
+				URL:         "http://localhost",
+				AgentID:     "",
+				CorpID:      "",
+				Secret:      "",
+				MsgType:     "text",
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name: "All empty fields = minimal valid configuration",
+			secureSettings: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			settings: `{
+				"endpointUrl" :"",
+				"agent_id" :"",
+				"corp_id" :"",
+				"secret" :"",
+				"msgtype" :"",
+				"message" :"",
+				"title" :"",
+				"touser" :""
+			}`,
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: weComEndpoint,
+				URL:         "http://localhost",
+				AgentID:     "",
+				CorpID:      "",
+				Secret:      "",
+				MsgType:     DefaultsgType,
+				Message:     templates.DefaultMessageEmbed,
+				Title:       templates.DefaultMessageTitleEmbed,
+				ToUser:      DefaultToUser,
+			},
+		},
+		{
+			name: "Extracts all fields",
+			secureSettings: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			settings: `{
+				"endpointUrl" : "test-endpointUrl",
+				"agent_id" : "test-agent_id",
+				"corp_id" : "test-corp_id",
+				"secret" : "test-secret",
+				"msgtype" : "markdown",
+				"message" : "test-message",
+				"title" : "test-title",
+				"touser" : "test-touser"
+			}`,
+			expectedConfig: Config{
+				Channel:     DefaultChannelType,
+				EndpointURL: "test-endpointUrl",
+				URL:         "http://localhost",
+				AgentID:     "test-agent_id",
+				CorpID:      "test-corp_id",
+				Secret:      "test-secret",
+				MsgType:     "markdown",
+				Message:     "test-message",
+				Title:       "test-title",
+				ToUser:      "test-touser",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &receivers.NotificationChannelConfig{
+				Settings:       json.RawMessage(c.settings),
+				SecureSettings: c.secureSettings,
+			}
+			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			require.NoError(t, err)
+
+			actual, err := ValidateConfig(fc)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/wecom/config_test.go
+++ b/receivers/wecom/config_test.go
@@ -22,7 +22,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:              "Error if empty",
 			settings:          "",
-			expectedInitError: `failed to unmarshal settings: unexpected end of JSON input`,
+			expectedInitError: `failed to unmarshal settings`,
 		},
 		{
 			name:              "Error if empty JSON object",


### PR DESCRIPTION
This PR introduces tests for parsing notifier configuration. This increases the coverage of the receiver parsing logic, which opens the possibility for further safe refactorings.

Note: this does not touch any existing tests, which will be refactored in the following PR.