### PR TITLE
Expose prom-AM silence state struct and helper methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/strfmt v0.22.0
+	github.com/google/go-cmp v0.6.0
+	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.25.0
 	github.com/prometheus/client_golang v1.18.0
@@ -55,7 +57,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/dns v1.1.50 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/notify/silences.go
+++ b/notify/silences.go
@@ -1,11 +1,15 @@
 package notify
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
+
 	v2 "github.com/prometheus/alertmanager/api/v2"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/silence"
@@ -151,4 +155,55 @@ func (am *GrafanaAlertmanager) DeleteSilence(silenceID string) error {
 	}
 
 	return nil
+}
+
+func (am *GrafanaAlertmanager) SilenceState() (SilenceState, error) {
+	r, w := io.Pipe()
+	go func() {
+		_, err := am.silences.Snapshot(w)
+		_ = w.CloseWithError(err)
+	}()
+
+	// Trade-off between type safety and performance ahead.
+	// This is a bit awkward as we marshalled the silence just to unmarshalling it again. We could keep the return value
+	// as (string, error) and return the string directly as, for now, callers just needs the string itself.
+	/// However, this would remove type safety on the interface, forcing the caller to trust the AM implementation to
+	// always return a consistent type or to perform the unmarshalling themselves.
+	return DecodeState(r)
+}
+
+// SilenceState copied from state in prometheus-alertmanager/silence/silence.go.
+type SilenceState map[string]*silencepb.MeshSilence
+
+func (s SilenceState) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+
+	for _, e := range s {
+		if _, err := pbutil.WriteDelimited(&buf, e); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeState copied from decodeState in prometheus-alertmanager/silence/silence.go.
+func DecodeState(r io.Reader) (SilenceState, error) {
+	st := SilenceState{}
+	for {
+		var s silencepb.MeshSilence
+		_, err := pbutil.ReadDelimited(r, &s)
+		if err == nil {
+			if s.Silence == nil {
+				return nil, silence.ErrInvalidState
+			}
+			st[s.Silence.Id] = &s
+			continue
+		}
+		//nolint:errorlint
+		if err == io.EOF {
+			break
+		}
+		return nil, err
+	}
+	return st, nil
 }

--- a/notify/silences.go
+++ b/notify/silences.go
@@ -199,8 +199,7 @@ func DecodeState(r io.Reader) (SilenceState, error) {
 			st[s.Silence.Id] = &s
 			continue
 		}
-		//nolint:errorlint
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		return nil, err

--- a/notify/silences_test.go
+++ b/notify/silences_test.go
@@ -1,0 +1,125 @@
+package notify
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/prometheus/alertmanager/silence/silencepb"
+)
+
+func TestSilenceState(t *testing.T) {
+	now := time.Now()
+	createSilence := func(name string, val string) PostableSilence {
+		return PostableSilence{
+			Silence: amv2.Silence{
+				Comment:   ptr("This is a comment"),
+				CreatedBy: ptr("test"),
+				EndsAt:    ptr(strfmt.DateTime(now.Add(time.Minute))),
+				Matchers: amv2.Matchers{{
+					IsEqual: ptr(true),
+					IsRegex: ptr(false),
+					Name:    ptr(name),
+					Value:   ptr(val),
+				}},
+				StartsAt: ptr(strfmt.DateTime(now)),
+			},
+		}
+	}
+
+	createExpectedSilenceMesh := func(name string, val string) *silencepb.MeshSilence {
+		return &silencepb.MeshSilence{
+			Silence: &silencepb.Silence{
+				Comment:   "This is a comment",
+				CreatedBy: "test",
+				EndsAt:    now.Add(time.Minute).UTC(),
+				Matchers:  []*silencepb.Matcher{{Type: silencepb.Matcher_EQUAL, Name: name, Pattern: val}},
+				StartsAt:  now.UTC(),
+				UpdatedAt: now.UTC(),
+			},
+			ExpiresAt: now.Add(time.Minute),
+		}
+	}
+
+	cmpOpts := cmp.Options{
+		cmpopts.IgnoreFields(silencepb.Silence{}, "Id", "UpdatedAt"),
+		cmpopts.EquateApproxTime(time.Second),
+	}
+
+	cases := []struct {
+		name     string
+		silences []PostableSilence
+		expired  bool
+	}{
+		{
+			name: "Single silence",
+			silences: []PostableSilence{
+				createSilence("foo", "bar"),
+			},
+		},
+		{
+			name: "Multiple silences",
+			silences: []PostableSilence{
+				createSilence("foo", "bar"),
+				createSilence("_foo1", "bar"),
+			},
+		},
+		{
+			name: "Unicode and edge case silences",
+			silences: []PostableSilence{
+				createSilence("0foo", "bar"),
+				createSilence("foo", "🙂bar"),
+				createSilence("foo🙂", "bar"),
+			},
+		},
+		{
+			name: "Expired silence",
+			silences: []PostableSilence{
+				createSilence("foo", "bar"),
+			},
+			expired: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			am, _ := setupAMTest(t)
+			expectedState := SilenceState{}
+			for _, silence := range c.silences {
+				sid, err := am.CreateSilence(&silence)
+				require.NoError(t, err)
+
+				expected := createExpectedSilenceMesh(*silence.Matchers[0].Name, *silence.Matchers[0].Value)
+				if c.expired {
+					require.NoError(t, am.DeleteSilence(sid))
+					sil, err := am.GetSilence(sid)
+					require.NoError(t, err)
+					expected.Silence.EndsAt = time.Time(*sil.EndsAt).UTC()
+					expected.ExpiresAt = time.Time(*sil.EndsAt).Add(30 * time.Millisecond).UTC()
+				}
+				expectedState[sid] = expected
+			}
+			state, err := am.SilenceState()
+			require.NoError(t, err)
+			if !cmp.Equal(state, expectedState, cmpOpts...) {
+				t.Errorf("Unexpected Diff: %v", cmp.Diff(state, expectedState, cmpOpts...))
+			}
+
+			b, err := state.MarshalBinary()
+			require.NoError(t, err)
+
+			decoded, err := DecodeState(bytes.NewReader(b))
+			require.NoError(t, err)
+
+			if !cmp.Equal(decoded, expectedState, cmpOpts...) {
+				t.Errorf("Unexpected Diff: %v", cmp.Diff(state, expectedState, cmpOpts...))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is this feature?

Exposes upstream prometheus alertmanager silence [state](https://github.com/prometheus/alertmanager/blob/3ee2cd0f1271e277295c02b6160507b4d193dde2/silence/silence.go#L908) type and some related helper methods, such as [DecodeState](https://github.com/prometheus/alertmanager/blob/3ee2cd0f1271e277295c02b6160507b4d193dde2/silence/silence.go#L942) and [MarshalBinary](https://github.com/prometheus/alertmanager/blob/3ee2cd0f1271e277295c02b6160507b4d193dde2/silence/silence.go#L931).

### Why do we need this feature?

These methods will be used by `grafana/grafana` [PR](https://github.com/grafana/grafana/pull/84705) to persist the silence state to the kvstore immediately instead of waiting for the
next maintenance run. This is used after Create/Delete to prevent silences from being lost when a new Alertmanager is started before the state has persisted. This can happen, for example, in a rolling deployment scenario when HA is not enabled.

### Considerations of note

- A trade-off between type safety and performance is made in `SilenceState() (SilenceState, error)`. Owing to the fact that upstream prom-AM does not expose the necessary types / methods, we marshalled the silence just to unmarshalling it again. Alternateively, we could keep the return value as (string, error) and return the string directly as, for now, callers just needs the string itself. However, this would remove type safety on the interface, forcing the caller to trust the AM implementation to always return a consistent type or to perform the unmarshalling themselves. Suggestions welcome, but keep in mind the `grafana/grafana` implementation and how it might interact with remote alertmanager.