### PR TITLE
Use type alias for Template

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
@@ -29,13 +29,14 @@ import (
 	"github.com/grafana/alerting/receivers/webex"
 	"github.com/grafana/alerting/receivers/webhook"
 	"github.com/grafana/alerting/receivers/wecom"
+	"github.com/grafana/alerting/templates"
 )
 
 // BuildReceiverIntegrations creates integrations for each configured notification channel in GrafanaReceiverConfig.
 // It returns a slice of Integration objects, one for each notification channel, along with any errors that occurred.
 func BuildReceiverIntegrations(
 	receiver GrafanaReceiverConfig,
-	tmpl *template.Template,
+	tmpl *templates.Template,
 	img images.ImageStore,
 	logger logging.LoggerFactory,
 	newWebhookSender func(n receivers.Metadata) (receivers.WebhookSender, error),

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -23,8 +23,6 @@ import (
 	"github.com/prometheus/alertmanager/provider/mem"
 	"github.com/prometheus/alertmanager/silence"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
-	"github.com/prometheus/alertmanager/template"
-
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -316,7 +314,7 @@ func (am *GrafanaAlertmanager) WithLock(fn func()) {
 
 // TemplateFromPaths returns a set of *Templates based on the paths given.
 func (am *GrafanaAlertmanager) TemplateFromPaths(u string, paths ...string) (*templates.Template, error) {
-	tmpl, err := template.FromGlobs(paths)
+	tmpl, err := templates.FromGlobs(paths)
 	if err != nil {
 		return nil, err
 	}

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -123,9 +123,7 @@ type MaintenanceOptions interface {
 }
 
 var NewIntegration = notify.NewIntegration
-var FromGlobs = template.FromGlobs
 
-type Template = template.Template
 type InhibitRule = config.InhibitRule
 type MuteTimeInterval = config.MuteTimeInterval
 type TimeInterval = timeinterval.TimeInterval

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/alertmanager/types"
 
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
 )
 
 func newFakeMaintanenceOptions(t *testing.T) *fakeMaintenanceOptions {
@@ -62,7 +63,7 @@ func (f *FakeConfig) RoutingTree() *Route {
 	panic("implement me")
 }
 
-func (f *FakeConfig) Templates() *Template {
+func (f *FakeConfig) Templates() *templates.Template {
 	// TODO implement me
 	panic("implement me")
 }

--- a/receivers/dinding/dingding.go
+++ b/receivers/dinding/dingding.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/logging"
@@ -19,11 +18,11 @@ type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -13,14 +13,14 @@ import (
 	"strings"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // Constants and models are set according to the official documentation https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params
@@ -69,7 +69,7 @@ type Notifier struct {
 	log        logging.Logger
 	ns         receivers.WebhookSender
 	images     images.ImageStore
-	tmpl       *template.Template
+	tmpl       *templates.Template
 	settings   Config
 	appVersion string
 }
@@ -82,7 +82,7 @@ type discordAttachment struct {
 	state     model.AlertStatus
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,
@@ -104,7 +104,7 @@ func (d Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) 
 	}
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, d.tmpl, as, d.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, d.tmpl, as, d.log, &tmplErr)
 
 	msg.Content = tmpl(d.settings.Message)
 	if tmplErr != nil {

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -7,13 +7,12 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // Notifier is responsible for sending
@@ -23,11 +22,11 @@ type Notifier struct {
 	log      logging.Logger
 	ns       receivers.EmailSender
 	images   images.ImageStore
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.EmailSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.EmailSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -41,7 +40,7 @@ func New(cfg Config, meta receivers.Metadata, template *template.Template, sende
 // Notify sends the alert notification.
 func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
 	var tmplErr error
-	tmpl, data := template2.TmplText(ctx, en.tmpl, alerts, en.log, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, en.tmpl, alerts, en.log, &tmplErr)
 
 	subject := tmpl(en.settings.Subject)
 	alertPageURL := en.tmpl.ExternalURL.String()

--- a/receivers/email/email_test.go
+++ b/receivers/email/email_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -82,17 +81,17 @@ func TestNotify(t *testing.T) {
 				"Alerts": templates.ExtendedAlerts{
 					templates.ExtendedAlert{
 						Status:       "firing",
-						Labels:       template.KV{"alertname": "AlwaysFiring", "severity": "warning"},
-						Annotations:  template.KV{"runbook_url": "http://fix.me"},
+						Labels:       templates.KV{"alertname": "AlwaysFiring", "severity": "warning"},
+						Annotations:  templates.KV{"runbook_url": "http://fix.me"},
 						Fingerprint:  "15a37193dce72bab",
 						SilenceURL:   "http://localhost/base/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DAlwaysFiring&matcher=severity%3Dwarning",
 						DashboardURL: "http://localhost/base/d/abc",
 						PanelURL:     "http://localhost/base/d/abc?viewPanel=5",
 					},
 				},
-				"GroupLabels":       template.KV{},
-				"CommonLabels":      template.KV{"alertname": "AlwaysFiring", "severity": "warning"},
-				"CommonAnnotations": template.KV{"runbook_url": "http://fix.me"},
+				"GroupLabels":       templates.KV{},
+				"CommonLabels":      templates.KV{"alertname": "AlwaysFiring", "severity": "warning"},
+				"CommonAnnotations": templates.KV{"runbook_url": "http://fix.me"},
 				"ExternalURL":       "http://localhost/base",
 				"RuleUrl":           "http://localhost/base/alerting/list",
 				"AlertPageUrl":      "http://localhost/base/alerting/list?alertState=firing&view=state",

--- a/receivers/googlechat/googlechat.go
+++ b/receivers/googlechat/googlechat.go
@@ -7,13 +7,12 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // Notifier is responsible for sending
@@ -23,7 +22,7 @@ type Notifier struct {
 	log        logging.Logger
 	ns         receivers.WebhookSender
 	images     images.ImageStore
-	tmpl       *template.Template
+	tmpl       *templates.Template
 	settings   Config
 	appVersion string
 }
@@ -33,7 +32,7 @@ var (
 	timeNow = time.Now
 )
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,
@@ -50,7 +49,7 @@ func (gcn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, erro
 	gcn.log.Debug("executing Google Chat notification")
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, gcn.tmpl, as, gcn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, gcn.tmpl, as, gcn.log, &tmplErr)
 
 	var widgets []widget
 

--- a/receivers/kafka/kafka.go
+++ b/receivers/kafka/kafka.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 type kafkaBody struct {
@@ -51,11 +51,11 @@ type Notifier struct {
 	log      logging.Logger
 	images   images.ImageStore
 	ns       receivers.WebhookSender
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -77,7 +77,7 @@ func (kn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 // Use the v2 API to send the alert notification.
 func (kn *Notifier) notifyWithAPIV2(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, kn.tmpl, as, kn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, kn.tmpl, as, kn.log, &tmplErr)
 
 	topicURL := kn.settings.Endpoint + "/topics/" + tmpl(kn.settings.Topic)
 	if tmplErr != nil {
@@ -114,7 +114,7 @@ func (kn *Notifier) notifyWithAPIV2(ctx context.Context, as ...*types.Alert) (bo
 // Use the v3 API to send the alert notification.
 func (kn *Notifier) notifyWithAPIV3(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, kn.tmpl, as, kn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, kn.tmpl, as, kn.log, &tmplErr)
 
 	// For v3 the Produce URL is like this,
 	// <Endpoint>/v3/clusters/<KafkaClusterID>/topics/<Topic>/records

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -6,12 +6,11 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 var (
@@ -25,11 +24,11 @@ type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -74,7 +73,7 @@ func (ln *Notifier) buildMessage(ctx context.Context, as ...*types.Alert) string
 	ruleURL := path.Join(ln.tmpl.ExternalURL.String(), "/alerting/list")
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, ln.tmpl, as, ln.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, ln.tmpl, as, ln.log, &tmplErr)
 
 	body := fmt.Sprintf(
 		"%s\n%s\n\n%s",

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
@@ -31,14 +31,14 @@ var (
 // Notifier is responsible for sending alert notifications to Opsgenie.
 type Notifier struct {
 	*receivers.Base
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	images   images.ImageStore
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -10,14 +10,14 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 const (
@@ -42,7 +42,7 @@ var (
 // alert notifications to pagerduty
 type Notifier struct {
 	*receivers.Base
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	images   images.ImageStore
@@ -50,7 +50,7 @@ type Notifier struct {
 }
 
 // New is the constructor for the PagerDuty notifier
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -122,7 +122,7 @@ func (pn *Notifier) buildPagerdutyMessage(ctx context.Context, alerts model.Aler
 	}
 
 	var tmplErr error
-	tmpl, data := template2.TmplText(ctx, pn.tmpl, as, pn.log, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, pn.tmpl, as, pn.log, &tmplErr)
 
 	details := make(map[string]string, len(pn.settings.Details))
 	for k, v := range pn.settings.Details {

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 const (
@@ -40,7 +40,7 @@ var (
 // alert notifications to Pushover
 type Notifier struct {
 	*receivers.Base
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	log      logging.Logger
 	images   images.ImageStore
 	ns       receivers.WebhookSender
@@ -48,7 +48,7 @@ type Notifier struct {
 }
 
 // New is the constructor for the pushover notifier
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -103,7 +103,7 @@ func (pn *Notifier) genPushoverBody(ctx context.Context, as ...*types.Alert) (ma
 	}
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, pn.tmpl, as, pn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, pn.tmpl, as, pn.log, &tmplErr)
 
 	if err := w.WriteField("user", tmpl(pn.settings.UserKey)); err != nil {
 		return nil, b, fmt.Errorf("failed to write the user: %w", err)

--- a/receivers/sensugo/sensugo.go
+++ b/receivers/sensugo/sensugo.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 var (
@@ -27,12 +26,12 @@ type Notifier struct {
 	log      logging.Logger
 	images   images.ImageStore
 	ns       receivers.WebhookSender
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
 // New is the constructor for the SensuGo notifier
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -48,7 +47,7 @@ func (sn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	sn.log.Debug("sending Sensu Go result")
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, sn.tmpl, as, sn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, sn.tmpl, as, sn.log, &tmplErr)
 
 	// Sensu Go alerts require an entity and a check. We set it to the user-specified
 	// value (optional), else we fallback and use the grafana rule anme  and ruleID.

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -19,7 +19,7 @@ import (
 
 	amConfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
@@ -66,7 +66,7 @@ const slackMaxTitleLenRunes = 1024
 type Notifier struct {
 	*receivers.Base
 	log           logging.Logger
-	tmpl          *template.Template
+	tmpl          *templates.Template
 	images        images.ImageStore
 	webhookSender receivers.WebhookSender
 	sendFn        sendFunc
@@ -90,7 +90,7 @@ func uploadURL(s Config) (string, error) {
 	return u.String(), nil
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		settings: cfg,

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 const (
@@ -226,14 +226,14 @@ func (i AdaptiveCardOpenURLActionItem) MarshalJSON() ([]byte, error) {
 
 type Notifier struct {
 	*receivers.Base
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	images   images.ImageStore
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -246,7 +246,7 @@ func New(cfg Config, meta receivers.Metadata, template *template.Template, sende
 
 func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
 
 	card := NewAdaptiveCard()
 	card.AppendItem(AdaptiveCardTextBlockItem{

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -9,13 +9,13 @@ import (
 	"os"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 var (
@@ -33,12 +33,12 @@ type Notifier struct {
 	log      logging.Logger
 	images   images.ImageStore
 	ns       receivers.WebhookSender
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
 // New is the constructor for the Telegram notifier
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		tmpl:     template,
@@ -116,7 +116,7 @@ func (tn *Notifier) buildTelegramMessage(ctx context.Context, as []*types.Alert)
 		}
 	}()
 
-	tmpl, _ := template2.TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
 	// Telegram supports 4096 chars max
 	messageText, truncated := receivers.TruncateInRunes(tmpl(tn.settings.Message), telegramMaxMessageLenRunes)
 	if truncated {

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -6,14 +6,13 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 var (
@@ -28,11 +27,11 @@ type Notifier struct {
 	log      logging.Logger
 	images   images.ImageStore
 	ns       receivers.WebhookSender
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -76,7 +75,7 @@ func (tn *Notifier) SendResolved() bool {
 
 func (tn *Notifier) buildMessage(ctx context.Context, as ...*types.Alert) string {
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
 
 	message := fmt.Sprintf("%s%s\n\n*Message:*\n%s\n*URL:* %s\n",
 		selectEmoji(as...),

--- a/receivers/victorops/victorops.go
+++ b/receivers/victorops/victorops.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
+
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // https://help.victorops.com/knowledge-base/incident-fields-glossary/ - 20480 characters.
@@ -33,14 +33,14 @@ type Notifier struct {
 	log        logging.Logger
 	images     images.ImageStore
 	ns         receivers.WebhookSender
-	tmpl       *template.Template
+	tmpl       *templates.Template
 	settings   Config
 	appVersion string
 }
 
 // New creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,
@@ -57,7 +57,7 @@ func (vn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	vn.log.Debug("sending notification", "notification", vn.Name)
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
 
 	messageType := buildMessageType(vn.log, tmpl, vn.settings.MessageType, as...)
 

--- a/receivers/webex/webex.go
+++ b/receivers/webex/webex.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // Notifier is responsible for sending alert notifications as webex messages.
@@ -21,12 +20,12 @@ type Notifier struct {
 	ns       receivers.WebhookSender
 	log      logging.Logger
 	images   images.ImageStore
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	orgID    int64
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, orgID int64) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, orgID int64) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		orgID:    orgID,
@@ -48,7 +47,7 @@ type webexMessage struct {
 // Notify implements the Notifier interface.
 func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var tmplErr error
-	tmpl, data := template2.TmplText(ctx, wn.tmpl, as, wn.log, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, wn.tmpl, as, wn.log, &tmplErr)
 
 	message, truncated := receivers.TruncateInBytes(tmpl(wn.settings.Message), 4096)
 	if truncated {

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // Notifier is responsible for sending
@@ -23,14 +22,14 @@ type Notifier struct {
 	log      logging.Logger
 	ns       receivers.WebhookSender
 	images   images.ImageStore
-	tmpl     *template.Template
+	tmpl     *templates.Template
 	orgID    int64
 	settings Config
 }
 
 // New is the constructor for
 // the WebHook notifier.
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, orgID int64) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, orgID int64) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		orgID:    orgID,
@@ -44,7 +43,7 @@ func New(cfg Config, meta receivers.Metadata, template *template.Template, sende
 
 // webhookMessage defines the JSON object send to webhook endpoints.
 type webhookMessage struct {
-	*template2.ExtendedData
+	*templates.ExtendedData
 
 	// The protocol version.
 	Version         string `json:"version"`
@@ -65,7 +64,7 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 
 	as, numTruncated := truncateAlerts(wn.settings.MaxAlerts, as)
 	var tmplErr error
-	tmpl, data := template2.TmplText(ctx, wn.tmpl, as, wn.log, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, wn.tmpl, as, wn.log, &tmplErr)
 
 	// Augment our Alert data with ImageURLs if available.
 	_ = images.WithStoredImages(ctx, wn.log, wn.images,

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -72,11 +71,11 @@ func TestNotify(t *testing.T) {
 					Alerts: templates.ExtendedAlerts{
 						{
 							Status: "firing",
-							Labels: template.KV{
+							Labels: templates.KV{
 								"alertname": "alert1",
 								"lbl1":      "val1",
 							},
-							Annotations: template.KV{
+							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
 							Fingerprint:  "fac0861a85de433a",
@@ -85,14 +84,14 @@ func TestNotify(t *testing.T) {
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
 						},
 					},
-					GroupLabels: template.KV{
+					GroupLabels: templates.KV{
 						"alertname": "",
 					},
-					CommonLabels: template.KV{
+					CommonLabels: templates.KV{
 						"alertname": "alert1",
 						"lbl1":      "val1",
 					},
-					CommonAnnotations: template.KV{
+					CommonAnnotations: templates.KV{
 						"ann1": "annv1",
 					},
 					ExternalURL: "http://localhost",
@@ -149,35 +148,35 @@ func TestNotify(t *testing.T) {
 					Alerts: templates.ExtendedAlerts{
 						{
 							Status: "firing",
-							Labels: template.KV{
+							Labels: templates.KV{
 								"alertname": "alert1",
 								"lbl1":      "val1",
 							},
-							Annotations: template.KV{
+							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
 							Fingerprint: "fac0861a85de433a",
 							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
 						}, {
 							Status: "firing",
-							Labels: template.KV{
+							Labels: templates.KV{
 								"alertname": "alert1",
 								"lbl1":      "val2",
 							},
-							Annotations: template.KV{
+							Annotations: templates.KV{
 								"ann1": "annv2",
 							},
 							Fingerprint: "fab6861a85d5eeb5",
 							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2",
 						},
 					},
-					GroupLabels: template.KV{
+					GroupLabels: templates.KV{
 						"alertname": "",
 					},
-					CommonLabels: template.KV{
+					CommonLabels: templates.KV{
 						"alertname": "alert1",
 					},
-					CommonAnnotations: template.KV{},
+					CommonAnnotations: templates.KV{},
 					ExternalURL:       "http://localhost",
 				},
 				Version:         "1",
@@ -226,35 +225,35 @@ func TestNotify(t *testing.T) {
 					Alerts: templates.ExtendedAlerts{
 						{
 							Status: "firing",
-							Labels: template.KV{
+							Labels: templates.KV{
 								"alertname": "alert1",
 								"lbl1":      "val1",
 							},
-							Annotations: template.KV{
+							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
 							Fingerprint: "fac0861a85de433a",
 							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
 						}, {
 							Status: "firing",
-							Labels: template.KV{
+							Labels: templates.KV{
 								"alertname": "alert1",
 								"lbl1":      "val2",
 							},
-							Annotations: template.KV{
+							Annotations: templates.KV{
 								"ann1": "annv2",
 							},
 							Fingerprint: "fab6861a85d5eeb5",
 							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2",
 						},
 					},
-					GroupLabels: template.KV{
+					GroupLabels: templates.KV{
 						"alertname": "",
 					},
-					CommonLabels: template.KV{
+					CommonLabels: templates.KV{
 						"alertname": "alert1",
 					},
-					CommonAnnotations: template.KV{},
+					CommonAnnotations: templates.KV{},
 					ExternalURL:       "http://localhost",
 				},
 				Version:         "1",
@@ -296,11 +295,11 @@ func TestNotify(t *testing.T) {
 					Alerts: templates.ExtendedAlerts{
 						{
 							Status: "firing",
-							Labels: template.KV{
+							Labels: templates.KV{
 								"alertname": "alert1",
 								"lbl1":      "val1",
 							},
-							Annotations: template.KV{
+							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
 							Fingerprint:  "fac0861a85de433a",
@@ -309,14 +308,14 @@ func TestNotify(t *testing.T) {
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
 						},
 					},
-					GroupLabels: template.KV{
+					GroupLabels: templates.KV{
 						"alertname": "",
 					},
-					CommonLabels: template.KV{
+					CommonLabels: templates.KV{
 						"alertname": "alert1",
 						"lbl1":      "val1",
 					},
-					CommonAnnotations: template.KV{
+					CommonAnnotations: templates.KV{
 						"ann1": "annv1",
 					},
 					ExternalURL: "http://localhost",

--- a/receivers/wecom/wecom.go
+++ b/receivers/wecom/wecom.go
@@ -7,19 +7,18 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
-	template2 "github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/templates"
 )
 
 // Notifier is responsible for sending alert notifications to WeCom.
 type Notifier struct {
 	*receivers.Base
-	tmpl        *template.Template
+	tmpl        *templates.Template
 	log         logging.Logger
 	ns          receivers.WebhookSender
 	settings    Config
@@ -28,7 +27,7 @@ type Notifier struct {
 	group       singleflight.Group
 }
 
-func New(cfg Config, meta receivers.Metadata, template *template.Template, sender receivers.WebhookSender, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		tmpl:     template,
@@ -43,7 +42,7 @@ func (w *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	w.log.Info("executing WeCom notification", "notification", w.Name)
 
 	var tmplErr error
-	tmpl, _ := template2.TmplText(ctx, w.tmpl, as, w.log, &tmplErr)
+	tmpl, _ := templates.TmplText(ctx, w.tmpl, as, w.log, &tmplErr)
 
 	bodyMsg := map[string]interface{}{
 		"msgtype": w.settings.MsgType,

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -101,7 +101,7 @@ Labels:
 {{ define "teams.default.message" }}{{ template "default.message" . }}{{ end }}
 `
 
-func ForTests(t *testing.T) *template.Template {
+func ForTests(t *testing.T) *Template {
 	f, err := os.CreateTemp("/tmp", "template")
 	require.NoError(t, err)
 	defer func(f *os.File) {

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -99,7 +98,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	_, err = f.WriteString(DefaultTemplateString)
 	require.NoError(t, err)
 
-	tmpl, err := template.FromGlobs([]string{f.Name()})
+	tmpl, err := FromGlobs([]string{f.Name()})
 	require.NoError(t, err)
 
 	externalURL, err := url.Parse("http://localhost/grafana")

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -25,8 +25,8 @@ var FromGlobs = template.FromGlobs
 
 type ExtendedAlert struct {
 	Status        string             `json:"status"`
-	Labels        template.KV        `json:"labels"`
-	Annotations   template.KV        `json:"annotations"`
+	Labels        KV                 `json:"labels"`
+	Annotations   KV                 `json:"annotations"`
 	StartsAt      time.Time          `json:"startsAt"`
 	EndsAt        time.Time          `json:"endsAt"`
 	GeneratorURL  string             `json:"generatorURL"`
@@ -47,9 +47,9 @@ type ExtendedData struct {
 	Status   string         `json:"status"`
 	Alerts   ExtendedAlerts `json:"alerts"`
 
-	GroupLabels       template.KV `json:"groupLabels"`
-	CommonLabels      template.KV `json:"commonLabels"`
-	CommonAnnotations template.KV `json:"commonAnnotations"`
+	GroupLabels       KV `json:"groupLabels"`
+	CommonLabels      KV `json:"commonLabels"`
+	CommonAnnotations KV `json:"commonAnnotations"`
 
 	ExternalURL string `json:"externalURL"`
 }

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -20,6 +20,7 @@ import (
 
 type Template = template.Template
 type KV = template.KV
+type Data = template.Data
 
 var FromGlobs = template.FromGlobs
 
@@ -156,8 +157,8 @@ func setOrgIDQueryParam(url *url.URL, orgID string) string {
 	return url.String()
 }
 
-func ExtendData(data *template.Data, logger logging.Logger) *ExtendedData {
-	alerts := []ExtendedAlert{}
+func ExtendData(data *Data, logger logging.Logger) *ExtendedData {
+	alerts := make([]ExtendedAlert, 0, len(data.Alerts))
 
 	for _, alert := range data.Alerts {
 		extendedAlert := extendAlert(alert, data.ExternalURL, logger)
@@ -177,7 +178,7 @@ func ExtendData(data *template.Data, logger logging.Logger) *ExtendedData {
 	return extended
 }
 
-func TmplText(ctx context.Context, tmpl *template.Template, alerts []*types.Alert, l logging.Logger, tmplErr *error) (func(string) string, *ExtendedData) {
+func TmplText(ctx context.Context, tmpl *Template, alerts []*types.Alert, l logging.Logger, tmplErr *error) (func(string) string, *ExtendedData) {
 	promTmplData := notify.GetTemplateData(ctx, tmpl, alerts, l)
 	data := ExtendData(promTmplData, l)
 

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -18,6 +18,11 @@ import (
 	"github.com/grafana/alerting/models"
 )
 
+type Template = template.Template
+type KV = template.KV
+
+var FromGlobs = template.FromGlobs
+
 type ExtendedAlert struct {
 	Status        string             `json:"status"`
 	Labels        template.KV        `json:"labels"`


### PR DESCRIPTION
This PR internalizes the usage of alertmanager's Template and updates all public functions and methods to use the type alias. This is a follow up for https://github.com/grafana/alerting/pull/63#discussion_r1146571465