### PR TITLE
Metrics: Receivers and Integrations

### DIFF
--- a/notify/grafana_alertmanager_metrics.go
+++ b/notify/grafana_alertmanager_metrics.go
@@ -3,11 +3,19 @@ package notify
 import (
 	"github.com/prometheus/alertmanager/api/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+const namesapce = "grafana"
+const subsystem = "alerting"
+const ActiveStateLabelValue = "active"
+const InactiveStateLabelValue = "inactive"
 
 type GrafanaAlertmanagerMetrics struct {
 	Registerer prometheus.Registerer
 	*metrics.Alerts
+	configuredReceivers    *prometheus.GaugeVec
+	configuredIntegrations *prometheus.GaugeVec
 }
 
 // NewGrafanaAlertmanagerMetrics creates a set of metrics for the Alertmanager.
@@ -15,5 +23,17 @@ func NewGrafanaAlertmanagerMetrics(r prometheus.Registerer) *GrafanaAlertmanager
 	return &GrafanaAlertmanagerMetrics{
 		Registerer: r,
 		Alerts:     metrics.NewAlerts("grafana", r),
+		configuredReceivers: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namesapce,
+			Subsystem: subsystem,
+			Name:      "alertmanager_receivers",
+			Help:      "Number of configured receivers by state. It is considered active if used within a route.",
+		}, []string{"org", "state"}),
+		configuredIntegrations: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namesapce,
+			Subsystem: subsystem,
+			Name:      "alertmanager_integrations",
+			Help:      "Number of configured receivers.",
+		}, []string{"org", "type"}),
 	}
 }

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -313,16 +313,6 @@ func TestPutAlert(t *testing.T) {
 	}
 }
 
-type fakeNotifier struct{}
-
-func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (bool, error) {
-	return true, nil
-}
-
-func (f *fakeNotifier) SendResolved() bool {
-	return true
-}
-
 func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
 	fn := &fakeNotifier{}
 	integrations := []*notify.Integration{
@@ -411,46 +401,4 @@ func TestSilenceCleanup(t *testing.T) {
 		require.NoError(t, err)
 		return len(found) == 2
 	}, 6*time.Second, 150*time.Millisecond)
