### PR TITLE
Accept template contents as strings instead of reading from disk

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"sync"
 	"time"
 
@@ -351,6 +352,11 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg Configuration) (err error) {
 	for _, tc := range am.templates {
 		tmpls = append(tmpls, tc)
 	}
+
+	// Simple sort for consistency in template rendering. Could improve later by sorting based on the template name or defined order.
+	sort.Slice(tmpls, func(i, j int) bool {
+		return tmpls[i] < tmpls[j]
+	})
 
 	tmpl, err := am.TemplateFromContent(tmpls)
 	if err != nil {

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -95,7 +95,6 @@ type GrafanaAlertmanager struct {
 	// buildReceiverIntegrationsFunc builds the integrations for a receiver based on its APIReceiver configuration and the current parsed template.
 	buildReceiverIntegrationsFunc func(next *APIReceiver, tmpl *templates.Template) ([]*Integration, error)
 	externalURL                   string
-	workingDirectory              string
 
 	// templates contains the template name -> template contents for each user-defined template.
 	templates map[string]string
@@ -151,7 +150,6 @@ type Configuration interface {
 }
 
 type GrafanaAlertmanagerConfig struct {
-	WorkingDirectory   string
 	ExternalURL        string
 	AlertStoreCallback mem.AlertStoreCallback
 	PeerTimeout        time.Duration
@@ -186,7 +184,6 @@ func NewGrafanaAlertmanager(tenantKey string, tenantID int64, config *GrafanaAle
 		Metrics:           m,
 		tenantID:          tenantID,
 		externalURL:       config.ExternalURL,
-		workingDirectory:  config.WorkingDirectory,
 		templates:         make(map[string]string),
 	}
 
@@ -300,10 +297,6 @@ func (am *GrafanaAlertmanager) GetReceivers() []*NotifyReceiver {
 
 func (am *GrafanaAlertmanager) ExternalURL() string {
 	return am.externalURL
-}
-
-func (am *GrafanaAlertmanager) WorkingDirectory() string {
-	return am.workingDirectory
 }
 
 // ConfigHash returns the hash of the current running configuration.

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	tmplhtml "html/template"
+	"sort"
 	tmpltext "text/template"
 
 	"github.com/grafana/alerting/templates"
@@ -83,6 +84,11 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 		}
 		templateContents = append(templateContents, tc)
 	}
+
+	// Simple sort for consistency in template rendering. Could improve later by sorting based on the template name or defined order.
+	sort.Slice(templateContents, func(i, j int) bool {
+		return templateContents[i] < templateContents[j]
+	})
 
 	// Capture the underlying text template so we can use ExecuteTemplate.
 	var newTextTmpl *tmpltext.Template

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -102,7 +102,7 @@ func TestTemplateSimple(t *testing.T) {
 				Kind: ExecutionError,
 				Error: template.ExecError{
 					Name: "slack.title",
-					Err:  errors.New(`template: slack.title:1:38: executing "slack.title" at <{{template "missing" .}}>: template "missing" not defined`),
+					Err:  errors.New(`template: :1:38: executing "slack.title" at <{{template "missing" .}}>: template "missing" not defined`),
 				},
 			}},
 		},
@@ -154,7 +154,7 @@ func TestTemplateSimple(t *testing.T) {
 				Kind: ExecutionError,
 				Error: template.ExecError{
 					Name: "other",
-					Err:  errors.New(`template: slack.title:1:91: executing "other" at <{{template "missing" .}}>: template "missing" not defined`),
+					Err:  errors.New(`template: :1:91: executing "other" at <{{template "missing" .}}>: template "missing" not defined`),
 				},
 			}},
 		},
