### PR TITLE
Fixes Opsgenie Create Alert failure when external image URL attached

### DIFF
--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -164,7 +164,7 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 			as...)
 
 		if len(imageUrls) != 0 {
-			details["image_urls"] = imageUrls
+			details["image_urls"] = strings.Join(imageUrls, ", ")
 		}
 	}
 


### PR DESCRIPTION
Fixes issue: https://github.com/grafana/grafana/issues/67177

When invoking the [Opsgenie Create Alert API](https://docs.opsgenie.com/docs/alert-api#create-alert), the field `detail` seems to only accept string value, does not accept array in the value. If the value is an array, Opsgenie will respond with 422 Unprocessable Entity.

This fix converts the array to a comma [joined](https://pkg.go.dev/strings#Join) string, and the following screenshot is a successfully sent alert with two images attached:

![opsgenie alert with multiple images attached](https://user-images.githubusercontent.com/13197632/234632397-2d162e59-a708-4998-a88a-21bdc45d9bf9.png)
![SNAG-20230426-152522-0000](https://user-images.githubusercontent.com/13197632/234632373-ef53aeb5-827f-4dec-972f-94e77c0ccb7d.png)

The following section is copied from the [original issue](https://github.com/grafana/grafana/issues/67177):

### What happened:
Cannot create Opsgenie Alerts with S3 image url attached

### What you expected to happen:
Opsgenie Alerts are created and image URL are attached in details section

### How to reproduce it (as minimally and precisely as possible):
1. Create a Grafana container
1. Create a Grafana Image Renderer container
1. Configure Grafana to use the Grafana Image Renderer by following the [tutorial](https://grafana.com/docs/grafana/latest/alerting/manage-notifications/images-in-notifications/)
1. Configure panels, alert rules, contact points, notification policies, etc.
1. Trigger an Grafana Alert
1. An image is created in the S3 bucket
1. Grafana log shows 422 Unprocessable Entity
1. No Opsgenie Alert is created