### PR TITLE
Fix nflog maintenance file path

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -223,7 +223,7 @@ func NewGrafanaAlertmanager(tenantKey string, tenantID int64, config *GrafanaAle
 
 	am.wg.Add(1)
 	go func() {
-		am.notificationLog.Maintenance(config.Nflog.MaintenanceFrequency(), config.Silences.Filepath(), am.stopc, func() (int64, error) {
+		am.notificationLog.Maintenance(config.Nflog.MaintenanceFrequency(), config.Nflog.Filepath(), am.stopc, func() (int64, error) {
 			if _, err := am.notificationLog.GC(); err != nil {
 				level.Error(am.logger).Log("notification log garbage collection", "err", err)
 			}


### PR DESCRIPTION
Fixes an apparently-incorrect filepath passed to nflog `.Maintenance()`

Discovered as part of internal [thread](https://raintank-corp.slack.com/archives/C04SWEHGASZ/p1678301362777299?thread_ts=1678301002.752439&cid=C04SWEHGASZ).