@@ -275,13 +275,6 @@ func TestTemplateSpecialCases(t *testing.T) {
 
 func TestTemplateWithExistingTemplates(t *testing.T) {
 	am, _ := setupAMTest(t)
-	tmpDir, err := os.MkdirTemp("", "test-templates")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-	})
-
-	am.workingDirectory = tmpDir
 
 	tests := []struct {
 		name              string
@@ -354,7 +347,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 				Kind: ExecutionError,
 				Error: template.ExecError{
 					Name: "slack.title",
-					Err:  errors.New(`template: slack.title:1:38: executing "slack.title" at <{{template "slack.alternate_title" .}}>: template "slack.alternate_title" not defined`),
+					Err:  errors.New(`template: :1:38: executing "slack.title" at <{{template "slack.alternate_title" .}}>: template "slack.alternate_title" not defined`),
 				},
 			}},
 		},
@@ -381,10 +374,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if len(test.existingTemplates) > 0 {
-				for name, tmpl := range test.existingTemplates {
-					createTemplate(t, tmpDir, name, tmpl)
-					am.templates = append(am.templates, name)
-				}
+				am.templates = test.existingTemplates
 			}
 			res, err := am.TestTemplate(context.Background(), test.input)
 			require.NoError(t, err)

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"errors"
+	"github.com/grafana/alerting/templates"
 	"os"
 	"path/filepath"
 	"testing"
@@ -278,7 +279,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		existingTemplates map[string]string
+		existingTemplates []templates.TemplateDefinition
 		input             TestTemplatesConfigBodyParams
 		expected          TestTemplatesResults
 	}{{
@@ -303,9 +304,10 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "existing" . }}{{ end }}`,
 		},
-		existingTemplates: map[string]string{
-			"existing": `{{ define "existing" }}Some existing template{{ end }}`,
-		},
+		existingTemplates: []templates.TemplateDefinition{{
+			Name:     "existing",
+			Template: `{{ define "existing" }}Some existing template{{ end }}`,
+		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
 				Name: "slack.title",
@@ -320,9 +322,10 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}New template{{ end }}`,
 		},
-		existingTemplates: map[string]string{
-			"slack.title": `{{ define "slack.title" }}Some existing template{{ end }}`,
-		},
+		existingTemplates: []templates.TemplateDefinition{{
+			Name:     "slack.title",
+			Template: `{{ define "slack.title" }}Some existing template{{ end }}`,
+		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
 				Name: "slack.title",
@@ -337,9 +340,10 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "slack.alternate_title" . }}{{ end }}`,
 		},
-		existingTemplates: map[string]string{
-			"slack.title": `{{ define "slack.title" }}Some existing template{{ end }}{{ define "slack.alternate_title" }}Some existing alternate template{{ end }}`,
-		},
+		existingTemplates: []templates.TemplateDefinition{{
+			Name:     "slack.title",
+			Template: `{{ define "slack.title" }}Some existing template{{ end }}{{ define "slack.alternate_title" }}Some existing alternate template{{ end }}`,
+		}},
 		expected: TestTemplatesResults{
 			Results: nil,
 			Errors: []TestTemplatesErrorResult{{
@@ -358,9 +362,10 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "slack.alternate_title" . }}{{ end }}{{ define "slack.alternate_title" }}Some new alternate template{{ end }}`,
 		},
