### PR TITLE
Load initial silence and nflog state from memory instead of disk

### DIFF
--- a/notify/testing.go
+++ b/notify/testing.go
@@ -46,7 +46,7 @@ func newFakeMaintanenceOptions(t *testing.T) *fakeMaintenanceOptions {
 type fakeMaintenanceOptions struct {
 }
 
-func (f *fakeMaintenanceOptions) Filepath() string {
+func (f *fakeMaintenanceOptions) InitialState() string {
 	return ""
 }
 


### PR DESCRIPTION
### What is this feature?

Currently, the initial loading of silence state and notification log state reads from disk. This change replaces the disk read via `SnapshotFile` with a string reader via `SnapshotReader`.

### Why do we need this feature?

Followup to https://github.com/grafana/alerting/pull/161 to remove another unnecessary disk-usage. Silence state and nflog are already persisted and read from the kvstore. The file on disk is used only on initial load and is otherwise redundant.

### Considerations of note

- Fairly simple change as `SnapshotReader` already exists on upstream prom-AM for this exact use-case.
- We still need to pass in a snapshot filename placeholder to the maintenance function even though it won't be used. Otherwise, the [state won't be persisted on shutdown](https://github.com/prometheus/alertmanager/blob/3ee2cd0f1271e277295c02b6160507b4d193dde2/silence/silence.go#L436).