### PR TITLE
Refactor notifier tests to use Config struct instead json

### DIFF
--- a/receivers/alertmanager/alertmanager_test.go
+++ b/receivers/alertmanager/alertmanager_test.go
@@ -16,14 +16,14 @@ import (
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestNotify(t *testing.T) {
 	imageStore := images.NewFakeImageStore(1)
 	singleURLConfig := Config{
 		URLs: []*url.URL{
-			testing2.ParseURLUnsafe("https://alertmanager.com/api/v1/alerts"),
+			receiversTesting.ParseURLUnsafe("https://alertmanager.com/api/v1/alerts"),
 		},
 		User:     "admin",
 		Password: "password",

--- a/receivers/alertmanager/alertmanager_test.go
+++ b/receivers/alertmanager/alertmanager_test.go
@@ -10,117 +10,35 @@ import (
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	"github.com/grafana/alerting/templates"
+	testing2 "github.com/grafana/alerting/receivers/testing"
 )
 
-func TestNewAlertmanagerNotifier(t *testing.T) {
-	tmpl := templates.ForTests(t)
-
-	externalURL, err := url.Parse("http://localhost")
-	require.NoError(t, err)
-	tmpl.ExternalURL = externalURL
-
-	cases := []struct {
-		name              string
-		settings          string
-		alerts            []*types.Alert
-		expectedInitError string
-		receiverName      string
-	}{
-		{
-			name:              "Error in initing: missing URL",
-			settings:          `{}`,
-			expectedInitError: `could not find url property in settings`,
-		}, {
-			name: "Error in initing: invalid URL",
-			settings: `{
-				"url": "://alertmanager.com"
-			}`,
-			expectedInitError: `invalid url property in settings: parse "://alertmanager.com/api/v1/alerts": missing protocol scheme`,
-			receiverName:      "Alertmanager",
+func TestNotify(t *testing.T) {
+	imageStore := images.NewFakeImageStore(1)
+	singleURLConfig := Config{
+		URLs: []*url.URL{
+			testing2.ParseURLUnsafe("https://alertmanager.com/api/v1/alerts"),
 		},
-		{
-			name: "Error in initing: empty URL",
-			settings: `{
-				"url": ""
-			}`,
-			expectedInitError: `could not find url property in settings`,
-			receiverName:      "Alertmanager",
-		},
-		{
-			name: "Error in initing: null URL",
-			settings: `{
-				"url": null
-			}`,
-			expectedInitError: `could not find url property in settings`,
-			receiverName:      "Alertmanager",
-		},
-		{
-			name: "Error in initing: one of multiple URLs is invalid",
-			settings: `{
-				"url": "https://alertmanager-01.com,://url"
-			}`,
-			expectedInitError: "invalid url property in settings: parse \"://url/api/v1/alerts\": missing protocol scheme",
-			receiverName:      "Alertmanager",
-		},
+		User:     "admin",
+		Password: "password",
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			secureSettings := make(map[string][]byte)
-
-			m := &receivers.NotificationChannelConfig{
-				Name:           c.receiverName,
-				Type:           "prometheus-alertmanager",
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: secureSettings,
-			}
-
-			decryptFn := func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
-				return fallback
-			}
-
-			fc := receivers.FactoryConfig{
-				Config:      m,
-				DecryptFunc: decryptFn,
-				ImageStore:  &images.UnavailableImageStore{},
-				Template:    tmpl,
-				Logger:      &logging.FakeLogger{},
-			}
-			sn, err := New(fc)
-			if c.expectedInitError != "" {
-				require.ErrorContains(t, err, c.expectedInitError)
-			} else {
-				require.NotNil(t, sn)
-			}
-		})
-	}
-}
-
-func TestAlertmanagerNotifier_Notify(t *testing.T) {
-	tmpl := templates.ForTests(t)
-
-	images := images.NewFakeImageStore(1)
-
-	externalURL, err := url.Parse("http://localhost")
-	require.NoError(t, err)
-	tmpl.ExternalURL = externalURL
 
 	cases := []struct {
 		name                 string
-		settings             string
+		settings             Config
 		alerts               []*types.Alert
 		expectedError        string
 		sendHTTPRequestError error
-		receiverName         string
 	}{
 		{
 			name:     "Default config with one alert",
-			settings: `{"url": "https://alertmanager.com"}`,
+			settings: singleURLConfig,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
@@ -129,10 +47,9 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 					},
 				},
 			},
-			receiverName: "Alertmanager",
 		}, {
 			name:     "Default config with one alert with image URL",
-			settings: `{"url": "https://alertmanager.com"}`,
+			settings: singleURLConfig,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
@@ -141,10 +58,9 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 					},
 				},
 			},
