### PR TITLE
Update Discord integration to accept URL as secure setting

### DIFF
--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -402,7 +402,7 @@ func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver 
 		}
 		result.DingdingConfigs = append(result.DingdingConfigs, newNotifierConfig(receiver, cfg))
 	case "discord":
-		cfg, err := discord.NewConfig(receiver.Settings)
+		cfg, err := discord.NewConfig(receiver.Settings, decryptFn)
 		if err != nil {
 			return err
 		}

--- a/receivers/discord/config.go
+++ b/receivers/discord/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -16,12 +17,13 @@ type Config struct {
 	UseDiscordUsername bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty"`
 }
 
-func NewConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
+	settings.WebhookURL = decryptFn("url", settings.WebhookURL)
 	if settings.WebhookURL == "" {
 		return Config{}, errors.New("could not find webhook url property in settings")
 	}


### PR DESCRIPTION
Provisioning documentation mentions Discord URL as secure setting, but in fact it is not.

Partially fixes https://github.com/grafana/grafana/issues/40148. This will need some changes in Grafana too