-		existingTemplates: map[string]string{
-			"slack.title": `{{ define "slack.title" }}Some existing template{{ end }}{{ define "slack.alternate_title" }}Some existing alternate template{{ end }}`,
-		},
+		existingTemplates: []templates.TemplateDefinition{{
+			Name:     "slack.title",
+			Template: `{{ define "slack.title" }}Some existing template{{ end }}{{ define "slack.alternate_title" }}Some existing alternate template{{ end }}`,
+		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
 				Name: "slack.title",

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"github.com/grafana/alerting/templates"
-	"os"
-	"path/filepath"
 	"testing"
 	"text/template"
 
@@ -430,19 +428,4 @@ CommonAnnotations: {{ range .CommonAnnotations.SortedPairs }}{{ .Name }}={{ .Val
 			assert.Equal(t, test.expected, *res)
 		})
 	}
-}
-
-func createTemplate(t *testing.T, tmpDir string, name string, tmpl string) {
-	f, err := os.Create(filepath.Join(tmpDir, name))
-	require.NoError(t, err)
-	defer func(f *os.File) {
-		_ = f.Close()
-	}(f)
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(f.Name()))
-	})
-
-	_, err = f.WriteString(tmpl)
-	require.NoError(t, err)
 }

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -3,9 +3,10 @@ package notify
 import (
 	"context"
 	"errors"
-	"github.com/grafana/alerting/templates"
 	"testing"
 	"text/template"
+
+	"github.com/grafana/alerting/templates"
 
 	"github.com/go-openapi/strfmt"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -1,10 +1,8 @@
 package templates
 
 import (
-	"os"
 	"testing"
 
-	"github.com/prometheus/alertmanager/template"
 	"github.com/stretchr/testify/require"
 )
 
@@ -102,21 +100,7 @@ Labels:
 `
 
 func ForTests(t *testing.T) *Template {
-	f, err := os.CreateTemp("/tmp", "template")
+	tmpl, err := FromContent([]string{TemplateForTestsString})
 	require.NoError(t, err)
-	defer func(f *os.File) {
-		_ = f.Close()
-	}(f)
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(f.Name()))
-	})
-
-	_, err = f.WriteString(TemplateForTestsString)
-	require.NoError(t, err)
-
-	tmpl, err := template.FromGlobs([]string{f.Name()})
-	require.NoError(t, err)
-
 	return tmpl
 }

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -3,7 +3,6 @@ package templates
 import (
 	"context"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -117,20 +116,7 @@ func TestDefaultTemplateString(t *testing.T) {
 		},
 	}
 
-	f, err := os.CreateTemp("/tmp", "template")
-	require.NoError(t, err)
-	defer func(f *os.File) {
-		_ = f.Close()
-	}(f)
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(f.Name()))
-	})
-
-	_, err = f.WriteString(DefaultTemplateString)
-	require.NoError(t, err)
-
-	tmpl, err := FromGlobs([]string{f.Name()})
+	tmpl, err := FromContent([]string{DefaultTemplateString})
 	require.NoError(t, err)
 
 	externalURL, err := url.Parse("http://localhost/grafana")

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -116,7 +116,7 @@ func TestDefaultTemplateString(t *testing.T) {
 		},
 	}
 
-	tmpl, err := FromContent([]string{DefaultTemplateString})
+	tmpl, err := FromContent(nil)
 	require.NoError(t, err)
 
 	externalURL, err := url.Parse("http://localhost/grafana")

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -29,7 +29,7 @@ var FromGlobs = template.FromGlobs
 type TemplateDefinition struct {
 	// Name of the template. Used to identify the template in the UI and when testing.
 	Name string
-	// Template string that contains the template definition.
+	// Template string that contains the template text.
 	Template string
 }
 
@@ -65,7 +65,7 @@ type ExtendedData struct {
 }
 
 // FromContent calls Parse on all provided template content and returns the resulting Template. Content equivalent to templates.FromGlobs.
-func FromContent(templateContents []string, options ...template.Option) (*Template, error) {
+func FromContent(tmpls []string, options ...template.Option) (*Template, error) {
 	// Create new template with only file-based defaults. Done this way to simplify transition to FromContent.
 	t, err := FromGlobs(nil, options...)
 	if err != nil {
@@ -79,7 +79,7 @@ func FromContent(templateContents []string, options ...template.Option) (*Templa
 	}
 
 	// Parse all provided templates.
-	for _, tc := range templateContents {
+	for _, tc := range tmpls {
 		err := t.Parse(strings.NewReader(tc))
 		if err != nil {
 			return nil, err

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -72,10 +72,9 @@ func FromContent(tmpls []string, options ...template.Option) (*Template, error) 
 		return nil, err
 	}
 
-	// Parse default template strings defined as files. Copied from template.FromGlobs.
-	// TODO: Consider removing this and defining them as strings. This would be a breaking change for those who defined custom default files.
-	defaultFileBasedTemplates := []string{"default.tmpl", "email.tmpl"}
-	for _, file := range defaultFileBasedTemplates {
+	// Parse prometheus default templates. Copied from template.FromGlobs.
+	defaultPrometheusTemplates := []string{"default.tmpl", "email.tmpl"}
+	for _, file := range defaultPrometheusTemplates {
 		f, err := asset.Assets.Open(path.Join("/templates", file))
 		if err != nil {
 			return nil, err

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -74,6 +74,9 @@ func FromContent(templateContents []string, options ...template.Option) (*Templa
 
 	// Parse default template string.
 	err = t.Parse(strings.NewReader(DefaultTemplateString))
+	if err != nil {
+		return nil, err
+	}
 
 	// Parse all provided templates.
 	for _, tc := range templateContents {

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -26,6 +26,13 @@ type Data = template.Data
 
 var FromGlobs = template.FromGlobs
 
+type TemplateDefinition struct {
+	// Name of the template. Used to identify the template in the UI and when testing.
+	Name string
+	// Template string that contains the template definition.
+	Template string
+}
+
 type ExtendedAlert struct {
 	Status        string             `json:"status"`
 	Labels        KV                 `json:"labels"`

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -57,6 +57,24 @@ type ExtendedData struct {
 	ExternalURL string `json:"externalURL"`
 }
 
+// FromContent calls Parse on all provided template content and returns the resulting Template. Content equivalent to templates.FromGlobs.
+func FromContent(templateContents []string, options ...template.Option) (*Template, error) {
+	// Create new template with only defaults.
+	t, err := FromGlobs(nil, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse all provided templates.
+	for _, tc := range templateContents {
+		err := t.Parse(strings.NewReader(tc))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}
+
 func removePrivateItems(kv template.KV) template.KV {
 	for key := range kv {
 		if strings.HasPrefix(key, "__") && strings.HasSuffix(key, "__") {

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -66,11 +66,14 @@ type ExtendedData struct {
 
 // FromContent calls Parse on all provided template content and returns the resulting Template. Content equivalent to templates.FromGlobs.
 func FromContent(templateContents []string, options ...template.Option) (*Template, error) {
-	// Create new template with only defaults.
+	// Create new template with only file-based defaults. Done this way to simplify transition to FromContent.
 	t, err := FromGlobs(nil, options...)
 	if err != nil {
 		return nil, err
 	}
+
+	// Parse default template string.
+	err = t.Parse(strings.NewReader(DefaultTemplateString))
 
 	// Parse all provided templates.
 	for _, tc := range templateContents {

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -25,7 +25,7 @@ type Template = template.Template
 type KV = template.KV
 type Data = template.Data
 
-var New = template.New
+var newTemplate = template.New
 
 type TemplateDefinition struct {
 	// Name of the template. Used to identify the template in the UI and when testing.
@@ -67,7 +67,7 @@ type ExtendedData struct {
 
 // FromContent calls Parse on all provided template content and returns the resulting Template. Content equivalent to templates.FromGlobs.
 func FromContent(tmpls []string, options ...template.Option) (*Template, error) {
-	t, err := New(options...)
+	t, err := newTemplate(options...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What is this feature?

Makes use of the new upstream `Template.New()` to stop passing user-defined templates to the Grafana Alertmanager by persisting them to disk.

### Why do we need this feature?

This PR is a general improvement and simplification, but there are also some specific reasons why we might want to do this:

- Incremental step towards abstracting data layer for Grafana's Alertmanager interface away from needing disk-based storage. Next step would likely focus on `FileStore`.
- Reduces likelihood of consistency complexities on save/apply, especially in the context of future Remote AM work.
- Since `DefaultTemplateString` is now treated like other defaults and therefor consistently applied first. This ensures that user-defined templates can now rely on being able to override defaults.

### Future improvements

- Similarly, we could consider moving the existing prometheus defaults (`default.tmpl` and `email.tmpl`) to strings as well, allowing them to be more easily overridden via API/UI.
- Similar changes can be made in Mimir Alertmanager eventually as well.