-}
-
-type FakeConfig struct {
-}
-
-func (f *FakeConfig) DispatcherLimits() DispatcherLimits {
-	panic("implement me")
-}
-
-func (f *FakeConfig) InhibitRules() []*InhibitRule {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (f *FakeConfig) MuteTimeIntervals() []MuteTimeInterval {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (f *FakeConfig) ReceiverIntegrations() (map[string][]Integration, error) {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (f *FakeConfig) RoutingTree() *Route {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (f *FakeConfig) Templates() *Template {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (f *FakeConfig) Hash() [16]byte {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (f *FakeConfig) Raw() []byte {
-	// TODO implement me
-	panic("implement me")
 }

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sort"
@@ -11,15 +12,18 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/provider/mem"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
-func setupAMTest(t *testing.T) *GrafanaAlertmanager {
-	m := NewGrafanaAlertmanagerMetrics(prometheus.NewPedanticRegistry())
+func setupAMTest(t *testing.T) (*GrafanaAlertmanager, *prometheus.Registry) {
+	reg := prometheus.NewPedanticRegistry()
+	m := NewGrafanaAlertmanagerMetrics(reg)
 
 	grafanaConfig := &GrafanaAlertmanagerConfig{
 		Silences: newFakeMaintanenceOptions(t),
@@ -28,11 +32,11 @@ func setupAMTest(t *testing.T) *GrafanaAlertmanager {
 
 	am, err := NewGrafanaAlertmanager("org", 1, grafanaConfig, &NilPeer{}, log.NewNopLogger(), m)
 	require.NoError(t, err)
-	return am
+	return am, reg
 }
 
 func TestPutAlert(t *testing.T) {
-	am := setupAMTest(t)
+	am, _ := setupAMTest(t)
 
 	startTime := time.Now()
 	endTime := startTime.Add(2 * time.Hour)
@@ -309,12 +313,52 @@ func TestPutAlert(t *testing.T) {
 	}
 }
 
+type fakeNotifier struct{}
+
+func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeNotifier) SendResolved() bool {
+	return true
+}
+
+func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
+	fn := &fakeNotifier{}
+	integrations := []*notify.Integration{
+		notify.NewIntegration(fn, fn, "grafana-oncall", 0),
+		notify.NewIntegration(fn, fn, "sns", 1),
+	}
+
+	am, reg := setupAMTest(t)
+
+	receivers := []*notify.Receiver{
+		notify.NewReceiver("ActiveNoIntegrations", true, nil),
+		notify.NewReceiver("InactiveNoIntegrations", false, nil),
+		notify.NewReceiver("ActiveMultipleIntegrations", true, integrations),
+		notify.NewReceiver("InactiveMultipleIntegrations", false, integrations),
+	}
+
+	am.setReceiverMetrics(receivers, 2)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+        	            	# HELP grafana_alerting_alertmanager_integrations Number of configured receivers.
+        	            	# TYPE grafana_alerting_alertmanager_integrations gauge
+        	            	grafana_alerting_alertmanager_integrations{org="1",type="grafana-oncall"} 2
+        	            	grafana_alerting_alertmanager_integrations{org="1",type="sns"} 2
+        	            	# HELP grafana_alerting_alertmanager_receivers Number of configured receivers by state. It is considered active if used within a route.
+        	            	# TYPE grafana_alerting_alertmanager_receivers gauge
+        	            	grafana_alerting_alertmanager_receivers{org="1",state="active"} 2
+        	            	grafana_alerting_alertmanager_receivers{org="1",state="inactive"} 2
+`), "grafana_alerting_alertmanager_receivers", "grafana_alerting_alertmanager_integrations"))
+}
+
 // Tests cleanup of expired Silences. We rely on prometheus/alertmanager for
 // our alert silencing functionality, so we rely on its tests. However, we
 // implement a custom maintenance function for silences, because we snapshot
 // our data differently, so we test that functionality.
 func TestSilenceCleanup(t *testing.T) {
-	am := setupAMTest(t)
+	am, _ := setupAMTest(t)
 	now := time.Now()
 	dt := func(t time.Time) strfmt.DateTime { return strfmt.DateTime(t) }
 

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -1,8 +1,11 @@
 package notify
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/prometheus/alertmanager/types"
 )
 
 func newFakeMaintanenceOptions(t *testing.T) *fakeMaintenanceOptions {
@@ -28,4 +31,56 @@ func (f *fakeMaintenanceOptions) MaintenanceFrequency() time.Duration {
 
 func (f *fakeMaintenanceOptions) MaintenanceFunc(_ State) (int64, error) {
 	return 0, nil
+}
+
+type FakeConfig struct {
+}
+
+func (f *FakeConfig) DispatcherLimits() DispatcherLimits {
+	panic("implement me")
+}
+
+func (f *FakeConfig) InhibitRules() []*InhibitRule {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *FakeConfig) MuteTimeIntervals() []MuteTimeInterval {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *FakeConfig) ReceiverIntegrations() (map[string][]Integration, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *FakeConfig) RoutingTree() *Route {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *FakeConfig) Templates() *Template {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *FakeConfig) Hash() [16]byte {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *FakeConfig) Raw() []byte {
+	// TODO implement me
+	panic("implement me")
+}
+
+type fakeNotifier struct{}
+
+func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeNotifier) SendResolved() bool {
+	return true
 }


### PR DESCRIPTION
Introduce a set of metrics to observe the integrations and recivers of an instance.

For the sake of keeping cardinality as low as possible receviers are group into two categories: active or inactive However, for integrations I think it's useful to know how many we have of each type. I'd like to further know if an integration is active or not but decided not to do that know and roll with the current set in the meantime.

- [x] tests