### PR TITLE
Replace incorrect usage of term "receivers" to "integrations"

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -34,11 +34,11 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	getFullConfig := func(t *testing.T) (GrafanaReceiverConfig, int) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
 		for notifierType, cfg := range allKnownConfigs {
-			recCfg.Receivers = append(recCfg.Receivers, cfg.getRawNotifierConfig(notifierType))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, GetDecryptedValueFnForTesting)
 		require.NoError(t, err)
-		return parsed, len(recCfg.Receivers)
+		return parsed, len(recCfg.Integrations)
 	}
 
 	t.Run("should build all supported notifiers", func(t *testing.T) {

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -100,7 +100,7 @@ type GrafanaAlertmanager struct {
 	configHash                   [16]byte
 	config                       []byte
 	receivers                    []*notify.Receiver
-	buildReceiverIntegrationFunc func(next *GrafanaReceiver, tmpl *templates.Template) (Notifier, error)
+	buildReceiverIntegrationFunc func(next *GrafanaIntegrationConfig, tmpl *templates.Template) (Notifier, error)
 }
 
 // State represents any of the two 'states' of the alertmanager. Notification log or Silences.
@@ -141,7 +141,7 @@ type Configuration interface {
 	InhibitRules() []InhibitRule
 	MuteTimeIntervals() []MuteTimeInterval
 	ReceiverIntegrations() (map[string][]*Integration, error)
-	BuildReceiverIntegrationsFunc() func(next *GrafanaReceiver, tmpl *templates.Template) (Notifier, error)
+	BuildReceiverIntegrationsFunc() func(next *GrafanaIntegrationConfig, tmpl *templates.Template) (Notifier, error)
 
 	RoutingTree() *Route
 	Templates() *templates.Template
@@ -614,6 +614,6 @@ func (am *GrafanaAlertmanager) tenantString() string {
 	return fmt.Sprintf("%d", am.tenantID)
 }
 
-func (am *GrafanaAlertmanager) buildReceiverIntegration(next *GrafanaReceiver, tmpl *templates.Template) (Notifier, error) {
+func (am *GrafanaAlertmanager) buildReceiverIntegration(next *GrafanaIntegrationConfig, tmpl *templates.Template) (Notifier, error) {
 	return am.buildReceiverIntegrationFunc(next, tmpl)
 }

--- a/notify/grafana_alertmanager_metrics.go
+++ b/notify/grafana_alertmanager_metrics.go
@@ -33,7 +33,7 @@ func NewGrafanaAlertmanagerMetrics(r prometheus.Registerer) *GrafanaAlertmanager
 			Namespace: namesapce,
 			Subsystem: subsystem,
 			Name:      "alertmanager_integrations",
-			Help:      "Number of configured receivers.",
+			Help:      "Number of configured integrations.",
 		}, []string{"org", "type"}),
 	}
 }

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -332,7 +332,7 @@ func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
 	am.setReceiverMetrics(receivers, 2)
 
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-        	            	# HELP grafana_alerting_alertmanager_integrations Number of configured receivers.
+        	            	# HELP grafana_alerting_alertmanager_integrations Number of configured integrations.
         	            	# TYPE grafana_alerting_alertmanager_integrations gauge
         	            	grafana_alerting_alertmanager_integrations{org="1",type="grafana-oncall"} 2
         	            	grafana_alerting_alertmanager_integrations{org="1",type="sns"} 2

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -350,9 +350,9 @@ func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decrypt G
 	for _, receiver := range api.Integrations {
 		err := parseNotifier(ctx, &result, receiver, decrypt)
 		if err != nil {
-			return GrafanaReceiverConfig{}, &ReceiverValidationError{
-				Cfg: receiver,
-				Err: fmt.Errorf("failed to parse notifier %s (UID: %s): %w", receiver.Name, receiver.UID, err),
+			return GrafanaReceiverConfig{}, &IntegrationValidationError{
+				Integration: receiver,
+				Err:         err,
 			}
 		}
 	}
@@ -518,18 +518,18 @@ func newNotifierConfig[T interface{}](receiver *GrafanaIntegrationConfig, settin
 	}
 }
 
