### PR TITLE
Alias imports from upstream's cluster package

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,0 +1,23 @@
+package cluster
+
+import (
+	"github.com/prometheus/alertmanager/cluster"
+)
+
+const (
+	DefaultGossipInterval    = cluster.DefaultGossipInterval
+	DefaultPushPullInterval  = cluster.DefaultPushPullInterval
+	DefaultProbeInterval     = cluster.DefaultProbeInterval
+	DefaultProbeTimeout      = cluster.DefaultProbeTimeout
+	DefaultReconnectInterval = cluster.DefaultReconnectInterval
+	DefaultReconnectTimeout  = cluster.DefaultReconnectTimeout
+	DefaultTCPTimeout        = cluster.DefaultTCPTimeout
+)
+
+var (
+	Create = cluster.Create
+)
+
+type ClusterChannel = cluster.ClusterChannel
+type Peer = cluster.Peer
+type State = cluster.State

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -18,6 +18,6 @@ var (
 	Create = cluster.Create
 )
 
-type ClusterChannel = cluster.ClusterChannel
+type ClusterChannel = cluster.ClusterChannel //nolint:golint
 type Peer = cluster.Peer
 type State = cluster.State

--- a/cluster/clusterpb/clusterpb.go
+++ b/cluster/clusterpb/clusterpb.go
@@ -1,0 +1,8 @@
+package clusterpb
+
+import (
+	"github.com/prometheus/alertmanager/cluster/clusterpb"
+)
+
+type FullState = clusterpb.FullState
+type Part = clusterpb.Part

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/alerting/cluster"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
-	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/featurecontrol"

--- a/notify/multiorg_alertmanager.go
+++ b/notify/multiorg_alertmanager.go
@@ -3,7 +3,7 @@ package notify
 import (
 	"context"
 
-	"github.com/prometheus/alertmanager/cluster"
+	"github.com/grafana/alerting/cluster"
 	"github.com/prometheus/client_golang/prometheus"
 )
 


### PR DESCRIPTION
This PR creates aliases for all imports from the `/cluster` and `/clusterpb` packages in Grafana.