### PR TITLE
Drop rule URL from LINE notifier message body 

### DIFF
--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -42,7 +42,7 @@ func New(cfg Config, meta receivers.Metadata, template *templates.Template, send
 func (ln *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	ln.log.Debug("executing line notification", "notification", ln.Name)
 
-	body := ln.buildMessage(ctx, as...)
+	body := ln.buildLineMessage(ctx, as...)
 
 	form := url.Values{}
 	form.Add("message", body)
@@ -69,7 +69,7 @@ func (ln *Notifier) SendResolved() bool {
 	return !ln.GetDisableResolveMessage()
 }
 
-func (ln *Notifier) buildMessage(ctx context.Context, as ...*types.Alert) string {
+func (ln *Notifier) buildLineMessage(ctx context.Context, as ...*types.Alert) string {
 	ruleURL := path.Join(ln.tmpl.ExternalURL.String(), "/alerting/list")
 
 	var tmplErr error

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	// APIURL of where the notification payload is sent. It is public to be overridable in integration tests.
+	// API document link: https://notify-bot.line.me/doc/en/
 	APIURL = "https://notify-api.line.me/api/notify"
 )
 

--- a/receivers/line/line.go
+++ b/receivers/line/line.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path"
 
 	"github.com/prometheus/alertmanager/types"
 
@@ -70,15 +69,12 @@ func (ln *Notifier) SendResolved() bool {
 }
 
 func (ln *Notifier) buildLineMessage(ctx context.Context, as ...*types.Alert) string {
-	ruleURL := path.Join(ln.tmpl.ExternalURL.String(), "/alerting/list")
-
 	var tmplErr error
 	tmpl, _ := templates.TmplText(ctx, ln.tmpl, as, ln.log, &tmplErr)
 
 	body := fmt.Sprintf(
-		"%s\n%s\n\n%s",
+		"%s\n%s",
 		tmpl(ln.settings.Title),
-		ruleURL,
 		tmpl(ln.settings.Description),
 	)
 	if tmplErr != nil {

--- a/receivers/line/line_test.go
+++ b/receivers/line/line_test.go
@@ -50,7 +50,7 @@ func TestNotify(t *testing.T) {
 				"Authorization": "Bearer sometoken",
 				"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
 			},
-			expMsg:      "message=%5BFIRING%3A1%5D++%28val1%29%0Ahttp%3A%2Flocalhost%2Falerting%2Flist%0A%0A%2A%2AFiring%2A%2A%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval1%0ADashboard%3A+http%3A%2F%2Flocalhost%2Fd%2Fabcd%0APanel%3A+http%3A%2F%2Flocalhost%2Fd%2Fabcd%3FviewPanel%3Defgh%0A",
+			expMsg:      "message=%5BFIRING%3A1%5D++%28val1%29%0A%2A%2AFiring%2A%2A%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval1%0ADashboard%3A+http%3A%2F%2Flocalhost%2Fd%2Fabcd%0APanel%3A+http%3A%2F%2Flocalhost%2Fd%2Fabcd%3FviewPanel%3Defgh%0A",
 			expMsgError: nil,
 		}, {
 			name: "Multiple alerts",
@@ -76,7 +76,7 @@ func TestNotify(t *testing.T) {
 				"Authorization": "Bearer sometoken",
 				"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
 			},
-			expMsg:      "message=%5BFIRING%3A2%5D++%0Ahttp%3A%2Flocalhost%2Falerting%2Flist%0A%0A%2A%2AFiring%2A%2A%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval1%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val2%0AAnnotations%3A%0A+-+ann1+%3D+annv2%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval2%0A",
+			expMsg:      "message=%5BFIRING%3A2%5D++%0A%2A%2AFiring%2A%2A%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval1%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val2%0AAnnotations%3A%0A+-+ann1+%3D+annv2%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval2%0A",
 			expMsgError: nil,
 		}, {
 			name: "One alert custom title and description",
@@ -97,7 +97,7 @@ func TestNotify(t *testing.T) {
 				"Authorization": "Bearer sometoken",
 				"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
 			},
-			expMsg:      "message=customTitle+1%0Ahttp%3A%2Flocalhost%2Falerting%2Flist%0A%0AcustomDescription",
+			expMsg:      "message=customTitle+1%0AcustomDescription",
 			expMsgError: nil,
 		},
 	}


### PR DESCRIPTION
The rule URL is stored and delivered under a different key through a response when using many other notifiers; however, when LINE is used as the notifier, the rule URL is included directly in the message body.
Since I mainly use LINE as the alert notifier in my project, it is impossible to customize the message body completely using a message template.
This PR drops the rule URL from LINE message body so the message looks like:

from this
<img width="254" alt="image" src="https://github.com/grafana/alerting/assets/2543211/257c8e33-f7ae-4299-b6c7-e222d549fbbc">

to this
<img width="221" alt="image" src="https://github.com/grafana/alerting/assets/2543211/e7a6e221-3767-4488-88ac-e5a24106c7d6">
