### PR TITLE
Rename image.ImageStore to image.Provider

### DIFF
--- a/images/images.go
+++ b/images/images.go
@@ -28,13 +28,13 @@ func (i Image) HasURL() bool {
 	return i.URL != ""
 }
 
-type ImageStore interface {
+type ImageProvider interface {
 	GetImage(ctx context.Context, token string) (*Image, error)
 }
 
-type UnavailableImageStore struct{}
+type UnavailableImageProvider struct{}
 
 // GetImage returns the image with the corresponding token, or ErrImageNotFound.
-func (u *UnavailableImageStore) GetImage(context.Context, string) (*Image, error) {
+func (u *UnavailableImageProvider) GetImage(context.Context, string) (*Image, error) {
 	return nil, ErrImagesUnavailable
 }

--- a/images/images.go
+++ b/images/images.go
@@ -28,13 +28,13 @@ func (i Image) HasURL() bool {
 	return i.URL != ""
 }
 
-type ImageProvider interface {
+type Provider interface {
 	GetImage(ctx context.Context, token string) (*Image, error)
 }
 
-type UnavailableImageProvider struct{}
+type UnavailableProvider struct{}
 
 // GetImage returns the image with the corresponding token, or ErrImageNotFound.
-func (u *UnavailableImageProvider) GetImage(context.Context, string) (*Image, error) {
+func (u *UnavailableProvider) GetImage(context.Context, string) (*Image, error) {
 	return nil, ErrImagesUnavailable
 }

--- a/images/testing.go
+++ b/images/testing.go
@@ -9,12 +9,12 @@ import (
 	"time"
 )
 
-type FakeImageStore struct {
+type FakeImageProvider struct {
 	Images []*Image
 }
 
 // GetImage returns an image with the same token.
-func (f *FakeImageStore) GetImage(_ context.Context, token string) (*Image, error) {
+func (f *FakeImageProvider) GetImage(_ context.Context, token string) (*Image, error) {
 	for _, img := range f.Images {
 		if img.Token == token {
 			return img, nil
@@ -23,29 +23,29 @@ func (f *FakeImageStore) GetImage(_ context.Context, token string) (*Image, erro
 	return nil, ErrImageNotFound
 }
 
-// NewFakeImageStore returns an image store with N test images.
+// NewFakeImageProvider returns an image provider with N test images.
 // Each image has a token and a URL, but does not have a file on disk.
-func NewFakeImageStore(n int) ImageStore {
-	s := FakeImageStore{}
+func NewFakeImageProvider(n int) ImageProvider {
+	p := FakeImageProvider{}
 	for i := 1; i <= n; i++ {
-		s.Images = append(s.Images, &Image{
+		p.Images = append(p.Images, &Image{
 			Token:     fmt.Sprintf("test-image-%d", i),
 			URL:       fmt.Sprintf("https://www.example.com/test-image-%d.jpg", i),
 			CreatedAt: time.Now().UTC(),
 		})
 	}
-	return &s
+	return &p
 }
 
-// NewFakeImageStoreWithFile returns an image store with N test images.
+// NewFakeImageProviderWithFile returns an image provider with N test images.
 // Each image has a token, path and a URL, where the path is 1x1 transparent
 // PNG on disk. The test should call deleteFunc to delete the images from disk
 // at the end of the test.
 // nolint:deadcode,unused
-func NewFakeImageStoreWithFile(t *testing.T, n int) ImageStore {
+func NewFakeImageProviderWithFile(t *testing.T, n int) ImageProvider {
 	var (
 		files []string
-		s     FakeImageStore
+		p     FakeImageProvider
 	)
 
 	t.Cleanup(func() {
@@ -63,7 +63,7 @@ func NewFakeImageStoreWithFile(t *testing.T, n int) ImageStore {
 			t.Fatalf("failed to create test image: %s", err)
 		}
 		files = append(files, file)
-		s.Images = append(s.Images, &Image{
+		p.Images = append(p.Images, &Image{
 			Token:     fmt.Sprintf("test-image-%d", i),
 			Path:      file,
 			URL:       fmt.Sprintf("https://www.example.com/test-image-%d", i),
@@ -71,7 +71,7 @@ func NewFakeImageStoreWithFile(t *testing.T, n int) ImageStore {
 		})
 	}
 
-	return &s
+	return &p
 }
 
 func newTestImage() (string, error) {

--- a/images/testing.go
+++ b/images/testing.go
@@ -9,12 +9,12 @@ import (
 	"time"
 )
 
-type FakeImageProvider struct {
+type FakeProvider struct {
 	Images []*Image
 }
 
 // GetImage returns an image with the same token.
-func (f *FakeImageProvider) GetImage(_ context.Context, token string) (*Image, error) {
+func (f *FakeProvider) GetImage(_ context.Context, token string) (*Image, error) {
 	for _, img := range f.Images {
 		if img.Token == token {
 			return img, nil
@@ -23,10 +23,10 @@ func (f *FakeImageProvider) GetImage(_ context.Context, token string) (*Image, e
 	return nil, ErrImageNotFound
 }
 
-// NewFakeImageProvider returns an image provider with N test images.
+// NewFakeProvider returns an image provider with N test images.
 // Each image has a token and a URL, but does not have a file on disk.
-func NewFakeImageProvider(n int) ImageProvider {
-	p := FakeImageProvider{}
+func NewFakeProvider(n int) Provider {
+	p := FakeProvider{}
 	for i := 1; i <= n; i++ {
 		p.Images = append(p.Images, &Image{
 			Token:     fmt.Sprintf("test-image-%d", i),
@@ -37,15 +37,15 @@ func NewFakeImageProvider(n int) ImageProvider {
 	return &p
 }
 
-// NewFakeImageProviderWithFile returns an image provider with N test images.
+// NewFakeProviderWithFile returns an image provider with N test images.
 // Each image has a token, path and a URL, where the path is 1x1 transparent
 // PNG on disk. The test should call deleteFunc to delete the images from disk
 // at the end of the test.
 // nolint:deadcode,unused
-func NewFakeImageProviderWithFile(t *testing.T, n int) ImageProvider {
+func NewFakeProviderWithFile(t *testing.T, n int) Provider {
 	var (
 		files []string
-		p     FakeImageProvider
+		p     FakeProvider
 	)
 
 	t.Cleanup(func() {

--- a/images/util_test.go
+++ b/images/util_test.go
@@ -29,7 +29,7 @@ func TestWithStoredImages(t *testing.T) {
 			},
 		},
 	}}
-	imageProvider := &FakeImageProvider{Images: []*Image{{
+	imageProvider := &FakeProvider{Images: []*Image{{
 		Token:     "test-image-1",
 		URL:       "https://www.example.com/test-image-1.jpg",
 		CreatedAt: time.Now().UTC(),

--- a/images/util_test.go
+++ b/images/util_test.go
@@ -29,7 +29,7 @@ func TestWithStoredImages(t *testing.T) {
 			},
 		},
 	}}
-	imageStore := &FakeImageStore{Images: []*Image{{
+	imageProvider := &FakeImageProvider{Images: []*Image{{
 		Token:     "test-image-1",
 		URL:       "https://www.example.com/test-image-1.jpg",
 		CreatedAt: time.Now().UTC(),
@@ -45,7 +45,7 @@ func TestWithStoredImages(t *testing.T) {
 	)
 
 	// should iterate all images
-	err = WithStoredImages(ctx, &logging.FakeLogger{}, imageStore, func(index int, image Image) error {
+	err = WithStoredImages(ctx, &logging.FakeLogger{}, imageProvider, func(index int, image Image) error {
 		i++
 		return nil
 	}, alerts...)
@@ -54,7 +54,7 @@ func TestWithStoredImages(t *testing.T) {
 
 	// should iterate just the first image
 	i = 0
-	err = WithStoredImages(ctx, &logging.FakeLogger{}, imageStore, func(index int, image Image) error {
+	err = WithStoredImages(ctx, &logging.FakeLogger{}, imageProvider, func(index int, image Image) error {
 		i++
 		return ErrImagesDone
 	}, alerts...)

--- a/images/utils.go
+++ b/images/utils.go
@@ -16,21 +16,21 @@ import (
 )
 
 const (
-	// ImageProviderTimeout should be used by all callers for calles to `Images`
-	ImageProviderTimeout = 500 * time.Millisecond
+	// ProviderTimeout should be used by all callers for calles to `Images`
+	ProviderTimeout = 500 * time.Millisecond
 )
 
 type forEachImageFunc func(index int, image Image) error
 
 // getImage returns the image for the alert or an error. It returns a nil
 // image if the alert does not have an image token or the image does not exist.
-func getImage(ctx context.Context, l logging.Logger, imageProvider ImageProvider, alert types.Alert) (*Image, error) {
+func getImage(ctx context.Context, l logging.Logger, imageProvider Provider, alert types.Alert) (*Image, error) {
 	token := getTokenFromAnnotations(alert.Annotations)
 	if token == "" {
 		return nil, nil
 	}
 
-	ctx, cancelFunc := context.WithTimeout(ctx, ImageProviderTimeout)
+	ctx, cancelFunc := context.WithTimeout(ctx, ProviderTimeout)
 	defer cancelFunc()
 
 	img, err := imageProvider.GetImage(ctx, token)
@@ -51,7 +51,7 @@ func getImage(ctx context.Context, l logging.Logger, imageProvider ImageProvider
 // the error and not iterate the remaining alerts. A forEachFunc can return ErrImagesDone
 // to stop the iteration of remaining alerts if the intended image or maximum number of
 // images have been found.
-func WithStoredImages(ctx context.Context, l logging.Logger, imageProvider ImageProvider, forEachFunc forEachImageFunc, alerts ...*types.Alert) error {
+func WithStoredImages(ctx context.Context, l logging.Logger, imageProvider Provider, forEachFunc forEachImageFunc, alerts ...*types.Alert) error {
 	for index, alert := range alerts {
 		logger := l.New("alert", alert.String())
 		img, err := getImage(ctx, logger, imageProvider, *alert)

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -37,7 +37,7 @@ import (
 func BuildReceiverIntegrations(
 	receiver GrafanaReceiverConfig,
 	tmpl *templates.Template,
-	img images.ImageProvider,
+	img images.Provider,
 	logger logging.LoggerFactory,
 	newWebhookSender func(n receivers.Metadata) (receivers.WebhookSender, error),
 	newEmailSender func(n receivers.Metadata) (receivers.EmailSender, error),

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -37,7 +37,7 @@ import (
 func BuildReceiverIntegrations(
 	receiver GrafanaReceiverConfig,
 	tmpl *templates.Template,
-	img images.ImageStore,
+	img images.ImageProvider,
 	logger logging.LoggerFactory,
 	newWebhookSender func(n receivers.Metadata) (receivers.WebhookSender, error),
 	newEmailSender func(n receivers.Metadata) (receivers.EmailSender, error),

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -18,7 +18,7 @@ import (
 func TestBuildReceiverIntegrations(t *testing.T) {
 	var orgID = rand.Int63()
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
-	imageStore := &images.FakeImageStore{}
+	imageProvider := &images.FakeImageProvider{}
 	tmpl := templates.ForTests(t)
 
 	webhookFactory := func(n receivers.Metadata) (receivers.WebhookSender, error) {
@@ -62,7 +62,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			return emailFactory(n)
 		}
 
-		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageStore, logger, wh, em, orgID, version)
+		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, logger, wh, em, orgID, version)
 
 		require.NoError(t, err)
 		require.Len(t, integrations, qty)
@@ -85,7 +85,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			return nil, errors.New("bad-test")
 		}
 
-		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageStore, loggerFactory, failingFactory, emailFactory, orgID, version)
+		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, loggerFactory, failingFactory, emailFactory, orgID, version)
 
 		require.Empty(t, integrations)
 		require.NotNil(t, err)
@@ -100,7 +100,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			return nil, errors.New("bad-test")
 		}
 
-		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageStore, loggerFactory, webhookFactory, failingFactory, orgID, version)
+		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, loggerFactory, webhookFactory, failingFactory, orgID, version)
 
 		require.Empty(t, integrations)
 		require.NotNil(t, err)
@@ -110,7 +110,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	t.Run("should not produce any integration if config is empty", func(t *testing.T) {
 		cfg := GrafanaReceiverConfig{Name: "test"}
 
-		integrations, err := BuildReceiverIntegrations(cfg, tmpl, imageStore, loggerFactory, webhookFactory, emailFactory, orgID, version)
+		integrations, err := BuildReceiverIntegrations(cfg, tmpl, imageProvider, loggerFactory, webhookFactory, emailFactory, orgID, version)
 
 		require.NoError(t, err)
 		require.Empty(t, integrations)

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -18,7 +18,7 @@ import (
 func TestBuildReceiverIntegrations(t *testing.T) {
 	var orgID = rand.Int63()
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
-	imageProvider := &images.FakeImageProvider{}
+	imageProvider := &images.FakeProvider{}
 	tmpl := templates.ForTests(t)
 
 	webhookFactory := func(n receivers.Metadata) (receivers.WebhookSender, error) {

--- a/receivers/alertmanager/alertmanager.go
+++ b/receivers/alertmanager/alertmanager.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/alerting/receivers"
 )
 
-func New(cfg Config, meta receivers.Metadata, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		images:   images,
@@ -25,7 +25,7 @@ func New(cfg Config, meta receivers.Metadata, images images.ImageStore, logger l
 // Notifier sends alert notifications to the alert manager
 type Notifier struct {
 	*receivers.Base
-	images   images.ImageStore
+	images   images.ImageProvider
 	settings Config
 	logger   logging.Logger
 }

--- a/receivers/alertmanager/alertmanager.go
+++ b/receivers/alertmanager/alertmanager.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/alerting/receivers"
 )
 
-func New(cfg Config, meta receivers.Metadata, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		images:   images,
@@ -25,7 +25,7 @@ func New(cfg Config, meta receivers.Metadata, images images.ImageProvider, logge
 // Notifier sends alert notifications to the alert manager
 type Notifier struct {
 	*receivers.Base
-	images   images.ImageProvider
+	images   images.Provider
 	settings Config
 	logger   logging.Logger
 }

--- a/receivers/alertmanager/alertmanager_test.go
+++ b/receivers/alertmanager/alertmanager_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNotify(t *testing.T) {
-	imageStore := images.NewFakeImageStore(1)
+	imageProvider := images.NewFakeImageProvider(1)
 	singleURLConfig := Config{
 		URLs: []*url.URL{
 			receiversTesting.ParseURLUnsafe("https://alertmanager.com/api/v1/alerts"),
@@ -93,7 +93,7 @@ func TestNotify(t *testing.T) {
 					UID:                   "",
 					DisableResolveMessage: false,
 				},
-				images:   imageStore,
+				images:   imageProvider,
 				settings: c.settings,
 				logger:   &logging.FakeLogger{},
 			}

--- a/receivers/alertmanager/alertmanager_test.go
+++ b/receivers/alertmanager/alertmanager_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNotify(t *testing.T) {
-	imageProvider := images.NewFakeImageProvider(1)
+	imageProvider := images.NewFakeProvider(1)
 	singleURLConfig := Config{
 		URLs: []*url.URL{
 			receiversTesting.ParseURLUnsafe("https://alertmanager.com/api/v1/alerts"),

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -68,7 +68,7 @@ type Notifier struct {
 	*receivers.Base
 	log        logging.Logger
 	ns         receivers.WebhookSender
-	images     images.ImageStore
+	images     images.ImageProvider
 	tmpl       *templates.Template
 	settings   Config
 	appVersion string
@@ -82,7 +82,7 @@ type discordAttachment struct {
 	state     model.AlertStatus
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -68,7 +68,7 @@ type Notifier struct {
 	*receivers.Base
 	log        logging.Logger
 	ns         receivers.WebhookSender
-	images     images.ImageProvider
+	images     images.Provider
 	tmpl       *templates.Template
 	settings   Config
 	appVersion string
@@ -82,7 +82,7 @@ type discordAttachment struct {
 	state     model.AlertStatus
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,

--- a/receivers/discord/discord_test.go
+++ b/receivers/discord/discord_test.go
@@ -345,7 +345,7 @@ func TestNotify(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			webhookSender := receivers.MockNotificationService()
-			imageStore := &images.UnavailableImageStore{}
+			imageProvider := &images.UnavailableImageProvider{}
 			dn := &Notifier{
 				Base: &receivers.Base{
 					Name:                  "",
@@ -357,7 +357,7 @@ func TestNotify(t *testing.T) {
 				ns:         webhookSender,
 				tmpl:       tmpl,
 				settings:   c.settings,
-				images:     imageStore,
+				images:     imageProvider,
 				appVersion: appVersion,
 			}
 

--- a/receivers/discord/discord_test.go
+++ b/receivers/discord/discord_test.go
@@ -345,7 +345,7 @@ func TestNotify(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			webhookSender := receivers.MockNotificationService()
-			imageProvider := &images.UnavailableImageProvider{}
+			imageProvider := &images.UnavailableProvider{}
 			dn := &Notifier{
 				Base: &receivers.Base{
 					Name:                  "",

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -21,12 +21,12 @@ type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
 	ns       receivers.EmailSender
-	images   images.ImageProvider
+	images   images.Provider
 	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.EmailSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.EmailSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -21,12 +21,12 @@ type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
 	ns       receivers.EmailSender
-	images   images.ImageStore
+	images   images.ImageProvider
 	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.EmailSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.EmailSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/email/email_test.go
+++ b/receivers/email/email_test.go
@@ -46,7 +46,7 @@ func TestNotify(t *testing.T) {
 			ns:       emailSender,
 			tmpl:     tmpl,
 			settings: settings,
-			images:   &images.UnavailableImageStore{},
+			images:   &images.UnavailableImageProvider{},
 		}
 
 		alerts := []*types.Alert{

--- a/receivers/email/email_test.go
+++ b/receivers/email/email_test.go
@@ -46,7 +46,7 @@ func TestNotify(t *testing.T) {
 			ns:       emailSender,
 			tmpl:     tmpl,
 			settings: settings,
-			images:   &images.UnavailableImageProvider{},
+			images:   &images.UnavailableProvider{},
 		}
 
 		alerts := []*types.Alert{

--- a/receivers/googlechat/googlechat.go
+++ b/receivers/googlechat/googlechat.go
@@ -21,7 +21,7 @@ type Notifier struct {
 	*receivers.Base
 	log        logging.Logger
 	ns         receivers.WebhookSender
-	images     images.ImageStore
+	images     images.ImageProvider
 	tmpl       *templates.Template
 	settings   Config
 	appVersion string
@@ -32,7 +32,7 @@ var (
 	timeNow = time.Now
 )
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,

--- a/receivers/googlechat/googlechat.go
+++ b/receivers/googlechat/googlechat.go
@@ -21,7 +21,7 @@ type Notifier struct {
 	*receivers.Base
 	log        logging.Logger
 	ns         receivers.WebhookSender
-	images     images.ImageProvider
+	images     images.Provider
 	tmpl       *templates.Template
 	settings   Config
 	appVersion string
@@ -32,7 +32,7 @@ var (
 	timeNow = time.Now
 )
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,

--- a/receivers/googlechat/googlechat_test.go
+++ b/receivers/googlechat/googlechat_test.go
@@ -495,7 +495,7 @@ func TestNotify(t *testing.T) {
 			tmpl.ExternalURL = externalURL
 
 			webhookSender := receivers.MockNotificationService()
-			imageStore := &images.UnavailableImageStore{}
+			imageProvider := &images.UnavailableImageProvider{}
 
 			pn := &Notifier{
 				Base: &receivers.Base{
@@ -508,7 +508,7 @@ func TestNotify(t *testing.T) {
 				ns:         webhookSender,
 				tmpl:       tmpl,
 				settings:   c.settings,
-				images:     imageStore,
+				images:     imageProvider,
 				appVersion: appVersion,
 			}
 

--- a/receivers/googlechat/googlechat_test.go
+++ b/receivers/googlechat/googlechat_test.go
@@ -495,7 +495,7 @@ func TestNotify(t *testing.T) {
 			tmpl.ExternalURL = externalURL
 
 			webhookSender := receivers.MockNotificationService()
-			imageProvider := &images.UnavailableImageProvider{}
+			imageProvider := &images.UnavailableProvider{}
 
 			pn := &Notifier{
 				Base: &receivers.Base{

--- a/receivers/kafka/kafka.go
+++ b/receivers/kafka/kafka.go
@@ -49,13 +49,13 @@ type kafkaContext struct {
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageProvider
+	images   images.Provider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -268,7 +268,7 @@ func buildState(as ...*types.Alert) receivers.AlertStateType {
 	return receivers.AlertStateAlerting
 }
 
-func buildContextImages(ctx context.Context, l logging.Logger, imageProvider images.ImageProvider, as ...*types.Alert) []kafkaContext {
+func buildContextImages(ctx context.Context, l logging.Logger, imageProvider images.Provider, as ...*types.Alert) []kafkaContext {
 	var contexts []kafkaContext
 	_ = images.WithStoredImages(ctx, l, imageProvider,
 		func(_ int, image images.Image) error {

--- a/receivers/kafka/kafka.go
+++ b/receivers/kafka/kafka.go
@@ -49,13 +49,13 @@ type kafkaContext struct {
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageStore
+	images   images.ImageProvider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,
@@ -268,9 +268,9 @@ func buildState(as ...*types.Alert) receivers.AlertStateType {
 	return receivers.AlertStateAlerting
 }
 
-func buildContextImages(ctx context.Context, l logging.Logger, imageStore images.ImageStore, as ...*types.Alert) []kafkaContext {
+func buildContextImages(ctx context.Context, l logging.Logger, imageProvider images.ImageProvider, as ...*types.Alert) []kafkaContext {
 	var contexts []kafkaContext
-	_ = images.WithStoredImages(ctx, l, imageStore,
+	_ = images.WithStoredImages(ctx, l, imageProvider,
 		func(_ int, image images.Image) error {
 			if image.URL != "" {
 				contexts = append(contexts, kafkaContext{

--- a/receivers/kafka/kafka_test.go
+++ b/receivers/kafka/kafka_test.go
@@ -20,7 +20,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageStore(2)
+	images := images2.NewFakeImageProvider(2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/kafka/kafka_test.go
+++ b/receivers/kafka/kafka_test.go
@@ -20,7 +20,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageProvider(2)
+	images := images2.NewFakeProvider(2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -34,11 +34,11 @@ type Notifier struct {
 	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageStore
+	images   images.ImageProvider
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -34,11 +34,11 @@ type Notifier struct {
 	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageProvider
+	images   images.Provider
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/opsgenie/opsgenie_test.go
+++ b/receivers/opsgenie/opsgenie_test.go
@@ -290,7 +290,7 @@ func TestNotify(t *testing.T) {
 				ns:       webhookSender,
 				tmpl:     tmpl,
 				settings: c.settings,
-				images:   &images.UnavailableImageProvider{},
+				images:   &images.UnavailableProvider{},
 			}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")

--- a/receivers/opsgenie/opsgenie_test.go
+++ b/receivers/opsgenie/opsgenie_test.go
@@ -290,7 +290,7 @@ func TestNotify(t *testing.T) {
 				ns:       webhookSender,
 				tmpl:     tmpl,
 				settings: c.settings,
-				images:   &images.UnavailableImageStore{},
+				images:   &images.UnavailableImageProvider{},
 			}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -45,12 +45,12 @@ type Notifier struct {
 	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageStore
+	images   images.ImageProvider
 	settings Config
 }
 
 // New is the constructor for the PagerDuty notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/pagerduty/pagerduty.go
+++ b/receivers/pagerduty/pagerduty.go
@@ -45,12 +45,12 @@ type Notifier struct {
 	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageProvider
+	images   images.Provider
 	settings Config
 }
 
 // New is the constructor for the PagerDuty notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -42,13 +42,13 @@ type Notifier struct {
 	*receivers.Base
 	tmpl     *templates.Template
 	log      logging.Logger
-	images   images.ImageStore
+	images   images.ImageProvider
 	ns       receivers.WebhookSender
 	settings Config
 }
 
 // New is the constructor for the pushover notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -42,13 +42,13 @@ type Notifier struct {
 	*receivers.Base
 	tmpl     *templates.Template
 	log      logging.Logger
-	images   images.ImageProvider
+	images   images.Provider
 	ns       receivers.WebhookSender
 	settings Config
 }
 
 // New is the constructor for the pushover notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/pushover/pushover_test.go
+++ b/receivers/pushover/pushover_test.go
@@ -26,7 +26,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageStoreWithFile(t, 2)
+	images := images2.NewFakeImageProviderWithFile(t, 2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/pushover/pushover_test.go
+++ b/receivers/pushover/pushover_test.go
@@ -26,7 +26,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageProviderWithFile(t, 2)
+	images := images2.NewFakeProviderWithFile(t, 2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/sensugo/sensugo.go
+++ b/receivers/sensugo/sensugo.go
@@ -24,14 +24,14 @@ var (
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageProvider
+	images   images.Provider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
 // New is the constructor for the SensuGo notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/sensugo/sensugo.go
+++ b/receivers/sensugo/sensugo.go
@@ -24,14 +24,14 @@ var (
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageStore
+	images   images.ImageProvider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
 // New is the constructor for the SensuGo notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/sensugo/sensugo_test.go
+++ b/receivers/sensugo/sensugo_test.go
@@ -28,7 +28,7 @@ func TestNotify(t *testing.T) {
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
 
-	images := images2.NewFakeImageStore(2)
+	images := images2.NewFakeImageProvider(2)
 
 	cases := []struct {
 		name        string

--- a/receivers/sensugo/sensugo_test.go
+++ b/receivers/sensugo/sensugo_test.go
@@ -28,7 +28,7 @@ func TestNotify(t *testing.T) {
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
 
-	images := images2.NewFakeImageProvider(2)
+	images := images2.NewFakeProvider(2)
 
 	cases := []struct {
 		name        string

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -67,7 +67,7 @@ type Notifier struct {
 	*receivers.Base
 	log           logging.Logger
 	tmpl          *templates.Template
-	images        images.ImageStore
+	images        images.ImageProvider
 	webhookSender receivers.WebhookSender
 	sendFn        sendFunc
 	settings      Config
@@ -90,7 +90,7 @@ func uploadURL(s Config) (string, error) {
 	return u.String(), nil
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		settings: cfg,

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -67,7 +67,7 @@ type Notifier struct {
 	*receivers.Base
 	log           logging.Logger
 	tmpl          *templates.Template
-	images        images.ImageProvider
+	images        images.Provider
 	webhookSender receivers.WebhookSender
 	sendFn        sendFunc
 	settings      Config
@@ -90,7 +90,7 @@ func uploadURL(s Config) (string, error) {
 	return u.String(), nil
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		settings: cfg,

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -478,7 +478,7 @@ func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequest
 		}
 	})
 
-	images := &images.FakeImageProvider{
+	images := &images.FakeProvider{
 		Images: []*images.Image{{
 			Token: "image-on-disk",
 			Path:  f.Name(),

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -478,7 +478,7 @@ func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequest
 		}
 	})
 
-	images := &images.FakeImageStore{
+	images := &images.FakeImageProvider{
 		Images: []*images.Image{{
 			Token: "image-on-disk",
 			Path:  f.Name(),

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -229,11 +229,11 @@ type Notifier struct {
 	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageStore
+	images   images.ImageProvider
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -229,11 +229,11 @@ type Notifier struct {
 	tmpl     *templates.Template
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageProvider
+	images   images.Provider
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/teams/teams_test.go
+++ b/receivers/teams/teams_test.go
@@ -265,7 +265,7 @@ func TestNotify(t *testing.T) {
 				ns:       webhookSender,
 				tmpl:     tmpl,
 				settings: c.settings,
-				images:   &images.UnavailableImageStore{},
+				images:   &images.UnavailableImageProvider{},
 			}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")

--- a/receivers/teams/teams_test.go
+++ b/receivers/teams/teams_test.go
@@ -265,7 +265,7 @@ func TestNotify(t *testing.T) {
 				ns:       webhookSender,
 				tmpl:     tmpl,
 				settings: c.settings,
-				images:   &images.UnavailableImageProvider{},
+				images:   &images.UnavailableProvider{},
 			}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -31,14 +31,14 @@ const telegramMaxMessageLenRunes = 4096
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageProvider
+	images   images.Provider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
 // New is the constructor for the Telegram notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		tmpl:     template,

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -31,14 +31,14 @@ const telegramMaxMessageLenRunes = 4096
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageStore
+	images   images.ImageProvider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
 // New is the constructor for the Telegram notifier
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		tmpl:     template,

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
-	images := images2.NewFakeImageStoreWithFile(t, 2)
+	images := images2.NewFakeImageProviderWithFile(t, 2)
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
-	images := images2.NewFakeImageProviderWithFile(t, 2)
+	images := images2.NewFakeProviderWithFile(t, 2)
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -25,13 +25,13 @@ var (
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageProvider
+	images   images.Provider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/threema/threema.go
+++ b/receivers/threema/threema.go
@@ -25,13 +25,13 @@ var (
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
-	images   images.ImageStore
+	images   images.ImageProvider
 	ns       receivers.WebhookSender
 	tmpl     *templates.Template
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		log:      logger,

--- a/receivers/threema/threema_test.go
+++ b/receivers/threema/threema_test.go
@@ -19,7 +19,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageStore(2)
+	images := images2.NewFakeImageProvider(2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/threema/threema_test.go
+++ b/receivers/threema/threema_test.go
@@ -19,7 +19,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageProvider(2)
+	images := images2.NewFakeProvider(2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/victorops/victorops.go
+++ b/receivers/victorops/victorops.go
@@ -31,7 +31,7 @@ const (
 type Notifier struct {
 	*receivers.Base
 	log        logging.Logger
-	images     images.ImageProvider
+	images     images.Provider
 	ns         receivers.WebhookSender
 	tmpl       *templates.Template
 	settings   Config
@@ -40,7 +40,7 @@ type Notifier struct {
 
 // New creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,

--- a/receivers/victorops/victorops.go
+++ b/receivers/victorops/victorops.go
@@ -31,7 +31,7 @@ const (
 type Notifier struct {
 	*receivers.Base
 	log        logging.Logger
-	images     images.ImageStore
+	images     images.ImageProvider
 	ns         receivers.WebhookSender
 	tmpl       *templates.Template
 	settings   Config
@@ -40,7 +40,7 @@ type Notifier struct {
 
 // New creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, appVersion string) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
 		Base:       receivers.NewBase(meta),
 		log:        logger,

--- a/receivers/victorops/victorops_test.go
+++ b/receivers/victorops/victorops_test.go
@@ -22,7 +22,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageStore(2)
+	images := images2.NewFakeImageProvider(2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/victorops/victorops_test.go
+++ b/receivers/victorops/victorops_test.go
@@ -22,7 +22,7 @@ import (
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
 
-	images := images2.NewFakeImageProvider(2)
+	images := images2.NewFakeProvider(2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/webex/webex.go
+++ b/receivers/webex/webex.go
@@ -19,13 +19,13 @@ type Notifier struct {
 	*receivers.Base
 	ns       receivers.WebhookSender
 	log      logging.Logger
-	images   images.ImageProvider
+	images   images.Provider
 	tmpl     *templates.Template
 	orgID    int64
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, orgID int64) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, orgID int64) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		orgID:    orgID,

--- a/receivers/webex/webex.go
+++ b/receivers/webex/webex.go
@@ -19,13 +19,13 @@ type Notifier struct {
 	*receivers.Base
 	ns       receivers.WebhookSender
 	log      logging.Logger
-	images   images.ImageStore
+	images   images.ImageProvider
 	tmpl     *templates.Template
 	orgID    int64
 	settings Config
 }
 
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, orgID int64) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, orgID int64) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		orgID:    orgID,

--- a/receivers/webex/webex_test.go
+++ b/receivers/webex/webex_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
-	images := images2.NewFakeImageStoreWithFile(t, 2)
+	images := images2.NewFakeImageProviderWithFile(t, 2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/webex/webex_test.go
+++ b/receivers/webex/webex_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNotify(t *testing.T) {
 	tmpl := templates.ForTests(t)
-	images := images2.NewFakeImageProviderWithFile(t, 2)
+	images := images2.NewFakeProviderWithFile(t, 2)
 
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -21,7 +21,7 @@ type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageStore
+	images   images.ImageProvider
 	tmpl     *templates.Template
 	orgID    int64
 	settings Config
@@ -29,7 +29,7 @@ type Notifier struct {
 
 // New is the constructor for
 // the WebHook notifier.
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageStore, logger logging.Logger, orgID int64) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, orgID int64) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		orgID:    orgID,

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -21,7 +21,7 @@ type Notifier struct {
 	*receivers.Base
 	log      logging.Logger
 	ns       receivers.WebhookSender
-	images   images.ImageProvider
+	images   images.Provider
 	tmpl     *templates.Template
 	orgID    int64
 	settings Config
@@ -29,7 +29,7 @@ type Notifier struct {
 
 // New is the constructor for
 // the WebHook notifier.
-func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.ImageProvider, logger logging.Logger, orgID int64) *Notifier {
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, orgID int64) *Notifier {
 	return &Notifier{
 		Base:     receivers.NewBase(meta),
 		orgID:    orgID,

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -371,7 +371,7 @@ func TestNotify(t *testing.T) {
 				ns:       webhookSender,
 				tmpl:     tmpl,
 				settings: c.settings,
-				images:   &images.UnavailableImageProvider{},
+				images:   &images.UnavailableProvider{},
 				orgID:    1,
 			}
 

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -371,7 +371,7 @@ func TestNotify(t *testing.T) {
 				ns:       webhookSender,
 				tmpl:     tmpl,
 				settings: c.settings,
-				images:   &images.UnavailableImageStore{},
+				images:   &images.UnavailableImageProvider{},
 				orgID:    1,
 			}
 


### PR DESCRIPTION
This PR renames our `images.ImageStore` to `images.Provider` for two main reasons:
- This interface is supposed to provide images. It does not store them, nor does it interact with the DB.
- This new naming avoids confusion with other similarly named interfaces in `grafana/grafana` like `ImageStore` (which interacts with the DB) and `ImageService`.

This interface will be refactored to support the use cases described in https://github.com/grafana/alerting-squad/issues/480

The number of modified files is pretty big, but this is just a rename, no functionality has been changed.