### PR TITLE
Silence Url to contain orgId parameter

### DIFF
--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -160,7 +160,7 @@ Labels:
 Annotations:
  - ann1 = annv1
 Source: http://localhost/alert1?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1
 Dashboard: http://localhost/grafana/d/dbuid123?orgId=1
 Panel: http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123
 
@@ -180,7 +180,7 @@ Labels:
 Annotations:
  - ann1 = annv3
 Source: http://localhost/alert3?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3&orgId=1
 
 
 **Resolved**
@@ -192,7 +192,7 @@ Labels:
 Annotations:
  - ann1 = annv4
 Source: http://localhost/alert4?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4&orgId=1
 Dashboard: http://localhost/grafana/d/dbuid456?orgId=1
 Panel: http://localhost/grafana/d/dbuid456?orgId=1&viewPanel=puid456
 
@@ -212,7 +212,7 @@ Labels:
 Annotations:
  - ann1 = annv6
 Source: http://localhost/alert6?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval6
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval6&orgId=1
 `,
 		},
 		{
@@ -229,7 +229,7 @@ Annotations:
 
 Source: [http://localhost/alert1?orgId=1](http://localhost/alert1?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1)
 
 Dashboard: [http://localhost/grafana/d/dbuid123?orgId=1](http://localhost/grafana/d/dbuid123?orgId=1)
 
@@ -261,7 +261,7 @@ Annotations:
 
 Source: [http://localhost/alert3?orgId=1](http://localhost/alert3?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3&orgId=1)
 
 
 
@@ -278,7 +278,7 @@ Annotations:
 
 Source: [http://localhost/alert4?orgId=1](http://localhost/alert4?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4&orgId=1)
 
 Dashboard: [http://localhost/grafana/d/dbuid456?orgId=1](http://localhost/grafana/d/dbuid456?orgId=1)
 
@@ -310,7 +310,7 @@ Annotations:
 
 Source: [http://localhost/alert6?orgId=1](http://localhost/alert6?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval6](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval6)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval6&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval6&orgId=1)
 
 
 `,

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -147,9 +147,11 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	}
 
 	u.RawQuery = query.Encode()
-
-	extended.SilenceURL = u.String()
-
+	if len(orgID) > 0 {
+		extended.SilenceURL = setOrgIDQueryParam(u, orgID)
+	} else {
+		extended.SilenceURL = u.String()
+	}
 	return extended
 }
 


### PR DESCRIPTION
Similar to #75. Currently, the Silence URL does not contain the parameter orgId; therefore, the user can create a silence in the wrong organization.
This PR fixes this bug by appending orgId to silence URL following the same logic applicable to other URLs.

Related to https://github.com/grafana/grafana/issues/66427