-			receiverName: "Alertmanager",
 		}, {
 			name:     "Default config with one alert with empty receiver name",
-			settings: `{"url": "https://alertmanager.com"}`,
+			settings: singleURLConfig,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
@@ -154,10 +70,8 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 				},
 			},
 		}, {
-			name: "Error sending to Alertmanager",
-			settings: `{
-				"url": "https://alertmanager.com"
-			}`,
+			name:     "Error sending to Alertmanager",
+			settings: singleURLConfig,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
@@ -168,34 +82,21 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 			},
 			expectedError:        "failed to send alert to Alertmanager: expected error",
 			sendHTTPRequestError: errors.New("expected error"),
-			receiverName:         "Alertmanager",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			settingsJSON := json.RawMessage(c.settings)
-			require.NoError(t, err)
-			secureSettings := make(map[string][]byte)
-
-			m := &receivers.NotificationChannelConfig{
-				Name:           c.receiverName,
-				Type:           "prometheus-alertmanager",
-				Settings:       settingsJSON,
-				SecureSettings: secureSettings,
+			sn := &Notifier{
+				Base: &receivers.Base{
+					Name:                  "",
+					Type:                  "",
+					UID:                   "",
+					DisableResolveMessage: false,
+				},
+				images:   imageStore,
+				settings: c.settings,
+				logger:   &logging.FakeLogger{},
 			}
-
-			decryptFn := func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
-				return fallback
-			}
-			fc := receivers.FactoryConfig{
-				Config:      m,
-				DecryptFunc: decryptFn,
-				ImageStore:  images,
-				Template:    tmpl,
-				Logger:      &logging.FakeLogger{},
-			}
-			sn, err := New(fc)
-			require.NoError(t, err)
 
 			var body []byte
 			origSendHTTPRequest := receivers.SendHTTPRequest
@@ -204,6 +105,8 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 			})
 			receivers.SendHTTPRequest = func(ctx context.Context, url *url.URL, cfg receivers.HTTPCfg, logger logging.Logger) ([]byte, error) {
 				body = cfg.Body
+				assert.Equal(t, c.settings.User, cfg.User)
+				assert.Equal(t, c.settings.Password, cfg.Password)
 				return nil, c.sendHTTPRequestError
 			}
 

--- a/receivers/alertmanager/config_test.go
+++ b/receivers/alertmanager/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestValidateConfig(t *testing.T) {
@@ -57,7 +57,7 @@ func TestValidateConfig(t *testing.T) {
 			}`,
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
 				},
 				User:     "",
 				Password: "",
@@ -70,9 +70,9 @@ func TestValidateConfig(t *testing.T) {
 			}`,
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
-					testing2.ParseURLUnsafe("https://alertmanager-02.com/api/v1/alerts"),
-					testing2.ParseURLUnsafe("https://alertmanager-03.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-02.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-03.com/api/v1/alerts"),
 				},
 				User:     "",
 				Password: "",
