### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
Enables dependabot on this repository.

For now, upgrade everything. We can restrict this in the future as needed.

contrib https://github.com/grafana/alerting-squad/issues/489