### PR TITLE
[v9.4.x] Slack: assume any non-JSON response is an incoming webhook

### DIFF
--- a/alerting/notifier/channels/slack.go
+++ b/alerting/notifier/channels/slack.go
@@ -261,11 +261,11 @@ var sendSlackRequest = func(ctx context.Context, req *http.Request, logger Logge
 	}
 
 	content := resp.Header.Get("Content-Type")
-	// If the response is text/html it could be the response to an incoming webhook
-	if strings.HasPrefix(content, "text/html") {
-		return handleSlackIncomingWebhookResponse(resp, logger)
+	if strings.HasPrefix(content, "application/json") {
+		return handleSlackJSONResponse(resp, logger)
 	}
-	return handleSlackJSONResponse(resp, logger)
+	// If the response is not JSON it could be the response to an incoming webhook
+	return handleSlackIncomingWebhookResponse(resp, logger)
 }
 
 func handleSlackIncomingWebhookResponse(resp *http.Response, logger Logger) (string, error) {

--- a/alerting/notifier/channels/slack_test.go
+++ b/alerting/notifier/channels/slack_test.go
@@ -488,6 +488,7 @@ func TestSendSlackRequest(t *testing.T) {
 		name        string
 		response    string
 		statusCode  int
+		contentType string
 		expectError bool
 	}{
 		{
@@ -497,11 +498,13 @@ func TestSendSlackRequest(t *testing.T) {
 					"error": "too_many_attachments"
 				}`,
 			statusCode:  http.StatusBadRequest,
+			contentType: "application/json",
 			expectError: true,
 		},
 		{
 			name:        "Non 200 status code, no response body",
 			statusCode:  http.StatusMovedPermanently,
+			contentType: "",
 			expectError: true,
 		},
 		{
@@ -527,36 +530,64 @@ func TestSendSlackRequest(t *testing.T) {
 				}
 			}`,
 			statusCode:  http.StatusOK,
+			contentType: "application/json",
 			expectError: false,
 		},
 		{
-			name:        "No response body",
+			name:        "No JSON response body",
 			statusCode:  http.StatusOK,
+			contentType: "application/json",
+			expectError: true,
+		},
+		{
+			name:        "No HTML response body",
+			statusCode:  http.StatusOK,
+			contentType: "text/html",
 			expectError: true,
 		},
 		{
 			name:        "Success case, unexpected response body",
 			statusCode:  http.StatusOK,
 			response:    `{"test": true}`,
+			contentType: "application/json",
 			expectError: true,
 		},
 		{
 			name:        "Success case, ok: true",
 			statusCode:  http.StatusOK,
 			response:    `{"ok": true}`,
+			contentType: "application/json",
 			expectError: false,
 		},
 		{
 			name:        "200 status code, error in body",
 			statusCode:  http.StatusOK,
 			response:    `{"ok": false, "error": "test error"}`,
+			contentType: "application/json",
 			expectError: true,
+		},
+		{
+			name:        "Success case, HTML ok",
+			statusCode:  http.StatusOK,
+			response:    "ok",
+			contentType: "text/html",
+			expectError: false,
+		},
+		{
+			name:        "Success case, text/plain ok",
+			statusCode:  http.StatusOK,
+			response:    "ok",
+			contentType: "text/plain",
+			expectError: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if test.contentType != "" {
+					w.Header().Set("Content-Type", test.contentType)
+				}
 				w.WriteHeader(test.statusCode)
 				_, err := w.Write([]byte(test.response))
 				require.NoError(tt, err)


### PR DESCRIPTION
backport of commit https://github.com/grafana/alerting/commit/c151a6de9652b347d4e4832423846fae67ba7427 from #67 to branch 9.4.x