### PR TITLE
Add missing yaml struct tags for configuration structs

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -374,10 +374,10 @@ func (r RawMessage) MarshalYAML() (interface{}, error) {
 }
 
 type PostableGrafanaReceiver struct {
-	UID                   string            `json:"uid"`
-	Name                  string            `json:"name"`
-	Type                  string            `json:"type"`
-	DisableResolveMessage bool              `json:"disableResolveMessage"`
+	UID                   string            `json:"uid" yaml:"uid"`
+	Name                  string            `json:"name" yaml:"name"`
+	Type                  string            `json:"type" yaml:"type"`
+	DisableResolveMessage bool              `json:"disableResolveMessage" yaml:"disableResolveMessage"`
 	Settings              RawMessage        `json:"settings,omitempty" yaml:"settings,omitempty"`
 	SecureSettings        map[string]string `json:"secureSettings,omitempty" yaml:"secureSettings,omitempty"`
 }

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -69,12 +69,12 @@ type TestIntegrationConfigResult struct {
 }
 
 type GrafanaIntegrationConfig struct {
-	UID                   string            `json:"uid"`
-	Name                  string            `json:"name"`
-	Type                  string            `json:"type"`
-	DisableResolveMessage bool              `json:"disableResolveMessage"`
-	Settings              json.RawMessage   `json:"settings"`
-	SecureSettings        map[string]string `json:"secureSettings"`
+	UID                   string            `json:"uid" yaml:"uid"`
+	Name                  string            `json:"name" yaml:"name"`
+	Type                  string            `json:"type" yaml:"type"`
+	DisableResolveMessage bool              `json:"disableResolveMessage" yaml:"disableResolveMessage"`
+	Settings              json.RawMessage   `json:"settings" yaml:"settings"`
+	SecureSettings        map[string]string `json:"secureSettings" yaml:"secureSettings"`
 }
 
 type ConfigReceiver = config.Receiver

--- a/receivers/email/config.go
+++ b/receivers/email/config.go
@@ -18,10 +18,10 @@ type Config struct {
 
 func NewConfig(jsonData json.RawMessage) (Config, error) {
 	type emailSettingsRaw struct {
-		SingleEmail bool   `json:"singleEmail,omitempty"`
-		Addresses   string `json:"addresses,omitempty"`
-		Message     string `json:"message,omitempty"`
-		Subject     string `json:"subject,omitempty"`
+		SingleEmail bool   `json:"singleEmail,omitempty" yaml:"singleEmail,omitempty"`
+		Addresses   string `json:"addresses,omitempty" yaml:"addresses,omitempty"`
+		Message     string `json:"message,omitempty" yaml:"message,omitempty"`
+		Subject     string `json:"subject,omitempty" yaml:"subject,omitempty"`
 	}
 
 	var settings emailSettingsRaw


### PR DESCRIPTION
Some fields are not being unmarshalled correctly when data is in yaml format, the default behavior for yaml and json unmarshallers are different (yaml takes the lowercased field name for a struct, see [here](https://github.com/go-yaml/yaml/blob/7649d4548cb53a614db133b2a8ac1f31859dda8c/yaml.go#L392-L396)). This PR adds `yaml` tags for configuration-related structs.