### PR TITLE
Support for responders in OpsGenie 

### DIFF
--- a/receivers/opsgenie/config.go
+++ b/receivers/opsgenie/config.go
@@ -108,6 +108,9 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 				return Config{}, fmt.Errorf("responder at index [%d] has unsupported type. Supported only: %s", idx, strings.Join(SupportedResponderTypes, ","))
 			}
 		}
+		if r.Type == "teams" && r.Name == "" {
+			return Config{}, fmt.Errorf("responder at index [%d] has type 'teams' but empty name. Must be comma-separated string of names", idx)
+		}
 	}
 
 	return Config{

--- a/receivers/opsgenie/config.go
+++ b/receivers/opsgenie/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"text/template"
 
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
@@ -18,6 +19,15 @@ const (
 	DefaultAlertsURL = "https://api.opsgenie.com/v2/alerts"
 )
 
+var SupportedResponderTypes = []string{"team", "teams", "user", "escalation", "schedule"}
+
+type MessageResponder struct {
+	ID       string `json:"id,omitempty" yaml:"id,omitempty"`
+	Name     string `json:"name,omitempty" yaml:"name,omitempty"`
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Type     string `json:"type" yaml:"type"` // team, user, escalation, schedule etc.
+}
+
 type Config struct {
 	APIKey           string
 	APIUrl           string
@@ -26,17 +36,19 @@ type Config struct {
 	AutoClose        bool
 	OverridePriority bool
 	SendTagsAs       string
+	Responders       []MessageResponder
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	type rawSettings struct {
-		APIKey           string `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
-		APIUrl           string `json:"apiUrl,omitempty" yaml:"apiUrl,omitempty"`
-		Message          string `json:"message,omitempty" yaml:"message,omitempty"`
-		Description      string `json:"description,omitempty" yaml:"description,omitempty"`
-		AutoClose        *bool  `json:"autoClose,omitempty" yaml:"autoClose,omitempty"`
-		OverridePriority *bool  `json:"overridePriority,omitempty" yaml:"overridePriority,omitempty"`
-		SendTagsAs       string `json:"sendTagsAs,omitempty" yaml:"sendTagsAs,omitempty"`
+		APIKey           string             `json:"apiKey,omitempty" yaml:"apiKey,omitempty"`
+		APIUrl           string             `json:"apiUrl,omitempty" yaml:"apiUrl,omitempty"`
+		Message          string             `json:"message,omitempty" yaml:"message,omitempty"`
+		Description      string             `json:"description,omitempty" yaml:"description,omitempty"`
+		AutoClose        *bool              `json:"autoClose,omitempty" yaml:"autoClose,omitempty"`
+		OverridePriority *bool              `json:"overridePriority,omitempty" yaml:"overridePriority,omitempty"`
+		SendTagsAs       string             `json:"sendTagsAs,omitempty" yaml:"sendTagsAs,omitempty"`
+		Responders       []MessageResponder `json:"responders,omitempty" yaml:"responders,omitempty"`
 	}
 
 	raw := rawSettings{}
@@ -74,6 +86,30 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		raw.OverridePriority = &overridePriority
 	}
 
+	for idx, r := range raw.Responders {
+		if r.ID == "" && r.Username == "" && r.Name == "" {
+			return Config{}, fmt.Errorf("responder at index [%d] must have at least one of id, username or name specified", idx)
+		}
+		if strings.Contains(r.Type, "{{") {
+			_, err := template.New("").Parse(r.Type)
+			if err != nil {
+				return Config{}, fmt.Errorf("responder at index [%d] type is not a valid template: %v", idx, err)
+			}
+		} else {
+			r.Type = strings.ToLower(r.Type)
+			match := false
+			for _, t := range SupportedResponderTypes {
+				if r.Type == t {
+					match = true
+					break
+				}
+			}
+			if !match {
+				return Config{}, fmt.Errorf("responder at index [%d] has unsupported type. Supported only: %s", idx, strings.Join(SupportedResponderTypes, ","))
+			}
+		}
+	}
+
 	return Config{
 		APIKey:           raw.APIKey,
 		APIUrl:           raw.APIUrl,
@@ -82,5 +118,6 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		AutoClose:        *raw.AutoClose,
 		OverridePriority: *raw.OverridePriority,
 		SendTagsAs:       raw.SendTagsAs,
+		Responders:       raw.Responders,
 	}, nil
 }

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -140,6 +140,16 @@ func TestNewConfig(t *testing.T) {
 			expectedInitError: `responder at index [0] has unsupported type. Supported only: team,teams,user,escalation,schedule`,
 		},
 		{
+			name: "Error if responder type is teams and name is empty",
+			settings: `{ "responders" : [
+				{ "type" : "teams", "id": "test" } 
+			] }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedInitError: `responder at index [0] has type 'teams' but empty name. Must be comma-separated string of names`,
+		},
+		{
 			name: "Error if responder type is not supported",
 			settings: `{ "responders" : [
 				{ "type" : "test-123", "id": "test" } 

--- a/receivers/opsgenie/config_test.go
+++ b/receivers/opsgenie/config_test.go
@@ -130,6 +130,36 @@ func TestNewConfig(t *testing.T) {
 			expectedInitError: `invalid value for sendTagsAs: "test-tags"`,
 		},
 		{
+			name: "Error if responder type is not supported",
+			settings: `{ "responders" : [
+				{ "type" : "test-123", "id": "test" } 
+			] }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedInitError: `responder at index [0] has unsupported type. Supported only: team,teams,user,escalation,schedule`,
+		},
+		{
+			name: "Error if responder type is not supported",
+			settings: `{ "responders" : [
+				{ "type" : "test-123", "id": "test" } 
+			] }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedInitError: `responder at index [0] has unsupported type. Supported only: team,teams,user,escalation,schedule`,
+		},
+		{
+			name: "Error if responder ID,name,username are empty",
+			settings: `{ "responders" : [
+				{ "type" : "user" } 
+			] }`,
+			secureSettings: map[string][]byte{
+				"apiKey": []byte("test-api-key"),
+			},
+			expectedInitError: `responder at index [0] must have at least one of id, username or name specified`,
+		},
+		{
 			name:     "Should use default message if all spaces",
 			settings: `{ "message" : " " }`,
 			secureSettings: map[string][]byte{
@@ -157,7 +187,8 @@ func TestNewConfig(t *testing.T) {
 				"description": "", 
 				"autoClose": null, 
 				"overridePriority": null, 
-				"sendTagsAs": ""
+				"sendTagsAs": "",
+				"responders": null
 			}`,
 			expectedConfig: Config{
 				APIKey:           "test-api-key",
@@ -167,6 +198,7 @@ func TestNewConfig(t *testing.T) {
 				AutoClose:        true,
 				OverridePriority: true,
 				SendTagsAs:       SendTags,
+				Responders:       nil,
 			},
 		},
 		{
@@ -181,6 +213,20 @@ func TestNewConfig(t *testing.T) {
 				AutoClose:        false,
 				OverridePriority: false,
 				SendTagsAs:       "both",
+				Responders: []MessageResponder{
+					{
+						ID:   "test-id",
+						Type: "team",
+					},
+					{
+						Username: "test-user",
+						Type:     "user",
+					},
+					{
+						Name: "test-schedule",
+						Type: "schedule",
+					},
+				},
 			},
 		},
 		{
@@ -195,6 +241,20 @@ func TestNewConfig(t *testing.T) {
 				AutoClose:        false,
 				OverridePriority: false,
 				SendTagsAs:       "both",
+				Responders: []MessageResponder{
+					{
+						ID:   "test-id",
+						Type: "team",
+					},
+					{
+						Username: "test-user",
+						Type:     "user",
+					},
+					{
+						Name: "test-schedule",
+						Type: "schedule",
+					},
+				},
 			},
 		},
 	}

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -199,7 +199,7 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 					continue
 				}
 				newResponder := opsGenieCreateMessageResponder{
-					Name: tmpl(team),
+					Name: team,
 					Type: "team",
 				}
 				responders = append(responders, newResponder)

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -176,6 +176,39 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 	}
 	sort.Strings(tags)
 
+	responders := make([]opsGenieCreateMessageResponder, 0, len(on.settings.Responders))
+	for idx, r := range on.settings.Responders {
+		responder := opsGenieCreateMessageResponder{
+			ID:       tmpl(r.ID),
+			Name:     tmpl(r.Name),
+			Username: tmpl(r.Username),
+			Type:     tmpl(r.Type),
+		}
+
+		if responder == (opsGenieCreateMessageResponder{}) {
+			on.log.Warn("templates in the responder were expanded to empty responder. Skipping it", "idx", idx)
+			// Filter out empty responders. This is useful if you want to fill
+			// responders dynamically from alert's common labels.
+			continue
+		}
+
+		if responder.Type == "teams" {
+			teams := strings.Split(responder.Name, ",")
+			for _, team := range teams {
+				if team == "" {
+					continue
+				}
+				newResponder := opsGenieCreateMessageResponder{
+					Name: tmpl(team),
+					Type: "team",
+				}
+				responders = append(responders, newResponder)
+			}
+			continue
+		}
+		responders = append(responders, responder)
+	}
+
 	result := opsGenieCreateMessage{
 		Alias:       key.Hash(),
 		Description: description,
@@ -184,6 +217,7 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 		Message:     message,
 		Details:     details,
 		Priority:    priority,
+		Responders:  responders,
 	}
 
 	apiURL = tmpl(on.settings.APIUrl)

--- a/receivers/opsgenie/opsgenie.go
+++ b/receivers/opsgenie/opsgenie.go
@@ -194,6 +194,7 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 
 		if responder.Type == "teams" {
 			teams := strings.Split(responder.Name, ",")
+			teamResponders := make([]opsGenieCreateMessageResponder, 0, len(teams))
 			for _, team := range teams {
 				if team == "" {
 					continue
@@ -202,8 +203,12 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 					Name: team,
 					Type: "team",
 				}
-				responders = append(responders, newResponder)
+				teamResponders = append(teamResponders, newResponder)
 			}
+			if len(teamResponders) == 0 {
+				on.log.Warn("teams responder were expanded to 0 team responders. Skipping it", "idx", idx)
+			}
+			responders = append(responders, teamResponders...)
 			continue
 		}
 		responders = append(responders, responder)

--- a/receivers/opsgenie/testing.go
+++ b/receivers/opsgenie/testing.go
@@ -2,13 +2,27 @@ package opsgenie
 
 // FullValidConfigForTesting is a string representation of a JSON object that contains all fields supported by the notifier Config. It can be used without secrets.
 const FullValidConfigForTesting = `{
-	"apiUrl" : "http://localhost", 
-	"apiKey": "test-api-key",
-	"message" : "test-message", 
-	"description": "test-description", 
-	"autoClose": false, 
-	"overridePriority": false, 
-	"sendTagsAs": "both"
+  "apiUrl": "http://localhost",
+  "apiKey": "test-api-key",
+  "message": "test-message",
+  "description": "test-description",
+  "autoClose": false,
+  "overridePriority": false,
+  "sendTagsAs": "both",
+  "responders": [
+    {
+      "type": "team",
+      "id": "test-id"
+    },
+    {
+      "type": "user",
+      "username": "test-user"
+    },
+    {
+      "type": "schedule",
+      "name": "test-schedule"
+    }
+  ]
 }`
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets


### PR DESCRIPTION
This PR adds support for a new field "responders" to OpsGenie. Documentation https://docs.opsgenie.com/docs/alert-api#create-alert 
The config structure and handling logic are taken from vanilla Alertmanager https://github.com/prometheus/alertmanager/blob/9a8d1f976e12b325ec47b84987a78b7845738be6/notify/opsgenie/opsgenie.go#L185-L213

I improved logic around expanding of "teams" responder to make sure that user provides the correct combination of fields.

Can be tested in https://github.com/grafana/grafana/pull/77159
