### PR TITLE
Slack: assume any non-JSON response is an incoming webhook

### DIFF
--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -205,11 +205,11 @@ var sendSlackRequest = func(ctx context.Context, req *http.Request, logger loggi
 	}
 
 	content := resp.Header.Get("Content-Type")
-	// If the response is text/html it could be the response to an incoming webhook
-	if strings.HasPrefix(content, "text/html") {
-		return handleSlackIncomingWebhookResponse(resp, logger)
+	if strings.HasPrefix(content, "application/json") {
+		return handleSlackJSONResponse(resp, logger)
 	}
-	return handleSlackJSONResponse(resp, logger)
+	// If the response is not JSON it could be the response to an incoming webhook
+	return handleSlackIncomingWebhookResponse(resp, logger)
 }
 
 func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logger) (string, error) {

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -514,6 +514,7 @@ func TestSendSlackRequest(t *testing.T) {
 		name        string
 		response    string
 		statusCode  int
+		contentType string
 		expectError bool
 	}{
 		{
@@ -523,11 +524,13 @@ func TestSendSlackRequest(t *testing.T) {
 					"error": "too_many_attachments"
 				}`,
 			statusCode:  http.StatusBadRequest,
+			contentType: "application/json",
 			expectError: true,
 		},
 		{
 			name:        "Non 200 status code, no response body",
 			statusCode:  http.StatusMovedPermanently,
+			contentType: "",
 			expectError: true,
 		},
 		{
@@ -553,29 +556,34 @@ func TestSendSlackRequest(t *testing.T) {
 				}
 			}`,
 			statusCode:  http.StatusOK,
+			contentType: "application/json",
 			expectError: false,
 		},
 		{
 			name:        "No response body",
 			statusCode:  http.StatusOK,
+			contentType: "application/json",
 			expectError: true,
 		},
 		{
 			name:        "Success case, unexpected response body",
 			statusCode:  http.StatusOK,
 			response:    `{"test": true}`,
+			contentType: "application/json",
 			expectError: true,
 		},
 		{
 			name:        "Success case, ok: true",
 			statusCode:  http.StatusOK,
 			response:    `{"ok": true}`,
+			contentType: "application/json",
 			expectError: false,
 		},
 		{
 			name:        "200 status code, error in body",
 			statusCode:  http.StatusOK,
 			response:    `{"ok": false, "error": "test error"}`,
+			contentType: "application/json",
 			expectError: true,
 		},
 	}
@@ -583,6 +591,9 @@ func TestSendSlackRequest(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if test.contentType != "" {
+					w.Header().Set("Content-Type", test.contentType)
+				}
 				w.WriteHeader(test.statusCode)
 				_, err := w.Write([]byte(test.response))
 				require.NoError(tt, err)

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -198,7 +198,7 @@ func TestNotify_IncomingWebhook(t *testing.T) {
 	}
 }
 
-func TestNotigy_PostMessage(t *testing.T) {
+func TestNotify_PostMessage(t *testing.T) {
 	tests := []struct {
 		name            string
 		alerts          []*types.Alert

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -560,9 +560,15 @@ func TestSendSlackRequest(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "No response body",
+			name:        "No JSON response body",
 			statusCode:  http.StatusOK,
 			contentType: "application/json",
+			expectError: true,
+		},
+		{
+			name:        "No HTML response body",
+			statusCode:  http.StatusOK,
+			contentType: "text/html",
 			expectError: true,
 		},
 		{
@@ -585,6 +591,20 @@ func TestSendSlackRequest(t *testing.T) {
 			response:    `{"ok": false, "error": "test error"}`,
 			contentType: "application/json",
 			expectError: true,
+		},
+		{
+			name:        "Success case, HTML ok",
+			statusCode:  http.StatusOK,
+			response:    "ok",
+			contentType: "text/html",
+			expectError: false,
+		},
+		{
+			name:        "Success case, text/plain ok",
+			statusCode:  http.StatusOK,
+			response:    "ok",
+			contentType: "text/plain",
+			expectError: false,
 		},
 	}
 


### PR DESCRIPTION
Slack returns these responses as `text/html` while Mattermost returns them as `text/plain` (see https://github.com/grafana/grafana/issues/64079#issuecomment-1469826393). To support both, we need to either add another clause to the if (`|| strings.HasPrefix(content, "text/plain")`), either reverse the current logic, as does this PR.

I also added tests on the `Content-Type` header as they were missing. This fixes https://github.com/grafana/grafana/issues/64079.