### PR TITLE
Refactor ValidateConfig of all receivers to accept only what is needed

### DIFF
--- a/receivers/alertmanager/alertmanager.go
+++ b/receivers/alertmanager/alertmanager.go
@@ -14,7 +14,7 @@ import (
 )
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/alertmanager/alertmanager.go
+++ b/receivers/alertmanager/alertmanager.go
@@ -14,7 +14,7 @@ import (
 )
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/alertmanager/config.go
+++ b/receivers/alertmanager/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Password string
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings struct {
 		URL      receivers.CommaSeparatedStrings `json:"url,omitempty" yaml:"url,omitempty"`
 		User     string                          `json:"basicAuthUser,omitempty" yaml:"basicAuthUser,omitempty"`

--- a/receivers/alertmanager/config_test.go
+++ b/receivers/alertmanager/config_test.go
@@ -113,7 +113,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			sn, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.GetDecryptForTesting(c.secrets))
+			sn, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/alertmanager/config_test.go
+++ b/receivers/alertmanager/config_test.go
@@ -10,7 +10,7 @@ import (
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -113,7 +113,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			sn, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+			sn, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/alertmanager/config_test.go
+++ b/receivers/alertmanager/config_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
@@ -114,14 +113,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secrets,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			sn, err := ValidateConfig(fc)
+			sn, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.GetDecryptForTesting(c.secrets))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/dinding/config.go
+++ b/receivers/dinding/config.go
@@ -17,7 +17,7 @@ type Config struct {
 
 const defaultDingdingMsgType = "link"
 
-func ValidateConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/dinding/config.go
+++ b/receivers/dinding/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -18,9 +17,9 @@ type Config struct {
 
 const defaultDingdingMsgType = "link"
 
-func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	var settings Config
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}

--- a/receivers/dinding/config.go
+++ b/receivers/dinding/config.go
@@ -17,14 +17,14 @@ type Config struct {
 
 const defaultDingdingMsgType = "link"
 
-func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 	if settings.URL == "" {
-		return nil, errors.New("could not find url property in settings")
+		return Config{}, errors.New("could not find url property in settings")
 	}
 	if settings.MessageType == "" {
 		settings.MessageType = defaultDingdingMsgType
@@ -35,5 +35,5 @@ func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	if settings.Message == "" {
 		settings.Message = templates.DefaultMessageEmbed
 	}
-	return &settings, nil
+	return settings, nil
 }

--- a/receivers/dinding/config_test.go
+++ b/receivers/dinding/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -70,7 +70,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/dinding/config_test.go
+++ b/receivers/dinding/config_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -72,13 +70,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings: json.RawMessage(c.settings),
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/dinding/config_test.go
+++ b/receivers/dinding/config_test.go
@@ -77,7 +77,7 @@ func TestValidateConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/dinding/dingding.go
+++ b/receivers/dinding/dingding.go
@@ -25,7 +25,7 @@ type Notifier struct {
 
 // New is the constructor for the Dingding notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings)
+	settings, err := NewConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/dinding/dingding.go
+++ b/receivers/dinding/dingding.go
@@ -25,7 +25,7 @@ type Notifier struct {
 
 // New is the constructor for the Dingding notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/dinding/dingding.go
+++ b/receivers/dinding/dingding.go
@@ -34,7 +34,7 @@ func New(fc receivers.FactoryConfig) (*Notifier, error) {
 		log:      fc.Logger,
 		ns:       fc.NotificationService,
 		tmpl:     fc.Template,
-		settings: *settings,
+		settings: settings,
 	}, nil
 }
 

--- a/receivers/discord/config.go
+++ b/receivers/discord/config.go
@@ -16,14 +16,14 @@ type Config struct {
 	UseDiscordUsername bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 	if settings.WebhookURL == "" {
-		return nil, errors.New("could not find webhook url property in settings")
+		return Config{}, errors.New("could not find webhook url property in settings")
 	}
 	if settings.Title == "" {
 		settings.Title = templates.DefaultMessageTitleEmbed
@@ -31,5 +31,5 @@ func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	if settings.Message == "" {
 		settings.Message = templates.DefaultMessageEmbed
 	}
-	return &settings, nil
+	return settings, nil
 }

--- a/receivers/discord/config.go
+++ b/receivers/discord/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	UseDiscordUsername bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/discord/config.go
+++ b/receivers/discord/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -17,9 +16,9 @@ type Config struct {
 	UseDiscordUsername bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	var settings Config
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}

--- a/receivers/discord/config_test.go
+++ b/receivers/discord/config_test.go
@@ -74,7 +74,7 @@ func TestValidateConfig(t *testing.T) {
 				require.ErrorContains(t, err, c.expectedInitError)
 				return
 			}
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/discord/config_test.go
+++ b/receivers/discord/config_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -70,13 +68,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings: json.RawMessage(c.settings),
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/discord/config_test.go
+++ b/receivers/discord/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -68,7 +68,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -83,7 +83,7 @@ type discordAttachment struct {
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings)
+	settings, err := NewConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -70,7 +70,7 @@ type Notifier struct {
 	ns         receivers.WebhookSender
 	images     images.ImageStore
 	tmpl       *template.Template
-	settings   *Config
+	settings   Config
 	appVersion string
 }
 

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -83,7 +83,7 @@ type discordAttachment struct {
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/discord/discord_test.go
+++ b/receivers/discord/discord_test.go
@@ -356,7 +356,7 @@ func TestNotify(t *testing.T) {
 				log:        &logging.FakeLogger{},
 				ns:         webhookSender,
 				tmpl:       tmpl,
-				settings:   &c.settings,
+				settings:   c.settings,
 				images:     imageStore,
 				appVersion: appVersion,
 			}

--- a/receivers/email/config.go
+++ b/receivers/email/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Subject     string
 }
 
-func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (Config, error) {
 	type emailSettingsRaw struct {
 		SingleEmail bool   `json:"singleEmail,omitempty"`
 		Addresses   string `json:"addresses,omitempty"`
@@ -27,10 +27,10 @@ func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	var settings emailSettingsRaw
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 	if settings.Addresses == "" {
-		return nil, errors.New("could not find addresses in settings")
+		return Config{}, errors.New("could not find addresses in settings")
 	}
 	// split addresses with a few different ways
 	addresses := splitEmails(settings.Addresses)
@@ -39,7 +39,7 @@ func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 		settings.Subject = templates.DefaultMessageTitleEmbed
 	}
 
-	return &Config{
+	return Config{
 		SingleEmail: settings.SingleEmail,
 		Message:     settings.Message,
 		Subject:     settings.Subject,

--- a/receivers/email/config.go
+++ b/receivers/email/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Subject     string
 }
 
-func ValidateConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage) (Config, error) {
 	type emailSettingsRaw struct {
 		SingleEmail bool   `json:"singleEmail,omitempty"`
 		Addresses   string `json:"addresses,omitempty"`

--- a/receivers/email/config.go
+++ b/receivers/email/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -17,7 +16,7 @@ type Config struct {
 	Subject     string
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	type emailSettingsRaw struct {
 		SingleEmail bool   `json:"singleEmail,omitempty"`
 		Addresses   string `json:"addresses,omitempty"`
@@ -26,7 +25,7 @@ func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
 	}
 
 	var settings emailSettingsRaw
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -92,7 +92,7 @@ func TestValidateConfig(t *testing.T) {
 				require.ErrorContains(t, err, c.expectedInitError)
 				return
 			}
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -88,13 +86,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings: json.RawMessage(c.settings),
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -86,7 +86,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -24,7 +24,7 @@ type Notifier struct {
 	ns       receivers.EmailSender
 	images   images.ImageStore
 	tmpl     *template.Template
-	settings *Config
+	settings Config
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -28,7 +28,7 @@ type Notifier struct {
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings)
+	settings, err := NewConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -28,7 +28,7 @@ type Notifier struct {
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/email/email_test.go
+++ b/receivers/email/email_test.go
@@ -46,7 +46,7 @@ func TestNotify(t *testing.T) {
 			log:      &logging.FakeLogger{},
 			ns:       emailSender,
 			tmpl:     tmpl,
-			settings: &settings,
+			settings: settings,
 			images:   &images.UnavailableImageStore{},
 		}
 

--- a/receivers/factory.go
+++ b/receivers/factory.go
@@ -15,6 +15,8 @@ import (
 // the given key. If the key is not present, then it returns the fallback value.
 type GetDecryptedValueFn func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string
 
+type DecryptFunc func(key string, fallback string) string
+
 type NotificationSender interface {
 	WebhookSender
 	EmailSender
@@ -40,6 +42,10 @@ type FactoryConfig struct {
 	// Used to retrieve image URLs for messages, or data for uploads.
 	Template *template.Template
 	Logger   logging.Logger
+}
+
+func (fc *FactoryConfig) Decrypt(key, fallback string) string {
+	return fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, key, fallback)
 }
 
 func NewFactoryConfig(config *NotificationChannelConfig, notificationService NotificationSender,

--- a/receivers/googlechat/config.go
+++ b/receivers/googlechat/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -15,9 +14,9 @@ type Config struct {
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	var settings Config
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}

--- a/receivers/googlechat/config.go
+++ b/receivers/googlechat/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/googlechat/config.go
+++ b/receivers/googlechat/config.go
@@ -14,15 +14,15 @@ type Config struct {
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
 	if settings.URL == "" {
-		return nil, errors.New("could not find url property in settings")
+		return Config{}, errors.New("could not find url property in settings")
 	}
 	if settings.Title == "" {
 		settings.Title = templates.DefaultMessageTitleEmbed
@@ -30,5 +30,5 @@ func ValidateConfig(jsonData json.RawMessage) (*Config, error) {
 	if settings.Message == "" {
 		settings.Message = templates.DefaultMessageEmbed
 	}
-	return &settings, nil
+	return settings, nil
 }

--- a/receivers/googlechat/config_test.go
+++ b/receivers/googlechat/config_test.go
@@ -68,7 +68,7 @@ func TestValidateConfig(t *testing.T) {
 				require.ErrorContains(t, err, c.expectedInitError)
 				return
 			}
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/googlechat/config_test.go
+++ b/receivers/googlechat/config_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -64,13 +62,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings: json.RawMessage(c.settings),
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/googlechat/config_test.go
+++ b/receivers/googlechat/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -62,7 +62,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/googlechat/googlechat.go
+++ b/receivers/googlechat/googlechat.go
@@ -24,7 +24,7 @@ type Notifier struct {
 	ns         receivers.WebhookSender
 	images     images.ImageStore
 	tmpl       *template.Template
-	settings   *Config
+	settings   Config
 	appVersion string
 }
 

--- a/receivers/googlechat/googlechat.go
+++ b/receivers/googlechat/googlechat.go
@@ -34,7 +34,7 @@ var (
 )
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings)
+	settings, err := NewConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/googlechat/googlechat.go
+++ b/receivers/googlechat/googlechat.go
@@ -34,7 +34,7 @@ var (
 )
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/googlechat/googlechat_test.go
+++ b/receivers/googlechat/googlechat_test.go
@@ -507,7 +507,7 @@ func TestNotify(t *testing.T) {
 				log:        &logging.FakeLogger{},
 				ns:         webhookSender,
 				tmpl:       tmpl,
-				settings:   &c.settings,
+				settings:   c.settings,
 				images:     imageStore,
 				appVersion: appVersion,
 			}

--- a/receivers/kafka/config.go
+++ b/receivers/kafka/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	KafkaClusterID string `json:"kafkaClusterId,omitempty" yaml:"kafkaClusterId,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/kafka/config.go
+++ b/receivers/kafka/config.go
@@ -30,20 +30,20 @@ type Config struct {
 	KafkaClusterID string `json:"kafkaClusterId,omitempty" yaml:"kafkaClusterId,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
 	if settings.Endpoint == "" {
-		return nil, errors.New("could not find kafka rest proxy endpoint property in settings")
+		return Config{}, errors.New("could not find kafka rest proxy endpoint property in settings")
 	}
 	settings.Endpoint = strings.TrimRight(settings.Endpoint, "/")
 
 	if settings.Topic == "" {
-		return nil, errors.New("could not find kafka topic property in settings")
+		return Config{}, errors.New("could not find kafka topic property in settings")
 	}
 	if settings.Description == "" {
 		settings.Description = templates.DefaultMessageTitleEmbed
@@ -57,10 +57,10 @@ func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (
 		settings.APIVersion = apiVersionV2
 	} else if settings.APIVersion == apiVersionV3 {
 		if settings.KafkaClusterID == "" {
-			return nil, errors.New("kafka cluster id must be provided when using api version 3")
+			return Config{}, errors.New("kafka cluster id must be provided when using api version 3")
 		}
 	} else if settings.APIVersion != apiVersionV2 && settings.APIVersion != apiVersionV3 {
-		return nil, fmt.Errorf("unsupported api version: %s", settings.APIVersion)
+		return Config{}, fmt.Errorf("unsupported api version: %s", settings.APIVersion)
 	}
-	return &settings, nil
+	return settings, nil
 }

--- a/receivers/kafka/config.go
+++ b/receivers/kafka/config.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,9 +30,9 @@ type Config struct {
 	KafkaClusterID string `json:"kafkaClusterId,omitempty" yaml:"kafkaClusterId,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
 	var settings Config
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
@@ -52,7 +51,7 @@ func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
 	if settings.Details == "" {
 		settings.Details = templates.DefaultMessageEmbed
 	}
-	settings.Password = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "password", settings.Password)
+	settings.Password = decryptFn("password", settings.Password)
 
 	if settings.APIVersion == "" {
 		settings.APIVersion = apiVersionV2

--- a/receivers/kafka/config_test.go
+++ b/receivers/kafka/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -172,7 +172,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/kafka/config_test.go
+++ b/receivers/kafka/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -173,14 +172,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/kafka/config_test.go
+++ b/receivers/kafka/config_test.go
@@ -179,7 +179,7 @@ func TestValidateConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/kafka/kafka.go
+++ b/receivers/kafka/kafka.go
@@ -57,7 +57,7 @@ type Notifier struct {
 
 // New is the constructor function for the Kafka notifier.
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/kafka/kafka.go
+++ b/receivers/kafka/kafka.go
@@ -57,7 +57,7 @@ type Notifier struct {
 
 // New is the constructor function for the Kafka notifier.
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/kafka/kafka.go
+++ b/receivers/kafka/kafka.go
@@ -52,7 +52,7 @@ type Notifier struct {
 	images   images.ImageStore
 	ns       receivers.WebhookSender
 	tmpl     *template.Template
-	settings *Config
+	settings Config
 }
 
 // New is the constructor function for the Kafka notifier.

--- a/receivers/kafka/kafka_test.go
+++ b/receivers/kafka/kafka_test.go
@@ -386,7 +386,7 @@ func TestNotify(t *testing.T) {
 				log:      &logging.FakeLogger{},
 				ns:       webhookSender,
 				tmpl:     tmpl,
-				settings: &c.settings,
+				settings: c.settings,
 				images:   images,
 			}
 

--- a/receivers/line/config.go
+++ b/receivers/line/config.go
@@ -1,7 +1,6 @@
 package line
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,13 +15,13 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
 	var settings Config
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.Token = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "token", settings.Token)
+	settings.Token = decryptFn("token", settings.Token)
 	if settings.Token == "" {
 		return nil, errors.New("could not find token in settings")
 	}

--- a/receivers/line/config.go
+++ b/receivers/line/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/line/config.go
+++ b/receivers/line/config.go
@@ -15,15 +15,15 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 	settings.Token = decryptFn("token", settings.Token)
 	if settings.Token == "" {
-		return nil, errors.New("could not find token in settings")
+		return Config{}, errors.New("could not find token in settings")
 	}
 	if settings.Title == "" {
 		settings.Title = templates.DefaultMessageTitleEmbed
@@ -31,5 +31,5 @@ func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (
 	if settings.Description == "" {
 		settings.Description = templates.DefaultMessageEmbed
 	}
-	return &settings, nil
+	return settings, nil
 }

--- a/receivers/line/config_test.go
+++ b/receivers/line/config_test.go
@@ -98,7 +98,7 @@ func TestValidateConfig(t *testing.T) {
 				require.ErrorContains(t, err, c.expectedInitError)
 				return
 			}
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/line/config_test.go
+++ b/receivers/line/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -92,7 +92,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/line/config_test.go
+++ b/receivers/line/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -93,14 +92,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -31,7 +31,7 @@ type Notifier struct {
 
 // New is the constructor for the LINE notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -26,7 +26,7 @@ type Notifier struct {
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	tmpl     *template.Template
-	settings *Config
+	settings Config
 }
 
 // New is the constructor for the LINE notifier

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -31,7 +31,7 @@ type Notifier struct {
 
 // New is the constructor for the LINE notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/line/line_test.go
+++ b/receivers/line/line_test.go
@@ -116,7 +116,7 @@ func TestNotify(t *testing.T) {
 				log:      &logging.FakeLogger{},
 				ns:       webhookSender,
 				tmpl:     tmpl,
-				settings: &c.settings,
+				settings: c.settings,
 			}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")

--- a/receivers/opsgenie/config.go
+++ b/receivers/opsgenie/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	SendTagsAs       string
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	type rawSettings struct {
 		APIKey           string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
 		APIUrl           string `json:"apiUrl,omitempty" yaml:"apiUrl,omitempty"`

--- a/receivers/opsgenie/config.go
+++ b/receivers/opsgenie/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	SendTagsAs       string
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	type rawSettings struct {
 		APIKey           string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
 		APIUrl           string `json:"apiUrl,omitempty" yaml:"apiUrl,omitempty"`
@@ -42,12 +42,12 @@ func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (
 	raw := rawSettings{}
 	err := json.Unmarshal(jsonData, &raw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
 	raw.APIKey = decryptFn("apiKey", raw.APIKey)
 	if raw.APIKey == "" {
-		return nil, errors.New("could not find api key property in settings")
+		return Config{}, errors.New("could not find api key property in settings")
 	}
 	if raw.APIUrl == "" {
 		raw.APIUrl = DefaultAlertsURL
@@ -62,7 +62,7 @@ func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (
 	case "":
 		raw.SendTagsAs = SendTags
 	default:
-		return nil, fmt.Errorf("invalid value for sendTagsAs: %q", raw.SendTagsAs)
+		return Config{}, fmt.Errorf("invalid value for sendTagsAs: %q", raw.SendTagsAs)
 	}
 
 	if raw.AutoClose == nil {
@@ -74,7 +74,7 @@ func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (
 		raw.OverridePriority = &overridePriority
 	}
 
-	return &Config{
+	return Config{
 		APIKey:           raw.APIKey,
 		APIUrl:           raw.APIUrl,
 		Message:          raw.Message,

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -196,7 +196,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -203,7 +203,7 @@ func TestValidateConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -197,14 +196,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -40,7 +40,7 @@ type Notifier struct {
 
 // New is the constructor for the Opsgenie notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -35,7 +35,7 @@ type Notifier struct {
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	images   images.ImageStore
-	settings *Config
+	settings Config
 }
 
 // New is the constructor for the Opsgenie notifier

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -40,7 +40,7 @@ type Notifier struct {
 
 // New is the constructor for the Opsgenie notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/opsgenie/opsgenie_test.go
+++ b/receivers/opsgenie/opsgenie_test.go
@@ -289,7 +289,7 @@ func TestNotify(t *testing.T) {
 				log:      &logging.FakeLogger{},
 				ns:       webhookSender,
 				tmpl:     tmpl,
-				settings: &c.settings,
+				settings: c.settings,
 				images:   &images.UnavailableImageStore{},
 			}
 

--- a/receivers/pagerduty/config.go
+++ b/receivers/pagerduty/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	ClientURL     string            `json:"client_url,omitempty" yaml:"client_url,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/pagerduty/config_test.go
+++ b/receivers/pagerduty/config_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -213,21 +212,15 @@ func TestValidateConfig(t *testing.T) {
 					getHostname = provideHostName
 				})
 			}
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
 
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/pagerduty/config_test.go
+++ b/receivers/pagerduty/config_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	hostName := "Grafana-TEST-host"
 	provideHostName := func() (string, error) {
 		return hostName, nil
@@ -213,7 +213,7 @@ func TestValidateConfig(t *testing.T) {
 				})
 			}
 
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -41,12 +41,12 @@ type Notifier struct {
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	images   images.ImageStore
-	settings *Config
+	settings Config
 }
 
 // New is the constructor for the PagerDuty notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -46,7 +46,7 @@ type Notifier struct {
 
 // New is the constructor for the PagerDuty notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/pagerduty/pagerduty_test.go
+++ b/receivers/pagerduty/pagerduty_test.go
@@ -333,7 +333,7 @@ func TestNotify(t *testing.T) {
 				log:      &logging.FakeLogger{},
 				ns:       webhookSender,
 				tmpl:     tmpl,
-				settings: &c.settings,
+				settings: c.settings,
 			}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")

--- a/receivers/pushover/config.go
+++ b/receivers/pushover/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	Message          string
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	rawSettings := struct {
 		UserKey          string                   `json:"userKey,omitempty" yaml:"userKey,omitempty"`

--- a/receivers/pushover/config.go
+++ b/receivers/pushover/config.go
@@ -1,7 +1,6 @@
 package pushover
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,7 +24,7 @@ type Config struct {
 	Message          string
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	rawSettings := struct {
 		UserKey          string                   `json:"userKey,omitempty" yaml:"userKey,omitempty"`
@@ -42,16 +41,16 @@ func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
 		Message          string                   `json:"message,omitempty" yaml:"message,omitempty"`
 	}{}
 
-	err := json.Unmarshal(fc.Config.Settings, &rawSettings)
+	err := json.Unmarshal(jsonData, &rawSettings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	settings.UserKey = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "userKey", rawSettings.UserKey)
+	settings.UserKey = decryptFn("userKey", rawSettings.UserKey)
 	if settings.UserKey == "" {
 		return settings, errors.New("user key not found")
 	}
-	settings.APIToken = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "apiToken", rawSettings.APIToken)
+	settings.APIToken = decryptFn("apiToken", rawSettings.APIToken)
 	if settings.APIToken == "" {
 		return settings, errors.New("API token not found")
 	}

--- a/receivers/pushover/config_test.go
+++ b/receivers/pushover/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -340,14 +339,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/pushover/config_test.go
+++ b/receivers/pushover/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -339,7 +339,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -49,7 +49,7 @@ type Notifier struct {
 
 // New is the constructor for the pushover notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -49,7 +49,7 @@ type Notifier struct {
 
 // New is the constructor for the pushover notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/sensugo/config.go
+++ b/receivers/sensugo/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Message   string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/sensugo/config.go
+++ b/receivers/sensugo/config.go
@@ -1,7 +1,6 @@
 package sensugo
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,16 +19,16 @@ type Config struct {
 	Message   string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 	if settings.URL == "" {
 		return settings, errors.New("could not find URL property in settings")
 	}
-	settings.APIKey = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "apikey", settings.APIKey)
+	settings.APIKey = decryptFn("apikey", settings.APIKey)
 	if settings.APIKey == "" {
 		return settings, errors.New("could not find the API key property in settings")
 	}

--- a/receivers/sensugo/config_test.go
+++ b/receivers/sensugo/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -134,7 +134,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/sensugo/config_test.go
+++ b/receivers/sensugo/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -135,14 +134,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/sensugo/sensugo.go
+++ b/receivers/sensugo/sensugo.go
@@ -33,7 +33,7 @@ type Notifier struct {
 
 // New is the constructor for the SensuGo notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/sensugo/sensugo.go
+++ b/receivers/sensugo/sensugo.go
@@ -33,7 +33,7 @@ type Notifier struct {
 
 // New is the constructor for the SensuGo notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/slack/config.go
+++ b/receivers/slack/config.go
@@ -1,7 +1,6 @@
 package slack
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,10 +26,9 @@ type Config struct {
 	MentionGroups  receivers.CommaSeparatedStrings `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
 }
 
-func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
-	decryptFunc := factoryConfig.DecryptFunc
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
-	err := json.Unmarshal(factoryConfig.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
@@ -38,7 +36,7 @@ func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
 	if settings.EndpointURL == "" {
 		settings.EndpointURL = APIURL
 	}
-	slackURL := decryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "url", settings.URL)
+	slackURL := decryptFn("url", settings.URL)
 	if slackURL == "" {
 		slackURL = settings.EndpointURL
 	}
@@ -56,7 +54,7 @@ func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
 	if settings.MentionChannel != "" && settings.MentionChannel != "here" && settings.MentionChannel != "channel" {
 		return Config{}, fmt.Errorf("invalid value for mentionChannel: %q", settings.MentionChannel)
 	}
-	settings.Token = decryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "token", settings.Token)
+	settings.Token = decryptFn("token", settings.Token)
 	if settings.Token == "" && settings.URL == APIURL {
 		return Config{}, errors.New("token must be specified when using the Slack chat API")
 	}

--- a/receivers/slack/config.go
+++ b/receivers/slack/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	MentionGroups  receivers.CommaSeparatedStrings `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -256,14 +255,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -255,7 +255,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -91,7 +91,7 @@ func uploadURL(s Config) (string, error) {
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig)
+	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -91,7 +91,7 @@ func uploadURL(s Config) (string, error) {
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
+	settings, err := NewConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/teams/config.go
+++ b/receivers/teams/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	SectionTitle string `json:"sectiontitle,omitempty" yaml:"sectiontitle,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/teams/config.go
+++ b/receivers/teams/config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -17,9 +16,9 @@ type Config struct {
 	SectionTitle string `json:"sectiontitle,omitempty" yaml:"sectiontitle,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (Config, error) {
 	settings := Config{}
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}

--- a/receivers/teams/config_test.go
+++ b/receivers/teams/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -70,7 +70,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/teams/config_test.go
+++ b/receivers/teams/config_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -72,13 +70,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings: json.RawMessage(c.settings),
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -235,7 +235,7 @@ type Notifier struct {
 
 // New is the constructor for Teams notifier.
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings)
+	settings, err := NewConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -235,7 +235,7 @@ type Notifier struct {
 
 // New is the constructor for Teams notifier.
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	DisableNotifications bool   `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -1,7 +1,6 @@
 package telegram
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,13 +24,13 @@ type Config struct {
 	DisableNotifications bool   `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.BotToken = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "bottoken", settings.BotToken)
+	settings.BotToken = decryptFn("bottoken", settings.BotToken)
 	if settings.BotToken == "" {
 		return settings, errors.New("could not find Bot Token in settings")
 	}

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -168,7 +168,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -169,14 +168,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -39,7 +39,7 @@ type Notifier struct {
 
 // New is the constructor for the Telegram notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -39,7 +39,7 @@ type Notifier struct {
 
 // New is the constructor for the Telegram notifier
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/testing/testing.go
+++ b/receivers/testing/testing.go
@@ -34,3 +34,13 @@ func DecryptForTesting(_ context.Context, sjd map[string][]byte, key string, fal
 	}
 	return string(v)
 }
+
+func GetDecryptForTesting(sjd map[string][]byte) receivers.DecryptFunc {
+	return func(key string, fallback string) string {
+		v, ok := sjd[key]
+		if !ok {
+			return fallback
+		}
+		return string(v)
+	}
+}

--- a/receivers/testing/testing.go
+++ b/receivers/testing/testing.go
@@ -1,23 +1,10 @@
 package testing
 
 import (
-	"context"
 	"net/url"
-	"testing"
 
-	"github.com/grafana/alerting/images"
-	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	"github.com/grafana/alerting/templates"
 )
-
-func NewFactoryConfigForValidateConfigTesting(t *testing.T, m *receivers.NotificationChannelConfig) (receivers.FactoryConfig, error) {
-	tmpl := templates.ForTests(t)
-	tmpl.ExternalURL = ParseURLUnsafe("http://localhost")
-	return receivers.NewFactoryConfig(m, nil, DecryptForTesting, tmpl, &images.UnavailableImageStore{}, func(ctx ...interface{}) logging.Logger {
-		return &logging.FakeLogger{}
-	}, "1.2.3")
-}
 
 func ParseURLUnsafe(s string) *url.URL {
 	u, err := url.Parse(s)
@@ -27,15 +14,7 @@ func ParseURLUnsafe(s string) *url.URL {
 	return u
 }
 
-func DecryptForTesting(_ context.Context, sjd map[string][]byte, key string, fallback string) string {
-	v, ok := sjd[key]
-	if !ok {
-		return fallback
-	}
-	return string(v)
-}
-
-func GetDecryptForTesting(sjd map[string][]byte) receivers.DecryptFunc {
+func DecryptForTesting(sjd map[string][]byte) receivers.DecryptFunc {
 	return func(key string, fallback string) string {
 		v, ok := sjd[key]
 		if !ok {

--- a/receivers/threema/config.go
+++ b/receivers/threema/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/threema/config.go
+++ b/receivers/threema/config.go
@@ -1,7 +1,6 @@
 package threema
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,9 +18,9 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
@@ -43,7 +42,7 @@ func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
 	if len(settings.RecipientID) != 8 {
 		return settings, errors.New("invalid Threema Recipient ID: Must be 8 characters long")
 	}
-	settings.APISecret = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "api_secret", settings.APISecret)
+	settings.APISecret = decryptFn("api_secret", settings.APISecret)
 	if settings.APISecret == "" {
 		return settings, errors.New("could not find Threema API secret in settings")
 	}

--- a/receivers/threema/config_test.go
+++ b/receivers/threema/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -167,14 +166,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/threema/config_test.go
+++ b/receivers/threema/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	var cases = []struct {
 		name              string
 		settings          string
@@ -166,7 +166,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -33,7 +33,7 @@ type Notifier struct {
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -33,7 +33,7 @@ type Notifier struct {
 }
 
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings, fc.Decrypt)
+	settings, err := NewConfig(fc.Config.Settings, fc.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/victorops/config.go
+++ b/receivers/victorops/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -21,9 +20,9 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(fc receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage) (Config, error) {
 	settings := Config{}
-	err := json.Unmarshal(fc.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}

--- a/receivers/victorops/config.go
+++ b/receivers/victorops/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/victorops/config_test.go
+++ b/receivers/victorops/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -70,7 +70,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/victorops/config_test.go
+++ b/receivers/victorops/config_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -72,13 +70,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings: json.RawMessage(c.settings),
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/victorops/victorops.go
+++ b/receivers/victorops/victorops.go
@@ -41,7 +41,7 @@ type Notifier struct {
 // New creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc.Config.Settings)
+	settings, err := NewConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/victorops/victorops.go
+++ b/receivers/victorops/victorops.go
@@ -41,7 +41,7 @@ type Notifier struct {
 // New creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
 func New(fc receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(fc)
+	settings, err := ValidateConfig(fc.Config.Settings)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/webex/config.go
+++ b/receivers/webex/config.go
@@ -23,8 +23,8 @@ type Config struct {
 	Token   string `json:"bot_token" yaml:"bot_token"`
 }
 
-// ValidateConfig is the constructor for the Webex notifier.
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+// NewConfig is the constructor for the Webex notifier.
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/webex/config.go
+++ b/receivers/webex/config.go
@@ -1,7 +1,6 @@
 package webex
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -25,9 +24,9 @@ type Config struct {
 }
 
 // ValidateConfig is the constructor for the Webex notifier.
-func ValidateConfig(factoryConfig receivers.FactoryConfig) (*Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
 	settings := &Config{}
-	err := json.Unmarshal(factoryConfig.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
@@ -40,7 +39,7 @@ func ValidateConfig(factoryConfig receivers.FactoryConfig) (*Config, error) {
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
-	settings.Token = factoryConfig.DecryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "bot_token", settings.Token)
+	settings.Token = decryptFn("bot_token", settings.Token)
 
 	u, err := url.Parse(settings.APIURL)
 	if err != nil {

--- a/receivers/webex/config.go
+++ b/receivers/webex/config.go
@@ -24,11 +24,11 @@ type Config struct {
 }
 
 // ValidateConfig is the constructor for the Webex notifier.
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (*Config, error) {
-	settings := &Config{}
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
 	if settings.APIURL == "" {
@@ -43,7 +43,7 @@ func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (
 
 	u, err := url.Parse(settings.APIURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL %q", settings.APIURL)
+		return Config{}, fmt.Errorf("invalid URL %q", settings.APIURL)
 	}
 	settings.APIURL = u.String()
 

--- a/receivers/webex/config_test.go
+++ b/receivers/webex/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -99,14 +98,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/webex/config_test.go
+++ b/receivers/webex/config_test.go
@@ -105,7 +105,7 @@ func TestValidateConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, c.expectedConfig, *actual)
+			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
 }

--- a/receivers/webex/config_test.go
+++ b/receivers/webex/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -98,7 +98,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/webex/webex.go
+++ b/receivers/webex/webex.go
@@ -27,7 +27,7 @@ type Notifier struct {
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
+	settings, err := NewConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/webex/webex.go
+++ b/receivers/webex/webex.go
@@ -23,7 +23,7 @@ type Notifier struct {
 	images   images.ImageStore
 	tmpl     *template.Template
 	orgID    int64
-	settings *Config
+	settings Config
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {

--- a/receivers/webex/webex.go
+++ b/receivers/webex/webex.go
@@ -27,7 +27,7 @@ type Notifier struct {
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig)
+	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/webex/webex_test.go
+++ b/receivers/webex/webex_test.go
@@ -117,7 +117,7 @@ func TestNotify(t *testing.T) {
 				log:      &logging.FakeLogger{},
 				ns:       notificationService,
 				tmpl:     tmpl,
-				settings: &c.settings,
+				settings: c.settings,
 				images:   images,
 			}
 

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	Message string
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	rawSettings := struct {
 		URL                      string                   `json:"url,omitempty" yaml:"url,omitempty"`

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -246,7 +246,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secretSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secretSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -247,14 +246,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secretSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secretSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -31,7 +31,7 @@ type Notifier struct {
 // New is the constructor for
 // the WebHook notifier.
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
+	settings, err := NewConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -31,7 +31,7 @@ type Notifier struct {
 // New is the constructor for
 // the WebHook notifier.
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig)
+	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/wecom/config.go
+++ b/receivers/wecom/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	ToUser      string  `json:"touser,omitempty" yaml:"touser,omitempty"`
 }
 
-func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings = Config{
 		Channel: DefaultChannelType,
 	}

--- a/receivers/wecom/config.go
+++ b/receivers/wecom/config.go
@@ -1,7 +1,6 @@
 package wecom
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,12 +38,12 @@ type Config struct {
 	ToUser      string  `json:"touser,omitempty" yaml:"touser,omitempty"`
 }
 
-func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
+func ValidateConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings = Config{
 		Channel: DefaultChannelType,
 	}
 
-	err := json.Unmarshal(factoryConfig.Config.Settings, &settings)
+	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
@@ -67,8 +66,8 @@ func ValidateConfig(factoryConfig receivers.FactoryConfig) (Config, error) {
 		settings.ToUser = DefaultToUser
 	}
 
-	settings.URL = factoryConfig.DecryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "url", settings.URL)
-	settings.Secret = factoryConfig.DecryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "secret", settings.Secret)
+	settings.URL = decryptFn("url", settings.URL)
+	settings.Secret = decryptFn("secret", settings.Secret)
 
 	if len(settings.URL) == 0 && len(settings.Secret) == 0 {
 		return settings, errors.New("either url or secret is required")

--- a/receivers/wecom/config_test.go
+++ b/receivers/wecom/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -216,14 +215,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			m := &receivers.NotificationChannelConfig{
-				Settings:       json.RawMessage(c.settings),
-				SecureSettings: c.secureSettings,
-			}
-			fc, err := receiversTesting.NewFactoryConfigForValidateConfigTesting(t, m)
-			require.NoError(t, err)
-
-			actual, err := ValidateConfig(fc)
+			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/wecom/config_test.go
+++ b/receivers/wecom/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cases := []struct {
 		name              string
 		settings          string
@@ -215,7 +215,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := ValidateConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secureSettings))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/wecom/wecom.go
+++ b/receivers/wecom/wecom.go
@@ -29,7 +29,7 @@ type Notifier struct {
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
+	settings, err := NewConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/wecom/wecom.go
+++ b/receivers/wecom/wecom.go
@@ -29,7 +29,7 @@ type Notifier struct {
 }
 
 func New(factoryConfig receivers.FactoryConfig) (*Notifier, error) {
-	settings, err := ValidateConfig(factoryConfig)
+	settings, err := ValidateConfig(factoryConfig.Config.Settings, factoryConfig.Decrypt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, every ValidateConfig accepts entire `receivers.FactoryConfig` and takes only 3 fields at best: raw settings, secure settings map, and decrypt function. 
This PR refactors those functions to accept only two parameters (sometimes one):
- raw settings
- a decrypt function `func(key string, fallback string) string` as you can see it does not accept the secure settings (and context). The reason is to hide the way secure settings are stored. 

Also, currently, some functions return `Config` struct and some pointer `*Config`. This PR refactors those that return pointer to return struct.

No public API of this package are changed.