### PR TITLE
Support Upload flag in Pushover integration

### DIFF
--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -215,7 +215,7 @@ func (pn *Notifier) genPushoverBody(ctx context.Context, as ...*types.Alert) (ma
 func (pn *Notifier) writeImageParts(ctx context.Context, w *multipart.Writer, as ...*types.Alert) {
 	// Pushover supports at most one image attachment with a maximum size of pushoverMaxFileSize.
 	// If the image is larger than pushoverMaxFileSize then return an error.
-	_ = images.WithStoredImages(ctx, pn.log, pn.images, func(index int, image images.Image) error {
+	err := images.WithStoredImages(ctx, pn.log, pn.images, func(index int, image images.Image) error {
 		f, err := os.Open(image.Path)
 		if err != nil {
 			return fmt.Errorf("failed to open the image: %w", err)
@@ -246,4 +246,7 @@ func (pn *Notifier) writeImageParts(ctx context.Context, w *multipart.Writer, as
 
 		return images.ErrImagesDone
 	}, as...)
+	if err != nil {
+		pn.log.Error("failed to fetch image for the notification", "error", err)
+	}
 }

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -175,7 +175,11 @@ func (pn *Notifier) genPushoverBody(ctx context.Context, as ...*types.Alert) (ma
 		return nil, b, fmt.Errorf("failed write the message: %w", err)
 	}
 
-	pn.writeImageParts(ctx, w, as...)
+	if pn.settings.Upload {
+		pn.writeImageParts(ctx, w, as...)
+	} else {
+		pn.log.Debug("skip uploading image because of the configuration")
+	}
 
 	var sound string
 	if status == model.AlertResolved {

--- a/receivers/pushover/pushover_test.go
+++ b/receivers/pushover/pushover_test.go
@@ -78,6 +78,43 @@ func TestNotify(t *testing.T) {
 			expMsgError: nil,
 		},
 		{
+			name: "Upload is false",
+			settings: Config{
+				UserKey:          "<userKey>",
+				APIToken:         "<apiToken>",
+				AlertingPriority: 0,
+				OkPriority:       0,
+				Retry:            0,
+				Expire:           0,
+				Device:           "",
+				AlertingSound:    "",
+				OkSound:          "",
+				Upload:           false,
+				Title:            templates.DefaultMessageTitleEmbed,
+				Message:          templates.DefaultMessageEmbed,
+			},
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
+					},
+				},
+			},
+			expMsg: map[string]string{
+				"user":      "<userKey>",
+				"token":     "<apiToken>",
+				"priority":  "0",
+				"sound":     "",
+				"title":     "[FIRING:1]  (val1)",
+				"url":       "http://localhost/alerting/list",
+				"url_title": "Show alert rule",
+				"message":   "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
+				"html":      "1",
+			},
+			expMsgError: nil,
+		},
+		{
 			name: "Custom title",
 			settings: Config{
 				UserKey:          "<userKey>",


### PR DESCRIPTION
This field was introduced since the inception of Pushover integration in the new Alerting https://github.com/grafana/grafana/pull/34371, which was a copy of the legacy alerting model. 
However, at the time of implementation, the new alerting did not support images in notifications, and they were added later.

This PR updates Pushover integration to support `uploadImages` flag.