### PR TITLE
Add MessageThreadID to Telegram configuration

### DIFF
--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/alerting/receivers"
@@ -42,6 +43,18 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	}
 	if settings.Message == "" {
 		settings.Message = templates.DefaultMessageEmbed
+	}
+
+	var messageThreadId int
+	if settings.MessageThreadID != "" {
+		messageThreadId, err = strconv.Atoi(settings.MessageThreadID)
+		if err != nil {
+			return settings, errors.New("message thread id must be an integer")
+		}
+
+		if messageThreadId != int(int32(messageThreadId)) {
+			return settings, errors.New("message thread id must be an int32")
+		}
 	}
 	// if field is missing, then we fall back to the previous default: HTML
 	if settings.ParseMode == "" {

--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -45,14 +45,14 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
-	var messageThreadId int
+	var messageThreadID int
 	if settings.MessageThreadID != "" {
-		messageThreadId, err = strconv.Atoi(settings.MessageThreadID)
+		messageThreadID, err = strconv.Atoi(settings.MessageThreadID)
 		if err != nil {
 			return settings, errors.New("message thread id must be an integer")
 		}
 
-		if messageThreadId != int(int32(messageThreadId)) {
+		if messageThreadID != int(int32(messageThreadID)) {
 			return settings, errors.New("message thread id must be an int32")
 		}
 	}

--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -19,6 +19,7 @@ var SupportedParseMode = map[string]string{"Markdown": "Markdown", "MarkdownV2":
 type Config struct {
 	BotToken              string `json:"bottoken,omitempty" yaml:"bottoken,omitempty"`
 	ChatID                string `json:"chatid,omitempty" yaml:"chatid,omitempty"`
+	MessageThreadID       string `json:"message_thread_id,omitempty" yaml:"message_thread_id,omitempty"`
 	Message               string `json:"message,omitempty" yaml:"message,omitempty"`
 	ParseMode             string `json:"parse_mode,omitempty" yaml:"parse_mode,omitempty"`
 	DisableWebPagePreview bool   `json:"disable_web_page_preview,omitempty" yaml:"disable_web_page_preview,omitempty"`

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -112,6 +112,7 @@ func TestNewConfig(t *testing.T) {
 				BotToken:              "test-token",
 				ChatID:                "12345678",
 				Message:               "test-message",
+				MessageThreadID:       "13579",
 				ParseMode:             "HTML",
 				DisableWebPagePreview: true,
 				ProtectContent:        true,
@@ -126,6 +127,7 @@ func TestNewConfig(t *testing.T) {
 				BotToken:              "test-secret-token",
 				ChatID:                "12345678",
 				Message:               "test-message",
+				MessageThreadID:       "13579",
 				ParseMode:             "HTML",
 				DisableWebPagePreview: true,
 				ProtectContent:        true,
@@ -187,6 +189,22 @@ func TestNewConfig(t *testing.T) {
 				ProtectContent:        false,
 				DisableNotifications:  false,
 			},
+		},
+		{
+			name:     "should fail if message_thread_id is not an int",
+			settings: `{"chatid": "12345678", "message_thread_id": "notanint"}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedInitError: "message thread id must be an integer",
+		},
+		{
+			name:     "should fail if message_thread_id is not a valid int32",
+			settings: `{"chatid": "12345678", "message_thread_id": "21474836471"}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedInitError: "message thread id must be an int32",
 		},
 	}
 

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/prometheus/alertmanager/notify"
-
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/images"
@@ -129,6 +128,9 @@ func (tn *Notifier) buildTelegramMessage(ctx context.Context, as []*types.Alert)
 
 	m := make(map[string]string)
 	m["text"] = messageText
+	if tn.settings.MessageThreadID != "" {
+		m["message_thread_id"] = tn.settings.MessageThreadID
+	}
 	if tn.settings.ParseMode != "" {
 		m["parse_mode"] = tn.settings.ParseMode
 	}

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -36,6 +36,7 @@ func TestNotify(t *testing.T) {
 			settings: Config{
 				BotToken:              "abcdefgh0123456789",
 				ChatID:                "someid",
+				MessageThreadID:       "threadid",
 				Message:               templates.DefaultMessageEmbed,
 				ParseMode:             "Markdown",
 				DisableWebPagePreview: true,
@@ -52,6 +53,7 @@ func TestNotify(t *testing.T) {
 				},
 			},
 			expMsg: map[string]string{
+				"message_thread_id":        "threadid",
 				"parse_mode":               "Markdown",
 				"text":                     "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: a URL\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 				"disable_web_page_preview": "true",
@@ -62,10 +64,10 @@ func TestNotify(t *testing.T) {
 		}, {
 			name: "Multiple alerts with custom template",
 			settings: Config{
-				BotToken:  "abcdefgh0123456789",
-				ChatID:    "someid",
-				Message:   "__Custom Firing__\n{{len .Alerts.Firing}} Firing\n{{ template \"__text_alert_list\" .Alerts.Firing }}",
-				ParseMode: DefaultTelegramParseMode,
+				BotToken:        "abcdefgh0123456789",
+				ChatID:          "someid",
+				Message:         "__Custom Firing__\n{{len .Alerts.Firing}} Firing\n{{ template \"__text_alert_list\" .Alerts.Firing }}",
+				ParseMode:       DefaultTelegramParseMode,
 			},
 			alerts: []*types.Alert{
 				{

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -64,10 +64,10 @@ func TestNotify(t *testing.T) {
 		}, {
 			name: "Multiple alerts with custom template",
 			settings: Config{
-				BotToken:        "abcdefgh0123456789",
-				ChatID:          "someid",
-				Message:         "__Custom Firing__\n{{len .Alerts.Firing}} Firing\n{{ template \"__text_alert_list\" .Alerts.Firing }}",
-				ParseMode:       DefaultTelegramParseMode,
+				BotToken:  "abcdefgh0123456789",
+				ChatID:    "someid",
+				Message:   "__Custom Firing__\n{{len .Alerts.Firing}} Firing\n{{ template \"__text_alert_list\" .Alerts.Firing }}",
+				ParseMode: DefaultTelegramParseMode,
 			},
 			alerts: []*types.Alert{
 				{

--- a/receivers/telegram/testing.go
+++ b/receivers/telegram/testing.go
@@ -5,6 +5,7 @@ const FullValidConfigForTesting = `{
 	"bottoken" :"test-token",
 	"chatid" :"12345678",
 	"message" :"test-message",
+	"message_thread_id" :"13579",
 	"parse_mode" :"html",
 	"disable_web_page_preview" :true,
 	"protect_content" :true,


### PR DESCRIPTION
Enable setting [message_thread_id](https://core.telegram.org/bots/api#sendmessage) for Telegram notifications.

Also see https://github.com/grafana/grafana/pull/79546.