### PR TITLE
Alerting: Add debug level logs before sending alerts to Alertmanager

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -520,6 +520,14 @@ func (am *GrafanaAlertmanager) PutAlerts(postableAlerts amv2.PostableAlerts) err
 			continue
 		}
 
+		level.Debug(am.logger).Log("msg",
+			"Putting alert",
+			"alert",
+			alert,
+			"starts_at",
+			alert.StartsAt,
+			"ends_at",
+			alert.EndsAt)
 		alerts = append(alerts, alert)
 	}
 


### PR DESCRIPTION
This commit adds debug level logging for each alert before it is sent to the Alertmanager. The information logged is the fingerprint of the alert, the StartsAt timestamp and the EndsAt timestamp. The same fingerprint is also logged in the dispatcher of the Alertmanger for each alert received.

Here is an example of how it looks:

```
DEBUG[06-20|12:34:30] Putting alert                            logger=ngalert.notifier.alertmanager LOG15_ERROR= component=alertmanager orgID=1 alert=Test[7145c5e][active] starts_at=2023-06-20T11:43:00+01:00 ends_at=2023-06-20T12:36:00+01:00
DEBUG[06-20|12:34:30] Received alert                           logger=ngalert.notifier.alertmanager LOG15_ERROR= component=alertmanager orgID=1 component=dispatcher alert=Test[7145c5e][active]
```

Fixes https://github.com/grafana/support-escalations/issues/6191