### PR TITLE
Add helper functions for working with Alertmanager configurations

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -203,6 +203,15 @@ type PostableApiAlertingConfig struct {
 	Receivers []*PostableApiReceiver `yaml:"receivers,omitempty" json:"receivers,omitempty"`
 }
 
+// Load parses a slice of bytes (json/yaml) into a configuration and validates it.
+func Load(rawCfg []byte) (*PostableApiAlertingConfig, error) {
+	var cfg PostableApiAlertingConfig
+	if err := yaml.Unmarshal(rawCfg, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
 func (c *PostableApiAlertingConfig) GetReceivers() []*PostableApiReceiver {
 	return c.Receivers
 }

--- a/definition/alertmanager_test.go
+++ b/definition/alertmanager_test.go
@@ -449,14 +449,12 @@ func Test_ApiAlertingConfig_Marshaling(t *testing.T) {
 			encoded, err := json.Marshal(tc.input)
 			require.Nil(t, err)
 
-			var out PostableApiAlertingConfig
-			err = json.Unmarshal(encoded, &out)
-
+			cfg, err := Load(encoded)
 			if tc.err {
 				require.Error(t, err)
 			} else {
 				require.Nil(t, err)
-				require.Equal(t, tc.input, out)
+				require.Equal(t, tc.input, *cfg)
 			}
 		})
 
@@ -464,14 +462,12 @@ func Test_ApiAlertingConfig_Marshaling(t *testing.T) {
 			encoded, err := yaml.Marshal(tc.input)
 			require.Nil(t, err)
 
-			var out PostableApiAlertingConfig
-			err = yaml.Unmarshal(encoded, &out)
-
+			cfg, err := Load(encoded)
 			if tc.err {
 				require.Error(t, err)
 			} else {
 				require.Nil(t, err)
-				require.Equal(t, tc.input, out)
+				require.Equal(t, tc.input, *cfg)
 			}
 		})
 	}

--- a/definition/compat.go
+++ b/definition/compat.go
@@ -26,7 +26,7 @@ func GrafanaToUpstreamConfig(cfg *PostableApiAlertingConfig) config.Config {
 	}
 }
 
-func PostableApiReceiverToApiReceiver(r *PostableApiReceiver) *notify.APIReceiver {
+func PostableAPIReceiverToAPIReceiver(r *PostableApiReceiver) *notify.APIReceiver {
 	integrations := notify.GrafanaIntegrations{
 		Integrations: make([]*notify.GrafanaIntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
 	}

--- a/definition/compat.go
+++ b/definition/compat.go
@@ -1,0 +1,48 @@
+package definition
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/alerting/notify"
+	"github.com/prometheus/alertmanager/config"
+)
+
+// GrafanaToUpstreamConfig converts a Grafana alerting configuration into an upstream Alertmanager configuration.
+// It ignores the configuration for Grafana receivers, adding only their names.
+func GrafanaToUpstreamConfig(cfg *PostableApiAlertingConfig) config.Config {
+	rcvs := make([]config.Receiver, 0, len(cfg.Receivers))
+	for _, r := range cfg.Receivers {
+		rcvs = append(rcvs, r.Receiver)
+	}
+
+	return config.Config{
+		Global:            cfg.Config.Global,
+		Route:             cfg.Config.Route.AsAMRoute(),
+		InhibitRules:      cfg.Config.InhibitRules,
+		Receivers:         rcvs,
+		Templates:         cfg.Config.Templates,
+		MuteTimeIntervals: cfg.Config.MuteTimeIntervals,
+		TimeIntervals:     cfg.Config.TimeIntervals,
+	}
+}
+
+func PostableApiReceiverToApiReceiver(r *PostableApiReceiver) *notify.APIReceiver {
+	integrations := notify.GrafanaIntegrations{
+		Integrations: make([]*notify.GrafanaIntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
+	}
+	for _, p := range r.GrafanaManagedReceivers {
+		integrations.Integrations = append(integrations.Integrations, &notify.GrafanaIntegrationConfig{
+			UID:                   p.UID,
+			Name:                  p.Name,
+			Type:                  p.Type,
+			DisableResolveMessage: p.DisableResolveMessage,
+			Settings:              json.RawMessage(p.Settings),
+			SecureSettings:        p.SecureSettings,
+		})
+	}
+
+	return &notify.APIReceiver{
+		ConfigReceiver:      r.Receiver,
+		GrafanaIntegrations: integrations,
+	}
+}

--- a/definition/compat_test.go
+++ b/definition/compat_test.go
@@ -43,7 +43,7 @@ func TestPostableApiReceiverToApiReceiver(t *testing.T) {
 			}},
 		},
 	}
