### PR TITLE
Make GetActiveReceiversMap function public

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -403,7 +403,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg Configuration) (err error) {
 
 	// TODO: This has not been upstreamed yet. Should be aligned when https://github.com/prometheus/alertmanager/pull/3016 is merged.
 	var receivers []*notify.Receiver
-	activeReceivers := am.getActiveReceiversMap(am.route)
+	activeReceivers := GetActiveReceiversMap(am.route)
 	for name := range integrationsMap {
 		stage := am.createReceiverStage(name, integrationsMap[name], am.waitFunc, am.notificationLog)
 		routingStage[name] = notify.MultiStage{meshStage, silencingStage, timeMuteStage, inhibitionStage, stage}
@@ -577,17 +577,6 @@ func (am *GrafanaAlertmanager) createReceiverStage(name string, integrations []*
 		fs = append(fs, s)
 	}
 	return fs
-}
-
-// getActiveReceiversMap returns all receivers that are in use by a route.
-func (am *GrafanaAlertmanager) getActiveReceiversMap(r *dispatch.Route) map[string]struct{} {
-	receiversMap := make(map[string]struct{})
-	visitFunc := func(r *dispatch.Route) {
-		receiversMap[r.RouteOpts.Receiver] = struct{}{}
-	}
-	r.Walk(visitFunc)
-
-	return receiversMap
 }
 
 func (am *GrafanaAlertmanager) waitFunc() time.Duration {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
@@ -545,6 +546,17 @@ func decodeSecretsFromBase64(secrets map[string]string) (map[string][]byte, erro
 		secureSettings[k] = d
 	}
 	return secureSettings, nil
+}
+
+// GetActiveReceiversMap returns all receivers that are in use by a route.
+func GetActiveReceiversMap(r *dispatch.Route) map[string]struct{} {
+	receiversMap := make(map[string]struct{})
+	visitFunc := func(r *dispatch.Route) {
+		receiversMap[r.RouteOpts.Receiver] = struct{}{}
+	}
+	r.Walk(visitFunc)
+
+	return receiversMap
 }
 
 func newNotifierConfig[T interface{}](receiver *GrafanaIntegrationConfig, settings T) *NotifierConfig[T] {


### PR DESCRIPTION
This PR extracts the `getActiveReceiversMap()` method from the grafana Alertmanager to its own public function to be used outside of the alerting repo.

Related PR: https://github.com/grafana/mimir/pull/8066