### PR TITLE
[v11.0.x] Load initial silence and nflog state from memory instead of disk (#170)

### DIFF
--- a/notify/testing.go
+++ b/notify/testing.go
@@ -46,7 +46,7 @@ func newFakeMaintanenceOptions(t *testing.T) *fakeMaintenanceOptions {
 type fakeMaintenanceOptions struct {
 }
 
-func (f *fakeMaintenanceOptions) Filepath() string {
+func (f *fakeMaintenanceOptions) InitialState() string {
 	return ""
 }
 


### PR DESCRIPTION
backport of f1abba3e2067157bd0ff0258ff7f9d5e9bbbe158 to v11.0.x