### PR TITLE
Add Template field in email receiver

### DIFF
--- a/receivers/email/config.go
+++ b/receivers/email/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Addresses   []string
 	Message     string
 	Subject     string
+	Template    string
 }
 
 func NewConfig(jsonData json.RawMessage) (Config, error) {
@@ -22,6 +23,7 @@ func NewConfig(jsonData json.RawMessage) (Config, error) {
 		Addresses   string `json:"addresses,omitempty"`
 		Message     string `json:"message,omitempty"`
 		Subject     string `json:"subject,omitempty"`
+		Template    string `json:"template,omitempty"`
 	}
 
 	var settings emailSettingsRaw
@@ -38,12 +40,16 @@ func NewConfig(jsonData json.RawMessage) (Config, error) {
 	if settings.Subject == "" {
 		settings.Subject = templates.DefaultMessageTitleEmbed
 	}
+	if settings.Template == "" {
+		settings.Template = templates.DefaultTemplate
+	}
 
 	return Config{
 		SingleEmail: settings.SingleEmail,
 		Message:     settings.Message,
 		Subject:     settings.Subject,
 		Addresses:   addresses,
+		Template:    settings.Template,
 	}, nil
 }
 

--- a/receivers/email/config_test.go
+++ b/receivers/email/config_test.go
@@ -39,8 +39,9 @@ func TestNewConfig(t *testing.T) {
 				Addresses: []string{
 					"test@grafana.com",
 				},
-				Message: "",
-				Subject: templates.DefaultMessageTitleEmbed,
+				Message:  "",
+				Subject:  templates.DefaultMessageTitleEmbed,
+				Template: templates.DefaultTemplate,
 			},
 		},
 		{
@@ -54,8 +55,9 @@ func TestNewConfig(t *testing.T) {
 					"test3@grafana.com",
 					"test4@granafa.com",
 				},
-				Message: "",
-				Subject: templates.DefaultMessageTitleEmbed,
+				Message:  "",
+				Subject:  templates.DefaultMessageTitleEmbed,
+				Template: templates.DefaultTemplate,
 			},
 		},
 		{
@@ -66,8 +68,9 @@ func TestNewConfig(t *testing.T) {
 				Addresses: []string{
 					"test@grafana.com",
 				},
-				Message: "",
-				Subject: templates.DefaultMessageTitleEmbed,
+				Message:  "",
+				Subject:  templates.DefaultMessageTitleEmbed,
+				Template: templates.DefaultTemplate,
 			},
 		},
 		{
@@ -78,8 +81,9 @@ func TestNewConfig(t *testing.T) {
 				Addresses: []string{
 					"test@grafana.com",
 				},
-				Message: "test-message",
-				Subject: "test-subject",
+				Message:  "test-message",
+				Subject:  "test-subject",
+				Template: templates.DefaultTemplate,
 			},
 		},
 	}

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -91,7 +91,7 @@ func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 		EmbeddedFiles: embeddedFiles,
 		To:            en.settings.Addresses,
 		SingleEmail:   en.settings.SingleEmail,
-		Template:      "ng_alert_notification",
+		Template:      en.settings.Template,
 	}
 
 	if tmplErr != nil {

--- a/receivers/email/email_test.go
+++ b/receivers/email/email_test.go
@@ -29,8 +29,9 @@ func TestNotify(t *testing.T) {
 				"someops@example.com",
 				"somedev@example.com",
 			},
-			Message: "{{ template \"default.title\" . }}",
-			Subject: templates.DefaultMessageTitleEmbed,
+			Message:  "{{ template \"default.title\" . }}",
+			Subject:  templates.DefaultMessageTitleEmbed,
+			Template: templates.DefaultTemplate,
 		}
 
 		emailSender := receivers.MockNotificationService()

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -9,6 +9,7 @@ import (
 const (
 	DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
 	DefaultMessageEmbed      = `{{ template "default.message" . }}`
+	DefaultTemplate          = `ng_alert_notification`
 )
 
 var DefaultTemplateString = `


### PR DESCRIPTION
Add a way to customize email template name, allowing to use multiple html email templating