### PR TITLE
Move integration building logic from Grafana

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -1,11 +1,15 @@
 package notify
 
 import (
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/prometheus/alertmanager/notify"
 
+	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/alertmanager"
 	"github.com/grafana/alerting/receivers/dinding"
@@ -96,3 +100,89 @@ func (e ReceiverInitError) Error() string {
 }
 
 func (e ReceiverInitError) Unwrap() error { return e.Err }
+
+type IntegrationsBuilder struct {
+	OrgID               int64
+	BuildVersion        string
+	NotificationService receivers.NotificationSender
+	DecryptFunc         receivers.GetDecryptedValueFn
+	ImageStore          images.ImageStore
+	LoggerFactory       logging.LoggerFactory
+}
+
+// BuildIntegrationsMap builds a map of name to the list of Grafana integration notifiers off of a list of receiver config.
+func (ib IntegrationsBuilder) BuildIntegrationsMap(receivers []*APIReceiver, templates *Template) (map[string][]*Integration, error) {
+	integrationsMap := make(map[string][]*Integration, len(receivers))
+	for _, receiver := range receivers {
+		integrations, err := ib.buildReceiverIntegrations(receiver, templates)
+		if err != nil {
+			return nil, err
+		}
+		integrationsMap[receiver.Name] = integrations
+	}
+
+	return integrationsMap, nil
+}
+
+// BuildReceiverIntegrations builds a list of integration notifiers off of a receiver config.
+func (ib IntegrationsBuilder) buildReceiverIntegrations(receiver *APIReceiver, tmpl *Template) ([]*Integration, error) {
+	integrations := make([]*Integration, 0, len(receiver.Receivers))
+	for i, r := range receiver.Receivers {
+		n, err := ib.buildReceiverIntegration(r, tmpl)
+		if err != nil {
+			return nil, err
+		}
+		integrations = append(integrations, NewIntegration(n, n, r.Type, i))
+	}
+	return integrations, nil
+}
+
+func (ib IntegrationsBuilder) buildReceiverIntegration(r *GrafanaReceiver, tmpl *Template) (NotificationChannel, error) {
+	// secure settings are already encrypted at this point
+	secureSettings := make(map[string][]byte, len(r.SecureSettings))
+
+	for k, v := range r.SecureSettings {
+		d, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return nil, InvalidReceiverError{
+				Receiver: r,
+				Err:      errors.New("failed to decode secure setting"),
+			}
+		}
+		secureSettings[k] = d
+	}
+
+	var (
+		cfg = &receivers.NotificationChannelConfig{
+			UID:                   r.UID,
+			OrgID:                 ib.OrgID,
+			Name:                  r.Name,
+			Type:                  r.Type,
+			DisableResolveMessage: r.DisableResolveMessage,
+			Settings:              r.Settings,
+			SecureSettings:        secureSettings,
+		}
+	)
+	factoryConfig, err := receivers.NewFactoryConfig(cfg, ib.NotificationService, ib.DecryptFunc, tmpl, ib.ImageStore, ib.LoggerFactory, ib.BuildVersion)
+	if err != nil {
+		return nil, InvalidReceiverError{
+			Receiver: r,
+			Err:      err,
+		}
+	}
+	receiverFactory, exists := Factory(r.Type)
+	if !exists {
+		return nil, InvalidReceiverError{
+			Receiver: r,
+			Err:      fmt.Errorf("notifier %s is not supported", r.Type),
+		}
+	}
+	n, err := receiverFactory(factoryConfig)
+	if err != nil {
+		return nil, InvalidReceiverError{
+			Receiver: r,
+			Err:      err,
+		}
+	}
+	return n, nil
+}

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -163,7 +164,7 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 
 	for _, receiver := range c.Receivers {
 		for _, next := range receiver.Receivers {
-			n, err := am.buildReceiverIntegration(next, tmpl)
+			n, err := am.IntegrationsBuilder.buildReceiverIntegration(next, tmpl)
 			if err != nil {
 				invalid = append(invalid, result{
 					Config:       next,

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -47,12 +47,12 @@ type InvalidReceiverError struct {
 }
 
 type GrafanaReceiver struct {
-	UID                   string                 `json:"uid"`
-	Name                  string                 `json:"name"`
-	Type                  string                 `json:"type"`
-	DisableResolveMessage bool                   `json:"disableResolveMessage"`
-	Settings              map[string]interface{} `json:"settings"`
-	SecureSettings        map[string]string      `json:"secureSettings"`
+	UID                   string            `json:"uid"`
+	Name                  string            `json:"name"`
+	Type                  string            `json:"type"`
+	DisableResolveMessage bool              `json:"disableResolveMessage"`
+	Settings              json.RawMessage   `json:"settings"`
+	SecureSettings        map[string]string `json:"secureSettings"`
 }
 
 type ConfigReceiver = config.Receiver


### PR DESCRIPTION
This PR splits the building of the integration from the alertmanager configuration.
- Interface `Configuration` is updated to require a method `Receivers` that returns a collection of `ApiReceiver`
- The Grafana Alertmanager is updated to accept a new struct IntegrationsBuilder. That struct encapsulates all services that are required to create an integration and build a `Notifier` from `GrafanaReceiver` configuration. The code is moved from Grafana with minimal changes.

Relates to PR https://github.com/grafana/grafana/pull/63340