-type ReceiverValidationError struct {
-	Err error
-	Cfg *GrafanaIntegrationConfig
+type IntegrationValidationError struct {
+	Err         error
+	Integration *GrafanaIntegrationConfig
 }
 
-func (e ReceiverValidationError) Error() string {
+func (e IntegrationValidationError) Error() string {
 	name := ""
-	if e.Cfg.Name != "" {
-		name = fmt.Sprintf("%q ", e.Cfg.Name)
+	if e.Integration.Name != "" {
+		name = fmt.Sprintf("%q ", e.Integration.Name)
 	}
-	s := fmt.Sprintf("failed to validate receiver %sof type %q: %s", name, e.Cfg.Type, e.Err.Error())
+	s := fmt.Sprintf("failed to validate integration %s(UID %s) of type %q: %s", name, e.Integration.UID, e.Integration.Type, e.Err.Error())
 	return s
 }
 
-func (e ReceiverValidationError) Unwrap() error { return e.Err }
+func (e IntegrationValidationError) Unwrap() error { return e.Err }

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -65,11 +65,6 @@ type TestReceiverConfigResult struct {
 	Error  error
 }
 
-type InvalidReceiverError struct {
-	Receiver *GrafanaIntegrationConfig
-	Err      error
-}
-
 type GrafanaIntegrationConfig struct {
 	UID                   string            `json:"uid"`
 	Name                  string            `json:"name"`
@@ -98,10 +93,6 @@ type TestReceiversConfigBodyParams struct {
 type TestReceiversConfigAlertParams struct {
 	Annotations model.LabelSet `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 	Labels      model.LabelSet `yaml:"labels,omitempty" json:"labels,omitempty"`
-}
-
-func (e InvalidReceiverError) Error() string {
-	return fmt.Sprintf("the receiver is invalid: %s", e.Err)
 }
 
 type ReceiverTimeoutError struct {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -55,10 +55,10 @@ type TestReceiversResult struct {
 
 type TestReceiverResult struct {
 	Name    string
-	Configs []TestReceiverConfigResult
+	Configs []TestIntegrationConfigResult
 }
 
-type TestReceiverConfigResult struct {
+type TestIntegrationConfigResult struct {
 	Name   string
 	UID    string
 	Status string
@@ -138,7 +138,7 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 			m[receiver.Name] = TestReceiverResult{
 				Name: receiver.Name,
 				// A Grafana receiver can have multiple nested receivers
-				Configs: make([]TestReceiverConfigResult, 0, len(receiver.Integrations)),
+				Configs: make([]TestIntegrationConfigResult, 0, len(receiver.Integrations)),
 			}
 		}
 		for _, next := range results {
@@ -147,7 +147,7 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 			if next.Error != nil {
 				status = "failed"
 			}
-			tmp.Configs = append(tmp.Configs, TestReceiverConfigResult{
+			tmp.Configs = append(tmp.Configs, TestIntegrationConfigResult{
 				Name:   next.Config.Name,
 				UID:    next.Config.UID,
 				Status: status,

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -151,7 +151,7 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 				Name:   next.Config.Name,
 				UID:    next.Config.UID,
 				Status: status,
-				Error:  ProcessNotifierError(next.Config, next.Error),
+				Error:  ProcessIntegrationError(next.Config, next.Error),
 			})
 			m[next.ReceiverName] = tmp
 		}
@@ -283,7 +283,7 @@ func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time
 	return alert
 }
 
-func ProcessNotifierError(config *GrafanaIntegrationConfig, err error) error {
+func ProcessIntegrationError(config *GrafanaIntegrationConfig, err error) error {
 	if err == nil {
 		return nil
 	}

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -66,11 +66,11 @@ type TestReceiverConfigResult struct {
 }
 
 type InvalidReceiverError struct {
-	Receiver *GrafanaReceiver
+	Receiver *GrafanaIntegrationConfig
 	Err      error
 }
 
-type GrafanaReceiver struct {
+type GrafanaIntegrationConfig struct {
 	UID                   string            `json:"uid"`
 	Name                  string            `json:"name"`
 	Type                  string            `json:"type"`
@@ -87,7 +87,7 @@ type APIReceiver struct {
 }
 
 type GrafanaIntegrations struct {
-	Integrations []*GrafanaReceiver `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
+	Integrations []*GrafanaIntegrationConfig `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
 }
 
 type TestReceiversConfigBodyParams struct {
@@ -105,7 +105,7 @@ func (e InvalidReceiverError) Error() string {
 }
 
 type ReceiverTimeoutError struct {
-	Receiver *GrafanaReceiver
+	Receiver *GrafanaIntegrationConfig
 	Err      error
 }
 
@@ -128,14 +128,14 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 
 	// job contains all metadata required to test a receiver
 	type job struct {
-		Config       *GrafanaReceiver
+		Config       *GrafanaIntegrationConfig
 		ReceiverName string
 		Notifier     notify.Notifier
 	}
 
 	// result contains the receiver that was tested and an error that is non-nil if the test failed
 	type result struct {
-		Config       *GrafanaReceiver
+		Config       *GrafanaIntegrationConfig
 		ReceiverName string
 		Error        error
 	}
@@ -292,7 +292,7 @@ func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time
 	return alert
 }
 
-func ProcessNotifierError(config *GrafanaReceiver, err error) error {
+func ProcessNotifierError(config *GrafanaIntegrationConfig, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -341,7 +341,7 @@ type GrafanaReceiverConfig struct {
 	WebexConfigs        []*NotifierConfig[webex.Config]
 }
 
-// NotifierConfig represents parsed GrafanaReceiver.
+// NotifierConfig represents parsed GrafanaIntegrationConfig.
 type NotifierConfig[T interface{}] struct {
 	receivers.Metadata
 	Settings T
@@ -369,7 +369,7 @@ func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decrypt G
 }
 
 // parseNotifier parses receivers and populates the corresponding field in GrafanaReceiverConfig. Returns an error if the configuration cannot be parsed.
-func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver *GrafanaReceiver, decrypt GetDecryptedValueFn) error {
+func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver *GrafanaIntegrationConfig, decrypt GetDecryptedValueFn) error {
 	secureSettings, err := decodeSecretsFromBase64(receiver.SecureSettings)
 	if err != nil {
 		return err
@@ -515,7 +515,7 @@ func decodeSecretsFromBase64(secrets map[string]string) (map[string][]byte, erro
 	return secureSettings, nil
 }
 
-func newNotifierConfig[T interface{}](receiver *GrafanaReceiver, settings T) *NotifierConfig[T] {
+func newNotifierConfig[T interface{}](receiver *GrafanaIntegrationConfig, settings T) *NotifierConfig[T] {
 	return &NotifierConfig[T]{
 		Metadata: receivers.Metadata{
 			UID:                   receiver.UID,
@@ -529,7 +529,7 @@ func newNotifierConfig[T interface{}](receiver *GrafanaReceiver, settings T) *No
 
 type ReceiverValidationError struct {
 	Err error
-	Cfg *GrafanaReceiver
+	Cfg *GrafanaIntegrationConfig
 }
 
 func (e ReceiverValidationError) Error() string {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -95,12 +95,12 @@ type TestReceiversConfigAlertParams struct {
 	Labels      model.LabelSet `yaml:"labels,omitempty" json:"labels,omitempty"`
 }
 
-type ReceiverTimeoutError struct {
-	Receiver *GrafanaIntegrationConfig
-	Err      error
+type IntegrationTimeoutError struct {
+	Integration *GrafanaIntegrationConfig
+	Err         error
 }
 
-func (e ReceiverTimeoutError) Error() string {
+func (e IntegrationTimeoutError) Error() string {
 	return fmt.Sprintf("the receiver timed out: %s", e.Err)
 }
 
@@ -291,17 +291,17 @@ func ProcessNotifierError(config *GrafanaIntegrationConfig, err error) error {
 	var urlError *url.Error
 	if errors.As(err, &urlError) {
 		if urlError.Timeout() {
-			return ReceiverTimeoutError{
-				Receiver: config,
-				Err:      err,
+			return IntegrationTimeoutError{
+				Integration: config,
+				Err:         err,
 			}
 		}
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) {
-		return ReceiverTimeoutError{
-			Receiver: config,
-			Err:      err,
+		return IntegrationTimeoutError{
+			Integration: config,
+			Err:         err,
 		}
 	}
 

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func TestReceiverTimeoutError_Error(t *testing.T) {
-	e := ReceiverTimeoutError{
-		Receiver: &GrafanaIntegrationConfig{
+	e := IntegrationTimeoutError{
+		Integration: &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
 		},
@@ -62,9 +62,9 @@ func TestProcessNotifierError(t *testing.T) {
 			Name: "test",
 			UID:  "uid",
 		}
-		require.Equal(t, ReceiverTimeoutError{
-			Receiver: r,
-			Err:      context.DeadlineExceeded,
+		require.Equal(t, IntegrationTimeoutError{
+			Integration: r,
+			Err:         context.DeadlineExceeded,
 		}, ProcessNotifierError(r, context.DeadlineExceeded))
 	})
 
@@ -78,9 +78,9 @@ func TestProcessNotifierError(t *testing.T) {
 			URL: "https://grafana.net",
 			Err: timeoutError{},
 		}
-		require.Equal(t, ReceiverTimeoutError{
-			Receiver: r,
-			Err:      urlError,
+		require.Equal(t, IntegrationTimeoutError{
+			Integration: r,
+			Err:         urlError,
 		}, ProcessNotifierError(r, urlError))
 	})
 

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -110,7 +110,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 	t.Run("should decode secrets from base64", func(t *testing.T) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
 		for notifierType, cfg := range allKnownConfigs {
-			recCfg.Receivers = append(recCfg.Receivers, cfg.getRawNotifierConfig(notifierType))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
 		counter := 0
 		decryptCount := func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
@@ -123,7 +123,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 	t.Run("should fail if at least one config is invalid", func(t *testing.T) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
 		for notifierType, cfg := range allKnownConfigs {
-			recCfg.Receivers = append(recCfg.Receivers, cfg.getRawNotifierConfig(notifierType))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
 		bad := &GrafanaReceiver{
 			UID:      "invalid-test",
@@ -131,7 +131,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 			Type:     "slack",
 			Settings: json.RawMessage(`{ "test" : "test" }`),
 		}
-		recCfg.Receivers = append(recCfg.Receivers, bad)
+		recCfg.Integrations = append(recCfg.Integrations, bad)
 
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NotNil(t, err)
@@ -158,7 +158,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 			for key := range notifierRaw.SecureSettings {
 				notifierRaw.SecureSettings[key] = "bad base-64"
 			}
-			recCfg.Receivers = append(recCfg.Receivers, notifierRaw)
+			recCfg.Integrations = append(recCfg.Integrations, notifierRaw)
 		}
 
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
@@ -172,7 +172,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 	t.Run("should fail if notifier type is unknown", func(t *testing.T) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
 		for notifierType, cfg := range allKnownConfigs {
-			recCfg.Receivers = append(recCfg.Receivers, cfg.getRawNotifierConfig(notifierType))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
 		bad := &GrafanaReceiver{
 			UID:      "test",
@@ -180,7 +180,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 			Type:     fmt.Sprintf("invalid-%d", rand.Uint32()),
 			Settings: json.RawMessage(`{ "test" : "test" }`),
 		}
-		recCfg.Receivers = append(recCfg.Receivers, bad)
+		recCfg.Integrations = append(recCfg.Integrations, bad)
 
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NotNil(t, err)
@@ -194,7 +194,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 	t.Run("should recognize all known types", func(t *testing.T) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
 		for notifierType, cfg := range allKnownConfigs {
-			recCfg.Receivers = append(recCfg.Receivers, cfg.getRawNotifierConfig(notifierType))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 				require.NotEmptyf(t, meta.UID, "%s notifier (idx: %d) '%s' uid: '%s'.", meta.Type, idx, meta.Name, meta.UID)
 				require.NotEmptyf(t, meta.Name, "%s notifier (idx: %d) '%s' uid: '%s'.", meta.Type, idx, meta.Name, meta.UID)
 				var notifierRaw *GrafanaReceiver
-				for _, receiver := range recCfg.Receivers {
+				for _, receiver := range recCfg.Integrations {
 					if receiver.Type == meta.Type && receiver.UID == meta.UID && receiver.Name == meta.Name {
 						notifierRaw = receiver
 						break
@@ -262,7 +262,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		for notifierType, cfg := range allKnownConfigs {
 			notifierRaw := cfg.getRawNotifierConfig(notifierType)
 			notifierRaw.Type = strings.ToUpper(notifierRaw.Type)
-			recCfg.Receivers = append(recCfg.Receivers, cfg.getRawNotifierConfig(notifierType))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NoError(t, err)

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -65,7 +65,7 @@ func TestProcessNotifierError(t *testing.T) {
 		require.Equal(t, IntegrationTimeoutError{
 			Integration: r,
 			Err:         context.DeadlineExceeded,
-		}, ProcessNotifierError(r, context.DeadlineExceeded))
+		}, ProcessIntegrationError(r, context.DeadlineExceeded))
 	})
 
 	t.Run("assert IntegrationTimeoutError is returned for *url.Error timeout", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestProcessNotifierError(t *testing.T) {
 		require.Equal(t, IntegrationTimeoutError{
 			Integration: r,
 			Err:         urlError,
-		}, ProcessNotifierError(r, urlError))
+		}, ProcessIntegrationError(r, urlError))
 	})
 
 	t.Run("assert unknown error is returned unmodified", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestProcessNotifierError(t *testing.T) {
 			UID:  "uid",
 		}
 		err := errors.New("this is an error")
-		require.Equal(t, err, ProcessNotifierError(r, err))
+		require.Equal(t, err, ProcessIntegrationError(r, err))
 	})
 }
 

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -57,7 +57,7 @@ func (e timeoutError) Timeout() bool {
 }
 
 func TestProcessNotifierError(t *testing.T) {
-	t.Run("assert ReceiverTimeoutError is returned for context deadline exceeded", func(t *testing.T) {
+	t.Run("assert IntegrationTimeoutError is returned for context deadline exceeded", func(t *testing.T) {
 		r := &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
@@ -68,7 +68,7 @@ func TestProcessNotifierError(t *testing.T) {
 		}, ProcessNotifierError(r, context.DeadlineExceeded))
 	})
 
-	t.Run("assert ReceiverTimeoutError is returned for *url.Error timeout", func(t *testing.T) {
+	t.Run("assert IntegrationTimeoutError is returned for *url.Error timeout", func(t *testing.T) {
 		r := &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
@@ -125,11 +125,11 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NotNil(t, err)
 		require.Equal(t, GrafanaReceiverConfig{}, parsed)
-		require.IsType(t, &ReceiverValidationError{}, err)
-		typedError := err.(*ReceiverValidationError)
-		require.NotNil(t, typedError.Cfg)
-		require.Equal(t, bad, typedError.Cfg)
-		require.ErrorContains(t, err, fmt.Sprintf(`failed to validate receiver "%s" of type "%s"`, bad.Name, bad.Type))
+		require.IsType(t, &IntegrationValidationError{}, err)
+		typedError := err.(*IntegrationValidationError)
+		require.NotNil(t, typedError.Integration)
+		require.Equal(t, bad, typedError.Integration)
+		require.ErrorContains(t, err, fmt.Sprintf(`failed to validate integration "%s" (UID %s) of type "%s"`, bad.Name, bad.UID, bad.Type))
 	})
 	t.Run("should accept empty config", func(t *testing.T) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
@@ -153,9 +153,9 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NotNil(t, err)
 		require.Equal(t, GrafanaReceiverConfig{}, parsed)
-		require.IsType(t, &ReceiverValidationError{}, err)
-		typedError := err.(*ReceiverValidationError)
-		require.NotNil(t, typedError.Cfg)
+		require.IsType(t, &IntegrationValidationError{}, err)
+		typedError := err.(*IntegrationValidationError)
+		require.NotNil(t, typedError.Integration)
 		require.ErrorContains(t, err, "failed to decode secure settings")
 	})
 	t.Run("should fail if notifier type is unknown", func(t *testing.T) {
@@ -174,10 +174,10 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, decrypt)
 		require.NotNil(t, err)
 		require.Equal(t, GrafanaReceiverConfig{}, parsed)
-		require.IsType(t, &ReceiverValidationError{}, err)
-		typedError := err.(*ReceiverValidationError)
-		require.NotNil(t, typedError.Cfg)
-		require.Equal(t, bad, typedError.Cfg)
+		require.IsType(t, &IntegrationValidationError{}, err)
+		typedError := err.(*IntegrationValidationError)
+		require.NotNil(t, typedError.Integration)
+		require.Equal(t, bad, typedError.Integration)
 		require.ErrorContains(t, err, fmt.Sprintf("notifier %s is not supported", bad.Type))
 	})
 	t.Run("should recognize all known types", func(t *testing.T) {

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -48,7 +48,7 @@ func TestInvalidReceiverError_Error(t *testing.T) {
 
 func TestReceiverTimeoutError_Error(t *testing.T) {
 	e := ReceiverTimeoutError{
-		Receiver: &GrafanaReceiver{
+		Receiver: &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
 		},
@@ -69,7 +69,7 @@ func (e timeoutError) Timeout() bool {
 
 func TestProcessNotifierError(t *testing.T) {
 	t.Run("assert ReceiverTimeoutError is returned for context deadline exceeded", func(t *testing.T) {
-		r := &GrafanaReceiver{
+		r := &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
 		}
@@ -80,7 +80,7 @@ func TestProcessNotifierError(t *testing.T) {
 	})
 
 	t.Run("assert ReceiverTimeoutError is returned for *url.Error timeout", func(t *testing.T) {
-		r := &GrafanaReceiver{
+		r := &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
 		}
@@ -96,7 +96,7 @@ func TestProcessNotifierError(t *testing.T) {
 	})
 
 	t.Run("assert unknown error is returned unmodified", func(t *testing.T) {
-		r := &GrafanaReceiver{
+		r := &GrafanaIntegrationConfig{
 			Name: "test",
 			UID:  "uid",
 		}
@@ -125,7 +125,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		for notifierType, cfg := range allKnownConfigs {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
-		bad := &GrafanaReceiver{
+		bad := &GrafanaIntegrationConfig{
 			UID:      "invalid-test",
 			Name:     "invalid-test",
 			Type:     "slack",
@@ -174,7 +174,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		for notifierType, cfg := range allKnownConfigs {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
 		}
-		bad := &GrafanaReceiver{
+		bad := &GrafanaIntegrationConfig{
 			UID:      "test",
 			Name:     "test",
 			Type:     fmt.Sprintf("invalid-%d", rand.Uint32()),
@@ -245,7 +245,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 				require.NotEmptyf(t, meta.Type, "%s notifier (idx: %d) '%s' uid: '%s'.", meta.Type, idx, meta.Name, meta.UID)
 				require.NotEmptyf(t, meta.UID, "%s notifier (idx: %d) '%s' uid: '%s'.", meta.Type, idx, meta.Name, meta.UID)
 				require.NotEmptyf(t, meta.Name, "%s notifier (idx: %d) '%s' uid: '%s'.", meta.Type, idx, meta.Name, meta.UID)
-				var notifierRaw *GrafanaReceiver
+				var notifierRaw *GrafanaIntegrationConfig
 				for _, receiver := range recCfg.Integrations {
 					if receiver.Type == meta.Type && receiver.UID == meta.UID && receiver.Name == meta.Name {
 						notifierRaw = receiver
@@ -377,7 +377,7 @@ type notifierConfigTest struct {
 	secrets      string
 }
 
-func (n notifierConfigTest) getRawNotifierConfig(name string) *GrafanaReceiver {
+func (n notifierConfigTest) getRawNotifierConfig(name string) *GrafanaIntegrationConfig {
 	secrets := make(map[string]string)
 	if n.secrets != "" {
 		err := json.Unmarshal([]byte(n.secrets), &secrets)
@@ -388,7 +388,7 @@ func (n notifierConfigTest) getRawNotifierConfig(name string) *GrafanaReceiver {
 			secrets[key] = base64.StdEncoding.EncodeToString([]byte(value))
 		}
 	}
-	return &GrafanaReceiver{
+	return &GrafanaIntegrationConfig{
 		UID:                   fmt.Sprintf("%s-%d", name, rand.Uint32()),
 		Name:                  name,
 		Type:                  n.notifierType,

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -35,17 +35,6 @@ import (
 	"github.com/grafana/alerting/receivers/wecom"
 )
 
-func TestInvalidReceiverError_Error(t *testing.T) {
-	e := InvalidReceiverError{
-		Receiver: &GrafanaReceiver{
-			Name: "test",
-			UID:  "uid",
-		},
-		Err: errors.New("this is an error"),
-	}
-	require.Equal(t, "the receiver is invalid: this is an error", e.Error())
-}
-
 func TestReceiverTimeoutError_Error(t *testing.T) {
 	e := ReceiverTimeoutError{
 		Receiver: &GrafanaIntegrationConfig{


### PR DESCRIPTION
The term "receivers" is used in many places and is confused with integrations. This PR renames structs, functions and log\error messages to use the correct term for the context.
This PR renames: 
- struct GrafanaReceivers to GrafanaIntegrations
- struct GrafanaReceiver to GrafanaIntegrationConfig
- struct TestReceiverConfigResult to TestIntegrationConfigResult
- struct ReceiverTimeoutError to IntegrationTimeoutError
- struct ReceiverValidationError to IntegrationValidationError
- function ProcessNotifierError to ProcessIntegrationError

Also, it removes struct InvalidReceiverError because it is not used anywhere and can be replaced by IntegrationValidationError in usages.

This PR is structured the way so it is simpler to review it by commit.