-	receiver := PostableApiReceiverToApiReceiver(postableReceiver)
+	receiver := PostableAPIReceiverToAPIReceiver(postableReceiver)
 
 	require.Equal(t, "test", receiver.Name)
 	require.Equal(t, 1, len(receiver.GrafanaIntegrations.Integrations))

--- a/definition/compat_test.go
+++ b/definition/compat_test.go
@@ -1,0 +1,58 @@
+package definition
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/stretchr/testify/require"
+)
+
+var validConfig = []byte(`{"route":{"receiver":"grafana-default-email","routes":[{"receiver":"grafana-default-email","object_matchers":[["a","=","b"]],"mute_time_intervals":["test1"]}]},"mute_time_intervals":[{"name":"test1","time_intervals":[{"times":[{"start_time":"00:00","end_time":"12:00"}]}]}],"templates":null,"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"uxwfZvtnz","name":"email receiver","type":"email","disableResolveMessage":false,"settings":{"addresses":"<example@email.com>"},"secureFields":{}}]}]}`)
+
+func TestGrafanaToUpstreamConfig(t *testing.T) {
+	cfg, err := Load(validConfig)
+	require.NoError(t, err)
+	upstream := GrafanaToUpstreamConfig(cfg)
+
+	require.Equal(t, cfg.Global, upstream.Global)
+	require.Equal(t, cfg.Route.AsAMRoute(), upstream.Route)
+	require.Equal(t, cfg.InhibitRules, upstream.InhibitRules)
+	require.Equal(t, cfg.Templates, upstream.Templates)
+	require.Equal(t, cfg.MuteTimeIntervals, upstream.MuteTimeIntervals)
+	require.Equal(t, cfg.TimeIntervals, upstream.TimeIntervals)
+
+	for i, r := range cfg.Receivers {
+		require.Equal(t, r.Name, upstream.Receivers[i].Name)
+	}
+}
+
+func TestPostableApiReceiverToApiReceiver(t *testing.T) {
+	postableReceiver := &PostableApiReceiver{
+		Receiver: config.Receiver{
+			Name: "test",
+		},
+		PostableGrafanaReceivers: PostableGrafanaReceivers{
+			GrafanaManagedReceivers: []*PostableGrafanaReceiver{{
+				UID:                   "abc",
+				Name:                  "test",
+				Type:                  "slack",
+				DisableResolveMessage: true,
+				Settings:              RawMessage{'b', 'y', 't', 'e', 's'},
+				SecureSettings:        map[string]string{"key": "value"},
+			}},
+		},
+	}
+	receiver := PostableApiReceiverToApiReceiver(postableReceiver)
+
+	require.Equal(t, "test", receiver.Name)
+	require.Equal(t, 1, len(receiver.GrafanaIntegrations.Integrations))
+
+	i := receiver.GrafanaIntegrations.Integrations[0]
+	require.Equal(t, "abc", i.UID)
+	require.Equal(t, "test", i.Name)
+	require.Equal(t, "slack", i.Type)
+	require.Equal(t, true, i.DisableResolveMessage)
+	require.Equal(t, json.RawMessage{'b', 'y', 't', 'e', 's'}, i.Settings)
+	require.Equal(t, map[string]string{"key": "value"}, i.SecureSettings)
+}


### PR DESCRIPTION
This PR adds a few functions to parse and convert Alertmanager configurations:
- `Load()`: It parses a slice of bytes (json/yaml) into an Alertmanager configuration
- `GrafanaToUpstreamConfig()`: it converts a portable Grafana configuration into its upstream equivalent, ignoring the configuration for Grafana integrations
- `PostableApiReceiverToApiReceiver()`: `PostableApiReceiver` and `APIReceiver` are almost equivalent, but one of them uses an alias for `json.RawMessage` that allows unmarshalling YAML

Related PR: https://github.com/grafana/mimir/pull/8066