### PR TITLE
Allow slack GeneratorURL as link

### DIFF
--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -284,12 +284,12 @@ func handleSlackJSONResponse(resp *http.Response, logger logging.Logger) (string
 }
 
 func (sn *Notifier) commonAlertGeneratorURL(ctx context.Context, alerts []*types.Alert) bool {
-	if len(alerts[0].GeneratorURL) == 0  {
+	if len(alerts[0].GeneratorURL) == 0 {
 		return false
 	}
-	firstUrl := alerts[0].GeneratorURL
+	firstURL := alerts[0].GeneratorURL
 	for _, a := range alerts {
-		if a.GeneratorURL != firstUrl {
+		if a.GeneratorURL != firstURL {
 			return false
 		}
 	}

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -263,8 +263,8 @@ func TestNotify_PostMessage(t *testing.T) {
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-				Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
 				GeneratorURL: "http://localhost/alerting/f23a674b-bb6b-46df-8723-12345678test",
 			},
 		}},
@@ -303,14 +303,14 @@ func TestNotify_PostMessage(t *testing.T) {
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-				Annotations: model.LabelSet{"ann1": "annv1"},
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations:  model.LabelSet{"ann1": "annv1"},
 				GeneratorURL: "http://localhost/alerting/f23a674b-bb6b-46df-8723-12345678test",
 			},
 		}, {
 			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-				Annotations: model.LabelSet{"ann1": "annv2"},
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+				Annotations:  model.LabelSet{"ann1": "annv2"},
 				GeneratorURL: "http://localhost/alerting/f23a674b-bb6b-46df-8723-1234567test2",
 			},
 		}},
@@ -349,14 +349,14 @@ func TestNotify_PostMessage(t *testing.T) {
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-				Annotations: model.LabelSet{"ann1": "annv1"},
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations:  model.LabelSet{"ann1": "annv1"},
 				GeneratorURL: "http://localhost/alerting/f23a674b-bb6b-46df-8723-12345678test",
 			},
 		}, {
 			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-				Annotations: model.LabelSet{"ann1": "annv2"},
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+				Annotations:  model.LabelSet{"ann1": "annv2"},
 				GeneratorURL: "http://localhost/alerting/f23a674b-bb6b-46df-8723-12345678test",
 			},
 		}},


### PR DESCRIPTION
This PR address issue: https://github.com/grafana/alerting/issues/96

This will update the Slack responder to update the link under the following circumstances:
* A single alert is fired and it as a GeneratorURL set (this should always be the case)
* Multiple alerts are fired but they all have the same Generator URL (grouped by alertname)
