### PR TITLE
[9.5.x] Slack: assume any non-JSON response is an incoming webhook (#67)

### DIFF
--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -205,11 +205,11 @@ var sendSlackRequest = func(ctx context.Context, req *http.Request, logger loggi
 	}
 
 	content := resp.Header.Get("Content-Type")
-	// If the response is text/html it could be the response to an incoming webhook
-	if strings.HasPrefix(content, "text/html") {
-		return handleSlackIncomingWebhookResponse(resp, logger)
+	if strings.HasPrefix(content, "application/json") {
+		return handleSlackJSONResponse(resp, logger)
 	}
-	return handleSlackJSONResponse(resp, logger)
+	// If the response is not JSON it could be the response to an incoming webhook
+	return handleSlackIncomingWebhookResponse(resp, logger)
 }
 
 func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logger) (string, error) {


### PR DESCRIPTION
backport of commit https://github.com/grafana/alerting/commit/c151a6de9652b347d4e4832423846fae67ba7427 from https://github.com/grafana/alerting/pull/67 to branch 9.5.x 