### PR TITLE
Alerting: Fix configuration of both incoming webhooks and bot tokens

### DIFF
--- a/receivers/slack/config.go
+++ b/receivers/slack/config.go
@@ -33,14 +33,20 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
+	// Here slackURL must be the URL of an incoming webhook
+	slackURL := decryptFn("url", settings.URL)
+	token := decryptFn("token", settings.Token)
+	// It is an error to have a token with an incoming webhook
+	if slackURL != "" && token != "" {
+		return Config{}, errors.New("must use either token or incoming webhooks")
+	}
+
 	if settings.EndpointURL == "" {
 		settings.EndpointURL = APIURL
 	}
-	slackURL := decryptFn("url", settings.URL)
 	if slackURL == "" {
 		slackURL = settings.EndpointURL
 	}
-
 	apiURL, err := url.Parse(slackURL)
 	if err != nil {
 		return Config{}, fmt.Errorf("invalid URL %q", slackURL)

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -131,16 +131,15 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			name:     "Should overwrite token from secrets",
-			settings: `{"url": "http://localhost", "token": "test" }`,
+			settings: `{ "recipient": "test-recipient", "token": "test" }`,
 			secureSettings: map[string][]byte{
-				"url":   []byte("http://slack.local/some-webhook"),
 				"token": []byte("test-token"),
 			},
 			expectedConfig: Config{
+				URL:            APIURL,
 				EndpointURL:    APIURL,
-				URL:            "http://slack.local/some-webhook",
 				Token:          "test-token",
-				Recipient:      "",
+				Recipient:      "test-recipient",
 				Text:           templates.DefaultMessageEmbed,
 				Title:          templates.DefaultMessageTitleEmbed,
 				Username:       "Grafana",
@@ -256,7 +255,7 @@ func TestNewConfig(t *testing.T) {
 			settings: FullValidConfigForTesting,
 			expectedConfig: Config{
 				EndpointURL:    "http://localhost/endpoint_url",
-				URL:            "http://localhost/url",
+				URL:            "http://localhost/endpoint_url",
 				Token:          "test-token",
 				Recipient:      "test-recipient",
 				Text:           "test-text",
@@ -275,7 +274,7 @@ func TestNewConfig(t *testing.T) {
 			secureSettings: receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
 			expectedConfig: Config{
 				EndpointURL:    "http://localhost/endpoint_url",
-				URL:            "http://localhost/url-secret",
+				URL:            "http://localhost/endpoint_url",
 				Token:          "test-secret-token",
 				Recipient:      "test-recipient",
 				Text:           "test-text",

--- a/receivers/slack/testing.go
+++ b/receivers/slack/testing.go
@@ -3,7 +3,6 @@ package slack
 // FullValidConfigForTesting is a string representation of a JSON object that contains all fields supported by the notifier Config. It can be used without secrets.
 const FullValidConfigForTesting = `{
 	"endpointUrl": "http://localhost/endpoint_url",
-	"url": "http://localhost/url",
 	"token": "test-token",
 	"recipient": "test-recipient",
 	"text": "test-text",
@@ -18,6 +17,5 @@ const FullValidConfigForTesting = `{
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
 const FullValidSecretsForTesting = `{
-	"url": "http://localhost/url-secret",
 	"token": "test-secret-token"
 }`


### PR DESCRIPTION
This commit fixes a bug in Slack where it was possible to configure both incoming webhooks and bot tokens at the same time. This is a bug as the intended behaviour is that users configure one or the other, but not both.

Fixes #68 

Support escalation: https://github.com/grafana/support-escalations/issues/5309