### PR TITLE
Remove object matchers from GettableStatus

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -86,7 +86,7 @@ func (r *Route) AsAMRoute() *config.Route {
 	return amRoute
 }
 
-// AsGrafanaRoute returns a Grafana route from an Alertmanager route. The Matchers are converted to ObjectMatchers.
+// AsGrafanaRoute returns a Grafana route from an Alertmanager route.
 func AsGrafanaRoute(r *config.Route) *Route {
 	gRoute := &Route{
 		Receiver:          r.Receiver,
@@ -95,7 +95,7 @@ func AsGrafanaRoute(r *config.Route) *Route {
 		GroupByAll:        r.GroupByAll,
 		Match:             r.Match,
 		MatchRE:           r.MatchRE,
-		ObjectMatchers:    ObjectMatchers(r.Matchers),
+		Matchers:          r.Matchers,
 		MuteTimeIntervals: r.MuteTimeIntervals,
 		Continue:          r.Continue,
 


### PR DESCRIPTION
This commit removes object matchers from `GettableStatus` as the Grafana UI now supports UTF-8 in matchers.