### PR TITLE
added support for extra headers on the webhook receiver

### DIFF
--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	// HTTP Basic Authentication.
 	User     string
 	Password string
+	// Extra Headers
+	ExtraHeaders map[string]string
 
 	Title   string
 	Message string
@@ -38,6 +40,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		Password                 string                   `json:"password,omitempty" yaml:"password,omitempty"`
 		Title                    string                   `json:"title,omitempty" yaml:"title,omitempty"`
 		Message                  string                   `json:"message,omitempty" yaml:"message,omitempty"`
+		ExtraHeaders             map[string]string        `json:"extra_headers,omitempty" yaml:"extra_headers,omitempty"`
 	}{}
 
 	err := json.Unmarshal(jsonData, &rawSettings)
@@ -49,6 +52,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	}
 	settings.URL = rawSettings.URL
 	settings.AuthorizationScheme = rawSettings.AuthorizationScheme
+	settings.ExtraHeaders = rawSettings.ExtraHeaders
 
 	if rawSettings.HTTPMethod == "" {
 		rawSettings.HTTPMethod = http.MethodPost

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -248,6 +248,28 @@ func TestNewConfig(t *testing.T) {
 			}`,
 			expectedInitError: "both HTTP Basic Authentication and Authorization Header are set, only 1 is permitted",
 		},
+		{
+			name: "extra headers defined",
+			settings: `{
+				"url": "http://localhost",
+				"extra_headers": {
+					"first":"abc",
+					"second":"123"
+				}
+			}`,
+			expectedConfig: Config{
+				URL:                      "http://localhost",
+				HTTPMethod:               http.MethodPost,
+				MaxAlerts:                0,
+				AuthorizationScheme:      "",
+				AuthorizationCredentials: "",
+				User:                     "",
+				Password:                 "",
+				Title:                    templates.DefaultMessageTitleEmbed,
+				Message:                  templates.DefaultMessageEmbed,
+				ExtraHeaders:             map[string]string{"first": "abc", "second": "123"},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -106,6 +106,10 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		headers["Authorization"] = fmt.Sprintf("%s %s", wn.settings.AuthorizationScheme, wn.settings.AuthorizationCredentials)
 	}
 
+	for k, v := range wn.settings.ExtraHeaders {
+		headers[k] = v
+	}
+
 	parsedURL := tmpl(wn.settings.URL)
 	if tmplErr != nil {
 		return false, tmplErr


### PR DESCRIPTION
This feature request addresses #134 by adding support for arbitrary headers on the webhook receiver