### PR TITLE
Make integration configs for testing publicly available

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -33,8 +33,8 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 
 	getFullConfig := func(t *testing.T) (GrafanaReceiverConfig, int) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
-		for notifierType, cfg := range allKnownConfigs {
-			recCfg.Integrations = append(recCfg.Integrations, cfg.getRawNotifierConfig(notifierType))
+		for notifierType, cfg := range AllKnownConfigsForTesting {
+			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(notifierType))
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, GetDecryptedValueFnForTesting)
 		require.NoError(t, err)

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -2,12 +2,34 @@ package notify
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/prometheus/alertmanager/types"
 
+	"github.com/grafana/alerting/receivers/alertmanager"
+	"github.com/grafana/alerting/receivers/dinding"
+	"github.com/grafana/alerting/receivers/discord"
+	"github.com/grafana/alerting/receivers/email"
+	"github.com/grafana/alerting/receivers/googlechat"
+	"github.com/grafana/alerting/receivers/kafka"
+	"github.com/grafana/alerting/receivers/line"
+	"github.com/grafana/alerting/receivers/opsgenie"
+	"github.com/grafana/alerting/receivers/pagerduty"
+	"github.com/grafana/alerting/receivers/pushover"
+	"github.com/grafana/alerting/receivers/sensugo"
+	"github.com/grafana/alerting/receivers/slack"
+	"github.com/grafana/alerting/receivers/teams"
+	"github.com/grafana/alerting/receivers/telegram"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/receivers/threema"
+	"github.com/grafana/alerting/receivers/victorops"
+	"github.com/grafana/alerting/receivers/webex"
+	"github.com/grafana/alerting/receivers/webhook"
+	"github.com/grafana/alerting/receivers/wecom"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -90,4 +112,105 @@ func (f *fakeNotifier) SendResolved() bool {
 
 func GetDecryptedValueFnForTesting(_ context.Context, sjd map[string][]byte, key string, fallback string) string {
 	return receiversTesting.DecryptForTesting(sjd)(key, fallback)
+}
+
+var AllKnownConfigsForTesting = map[string]NotifierConfigTest{
+	"prometheus-alertmanager": {
+		NotifierType: "prometheus-alertmanager",
+		Config:       alertmanager.FullValidConfigForTesting,
+		Secrets:      alertmanager.FullValidSecretsForTesting,
+	},
+	"dingding": {NotifierType: "dingding",
+		Config: dinding.FullValidConfigForTesting,
+	},
+	"discord": {NotifierType: "discord",
+		Config: discord.FullValidConfigForTesting,
+	},
+	"email": {NotifierType: "email",
+		Config: email.FullValidConfigForTesting,
+	},
+	"googlechat": {NotifierType: "googlechat",
+		Config: googlechat.FullValidConfigForTesting,
+	},
+	"kafka": {NotifierType: "kafka",
+		Config:  kafka.FullValidConfigForTesting,
+		Secrets: kafka.FullValidSecretsForTesting,
+	},
+	"line": {NotifierType: "line",
+		Config:  line.FullValidConfigForTesting,
+		Secrets: line.FullValidSecretsForTesting,
+	},
+	"opsgenie": {NotifierType: "opsgenie",
+		Config:  opsgenie.FullValidConfigForTesting,
+		Secrets: opsgenie.FullValidSecretsForTesting,
+	},
+	"pagerduty": {NotifierType: "pagerduty",
+		Config:  pagerduty.FullValidConfigForTesting,
+		Secrets: pagerduty.FullValidSecretsForTesting,
+	},
+	"pushover": {NotifierType: "pushover",
+		Config:  pushover.FullValidConfigForTesting,
+		Secrets: pushover.FullValidSecretsForTesting,
+	},
+	"sensugo": {NotifierType: "sensugo",
+		Config:  sensugo.FullValidConfigForTesting,
+		Secrets: sensugo.FullValidSecretsForTesting,
+	},
+	"slack": {NotifierType: "slack",
+		Config:  slack.FullValidConfigForTesting,
+		Secrets: slack.FullValidSecretsForTesting,
+	},
+	"teams": {NotifierType: "teams",
+		Config: teams.FullValidConfigForTesting,
+	},
+	"telegram": {NotifierType: "telegram",
+		Config:  telegram.FullValidConfigForTesting,
+		Secrets: telegram.FullValidSecretsForTesting,
+	},
+	"threema": {NotifierType: "threema",
+		Config:  threema.FullValidConfigForTesting,
+		Secrets: threema.FullValidSecretsForTesting,
+	},
+	"victorops": {NotifierType: "victorops",
+		Config: victorops.FullValidConfigForTesting,
+	},
+	"webhook": {NotifierType: "webhook",
+		Config:  webhook.FullValidConfigForTesting,
+		Secrets: webhook.FullValidSecretsForTesting,
+	},
+	"wecom": {NotifierType: "wecom",
+		Config:  wecom.FullValidConfigForTesting,
+		Secrets: wecom.FullValidSecretsForTesting,
+	},
+	"webex": {NotifierType: "webex",
+		Config:  webex.FullValidConfigForTesting,
+		Secrets: webex.FullValidSecretsForTesting,
+	},
+}
+
+type NotifierConfigTest struct {
+	NotifierType string
+	Config       string
+	Secrets      string
+}
+
+func (n NotifierConfigTest) GetRawNotifierConfig(name string) *GrafanaIntegrationConfig {
+	secrets := make(map[string]string)
+	if n.Secrets != "" {
+		err := json.Unmarshal([]byte(n.Secrets), &secrets)
+		if err != nil {
+			panic(err)
+		}
+		for key, value := range secrets {
+			secrets[key] = base64.StdEncoding.EncodeToString([]byte(value))
+		}
+	}
+	return &GrafanaIntegrationConfig{
+		UID:                   fmt.Sprintf("%s-uid", name),
+		Name:                  name,
+		Type:                  n.NotifierType,
+		DisableResolveMessage: true,
+		Settings:              json.RawMessage(n.Config),
+		SecureSettings:        secrets,
+	}
 }


### PR DESCRIPTION
This PR introduces a package public variable `AllKnownConfigsForTesting` in `notify` package. This will allow us to reuse this configuration in Grafana tests (see PR https://github.com/grafana/grafana/pull/75849) 