### PR TITLE
Skip errors for invalid receivers if they are unused in any notification policy

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -383,7 +383,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg Configuration) (err error) {
 			// If an invalid receiver configuration somehow passed validation but isn't actually used anywhere,
 			// we just log the event and move on. It's not necessary to fail the entire configuration reload.
 			if _, ok := usedReceivers[apiReceiver.Name]; !ok {
-				level.Info(am.logger).Log("msg", "Unused receiver has an error. Skipping.", "receiver", apiReceiver.Name, "error", err)
+				level.Warn(am.logger).Log("msg", "Unused receiver has a validation error, excluding from Alertmanager configuration.", "receiver", apiReceiver.Name, "error", err)
 				continue
 			}
 			return err

--- a/notify/routes.go
+++ b/notify/routes.go
@@ -1,0 +1,29 @@
+package notify
+
+import "github.com/prometheus/alertmanager/config"
+
+type Route = config.Route
+
+// AllReceivers will recursively walk a routing tree and return the set of all the
+// referenced receiver names.
+func AllReceivers(route *Route) map[string]struct{} {
+	return allReceivers(route, nil)
+}
+
+func allReceivers(route *Route, res map[string]struct{}) map[string]struct{} {
+	if res == nil {
+		res = make(map[string]struct{})
+	}
+	if route == nil {
+		return res
+	}
+
+	if route.Receiver != "" {
+		res[route.Receiver] = struct{}{}
+	}
+
+	for _, subRoute := range route.Routes {
+		allReceivers(subRoute, res)
+	}
+	return res
+}

--- a/notify/routes_test.go
+++ b/notify/routes_test.go
@@ -1,0 +1,38 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AllReceivers(t *testing.T) {
+	input := &Route{
+		Receiver: "foo",
+		Routes: []*Route{
+			{
+				Receiver: "bar",
+				Routes: []*Route{
+					{
+						Receiver: "bazz",
+					},
+				},
+			},
+			{
+				Receiver: "buzz",
+			},
+		},
+	}
+
+	require.Equal(t, map[string]struct{}{
+		"foo":  {},
+		"bar":  {},
+		"bazz": {},
+		"buzz": {},
+	}, AllReceivers(input))
+
+	// test empty
+	empty := make(map[string]struct{})
+	emptyRoute := &Route{}
+	require.Equal(t, empty, AllReceivers(emptyRoute))
+}


### PR DESCRIPTION
Currently, if an invalid receiver config manages to pass API boundary validations the embedded alertmanager fails to start. This happens even if the receiver is not referenced by any notification policy.

This change will ignore invalid receivers if they are unused and consider such configurations valid.

Relates to https://github.com/grafana/grafana/issues/71466

Grafana-side changes:

- https://github.com/grafana/grafana/pull/71500
- https://github.com/grafana/grafana/pull/71499