@@ -87,7 +87,7 @@ func TestValidateConfig(t *testing.T) {
 			}`,
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
 				},
 				User:     "grafana",
 				Password: "admin",
@@ -105,7 +105,7 @@ func TestValidateConfig(t *testing.T) {
 			},
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					testing2.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
 				},
 				User:     "grafana",
 				Password: "grafana-admin",
@@ -118,7 +118,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secrets,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			sn, err := ValidateConfig(fc)

--- a/receivers/dinding/config_test.go
+++ b/receivers/dinding/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -75,7 +75,7 @@ func TestValidateConfig(t *testing.T) {
 			m := &receivers.NotificationChannelConfig{
 				Settings: json.RawMessage(c.settings),
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/discord/config_test.go
+++ b/receivers/discord/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -73,7 +73,7 @@ func TestValidateConfig(t *testing.T) {
 			m := &receivers.NotificationChannelConfig{
 				Settings: json.RawMessage(c.settings),
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -91,7 +91,7 @@ func TestValidateConfig(t *testing.T) {
 			m := &receivers.NotificationChannelConfig{
 				Settings: json.RawMessage(c.settings),
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/googlechat/config_test.go
+++ b/receivers/googlechat/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -67,7 +67,7 @@ func TestValidateConfig(t *testing.T) {
 			m := &receivers.NotificationChannelConfig{
 				Settings: json.RawMessage(c.settings),
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/kafka/config_test.go
+++ b/receivers/kafka/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -177,7 +177,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/line/config_test.go
+++ b/receivers/line/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -97,7 +97,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -201,7 +201,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/pagerduty/config_test.go
+++ b/receivers/pagerduty/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -217,7 +217,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/pushover/config_test.go
+++ b/receivers/pushover/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -344,7 +344,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/sensugo/config_test.go
+++ b/receivers/sensugo/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -139,7 +139,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -260,7 +260,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -29,20 +29,29 @@ import (
 
 var appVersion = fmt.Sprintf("%d.0.0", rand.Uint32())
 
-func TestSlackIncomingWebhook(t *testing.T) {
+func TestNotify_IncomingWebhook(t *testing.T) {
 	tests := []struct {
 		name            string
 		alerts          []*types.Alert
 		expectedMessage *slackMessage
 		expectedError   string
-		settings        string
+		settings        Config
 	}{{
 		name: "Message is sent",
-		settings: `{
-			"icon_emoji": ":emoji:",
-			"recipient": "#test",
-			"url": "https://example.com/hooks/xxxx"
-		}`,
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            "https://example.com/hooks/xxxx",
+			Token:          "",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -68,11 +77,20 @@ func TestSlackIncomingWebhook(t *testing.T) {
 		},
 	}, {
 		name: "Message is sent with image URL",
-		settings: `{
-				"icon_emoji": ":emoji:",
-				"recipient": "#test",
-				"url": "https://example.com/hooks/xxxx"
-			}`,
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            "https://example.com/hooks/xxxx",
+			Token:          "",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -99,11 +117,20 @@ func TestSlackIncomingWebhook(t *testing.T) {
 		},
 	}, {
 		name: "Message is sent and image on local disk is ignored",
-		settings: `{
-				"icon_emoji": ":emoji:",
-				"recipient": "#test",
-				"url": "https://example.com/hooks/xxxx"
-			}`,
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            "https://example.com/hooks/xxxx",
+			Token:          "",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -171,21 +198,30 @@ func TestSlackIncomingWebhook(t *testing.T) {
 	}
 }
 
-func TestSlackPostMessage(t *testing.T) {
+func TestNotigy_PostMessage(t *testing.T) {
 	tests := []struct {
 		name            string
 		alerts          []*types.Alert
 		expectedMessage *slackMessage
 		expectedReplies []interface{} // can contain either slackMessage or map[string]struct{} for multipart/form-data
 		expectedError   string
-		settings        string
+		settings        Config
 	}{{
 		name: "Message is sent",
-		settings: `{
-			"icon_emoji": ":emoji:",
-			"recipient": "#test",
-			"token": "1234"
-		}`,
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            APIURL,
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -211,12 +247,20 @@ func TestSlackPostMessage(t *testing.T) {
 		},
 	}, {
 		name: "Message is sent with two firing alerts",
-		settings: `{
-			"title": "{{ .Alerts.Firing | len }} firing, {{ .Alerts.Resolved | len }} resolved",
-			"icon_emoji": ":emoji:",
-			"recipient": "#test",
-			"token": "1234"
-		}`,
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            APIURL,
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          "{{ .Alerts.Firing | len }} firing, {{ .Alerts.Resolved | len }} resolved",
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -247,11 +291,20 @@ func TestSlackPostMessage(t *testing.T) {
 		},
 	}, {
 		name: "Message is sent and image is uploaded",
-		settings: `{
-			"icon_emoji": ":emoji:",
-			"recipient": "#test",
-			"token": "1234"
-		}`,
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            APIURL,
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -286,12 +339,20 @@ func TestSlackPostMessage(t *testing.T) {
 		},
 	}, {
 		name: "Message is sent to custom URL",
-		settings: `{
-			"icon_emoji": ":emoji:",
-			"recipient": "#test",
-			"endpointUrl": "https://example.com/api",
-			"token": "1234"
-		}`,
+		settings: Config{
+			EndpointURL:    "https://example.com/api",
+			URL:            "https://example.com/api",
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
@@ -402,7 +463,7 @@ func checkMultipart(t *testing.T, expected map[string]struct{}, r io.Reader, bou
 	assert.Equal(t, expected, visited)
 }
 
-func setupSlackForTests(t *testing.T, settings string) (*Notifier, *slackRequestRecorder, error) {
+func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequestRecorder, error) {
 	tmpl := templates.ForTests(t)
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
@@ -428,64 +489,24 @@ func setupSlackForTests(t *testing.T, settings string) (*Notifier, *slackRequest
 	}
 	notificationService := receivers.MockNotificationService()
 
-	c := receivers.FactoryConfig{
-		Config: &receivers.NotificationChannelConfig{
-			Name:           "slack_testing",
-			Type:           "slack",
-			Settings:       json.RawMessage(settings),
-			SecureSettings: make(map[string][]byte),
+	sn := &Notifier{
+		Base: &receivers.Base{
+			Name:                  "",
+			Type:                  "",
+			UID:                   "",
+			DisableResolveMessage: false,
 		},
-		ImageStore:          images,
-		NotificationService: notificationService,
-		DecryptFunc: func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
-			return fallback
-		},
-		Template:            tmpl,
-		Logger:              &logging.FakeLogger{},
-		GrafanaBuildVersion: appVersion,
-	}
-
-	sn, err := New(c)
-	if err != nil {
-		return nil, nil, err
+		log:           &logging.FakeLogger{},
+		webhookSender: notificationService,
+		tmpl:          tmpl,
+		settings:      settings,
+		images:        images,
+		appVersion:    appVersion,
 	}
 
 	sr := &slackRequestRecorder{}
 	sn.sendFn = sr.fn
 	return sn, sr, nil
-}
-
-func TestCreateSlackNotifierFromConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		settings      string
-		expectedError string
-	}{{
-		name: "Missing token",
-		settings: `{
-			"recipient": "#testchannel"
-		}`,
-		expectedError: "token must be specified when using the Slack chat API",
-	}, {
-		name: "Missing recipient",
-		settings: `{
-			"token": "1234"
-		}`,
-		expectedError: "recipient must be specified when using the Slack chat API",
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			n, _, err := setupSlackForTests(t, test.settings)
-			if test.expectedError != "" {
-				assert.Nil(t, n)
-				assert.EqualError(t, err, test.expectedError)
-			} else {
-				assert.NotNil(t, n)
-				assert.Nil(t, err)
-			}
-		})
-	}
 }
 
 func TestSendSlackRequest(t *testing.T) {

--- a/receivers/teams/config_test.go
+++ b/receivers/teams/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -75,7 +75,7 @@ func TestValidateConfig(t *testing.T) {
 			m := &receivers.NotificationChannelConfig{
 				Settings: json.RawMessage(c.settings),
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -173,7 +173,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/threema/config_test.go
+++ b/receivers/threema/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -171,7 +171,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/victorops/config_test.go
+++ b/receivers/victorops/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -75,7 +75,7 @@ func TestValidateConfig(t *testing.T) {
 			m := &receivers.NotificationChannelConfig{
 				Settings: json.RawMessage(c.settings),
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/webex/config_test.go
+++ b/receivers/webex/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -103,7 +103,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -251,7 +251,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secretSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)

--- a/receivers/wecom/config_test.go
+++ b/receivers/wecom/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
-	testing2 "github.com/grafana/alerting/receivers/testing"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -220,7 +220,7 @@ func TestValidateConfig(t *testing.T) {
 				Settings:       json.RawMessage(c.settings),
 				SecureSettings: c.secureSettings,
 			}
-			fc, err := testing2.NewFactoryConfigForValidateConfigTesting(t, m)
+			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
 			require.NoError(t, err)
 
 			actual, err := ValidateConfig(fc)


### PR DESCRIPTION
Refactors tests that test notifiers' `Notify` methods to use Config struct instead of raw JSON.  The tests that assert parser logic are deleted because they are duplicates of tests introduced in https://github.com/grafana/alerting/pull/57

The structures that replace raw JSON are equivalent.