### PR TITLE
Parse config in a way that is compatible with the Mimir Alertmanager

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -135,12 +135,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	// Having a nil global config causes panics in the Alertmanager codebase.
-	if c.Global == nil {
-		c.Global = &config.GlobalConfig{}
-		*c.Global = config.DefaultGlobalConfig()
-	}
-
 	if c.Route == nil {
 		return fmt.Errorf("no routes provided")
 	}

--- a/definition/compat.go
+++ b/definition/compat.go
@@ -2,10 +2,219 @@ package definition
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/grafana/alerting/notify"
 	"github.com/prometheus/alertmanager/config"
+	"gopkg.in/yaml.v3"
 )
+
+// LoadCompat loads a PostableApiAlertingConfig from a YAML configuration
+// and runs validations to ensure that it works with the Mimir Alertmanager.
+func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
+	if len(rawCfg) == 0 {
+		return nil, fmt.Errorf("empty input")
+	}
+
+	var c PostableApiAlertingConfig
+	if err := yaml.Unmarshal(rawCfg, &c); err != nil {
+		return nil, err
+	}
+
+	// Having a nil global config causes panics in the Alertmanager codebase.
+	if c.Global == nil {
+		c.Global = &config.GlobalConfig{}
+		*c.Global = config.DefaultGlobalConfig()
+	}
+
+	// Check that the configuration for upstream receivers is well formed.
+	// Taken from https://github.com/prometheus/alertmanager/blob/e5821b78917591a5603e3e1788b6a94d5b2972e0/config/config.go#L356-L545
+	// with some modifications to ignore file-related settings.
+	names := map[string]struct{}{}
+	for _, rcv := range c.Receivers {
+		if _, ok := names[rcv.Name]; ok {
+			return nil, fmt.Errorf("notification config name %q is not unique", rcv.Name)
+		}
+		for _, wh := range rcv.WebhookConfigs {
+			if wh.HTTPConfig == nil {
+				wh.HTTPConfig = c.Global.HTTPConfig
+			}
+		}
+		for _, ec := range rcv.EmailConfigs {
+			if ec.Smarthost.String() == "" {
+				if c.Global.SMTPSmarthost.String() == "" {
+					return nil, fmt.Errorf("no global SMTP smarthost set")
+				}
+				ec.Smarthost = c.Global.SMTPSmarthost
+			}
+			if ec.From == "" {
+				if c.Global.SMTPFrom == "" {
+					return nil, fmt.Errorf("no global SMTP from set")
+				}
+				ec.From = c.Global.SMTPFrom
+			}
+			if ec.Hello == "" {
+				ec.Hello = c.Global.SMTPHello
+			}
+			if ec.AuthUsername == "" {
+				ec.AuthUsername = c.Global.SMTPAuthUsername
+			}
+			if ec.AuthPassword == "" {
+				ec.AuthPassword = c.Global.SMTPAuthPassword
+			}
+			if ec.AuthSecret == "" {
+				ec.AuthSecret = c.Global.SMTPAuthSecret
+			}
+			if ec.AuthIdentity == "" {
+				ec.AuthIdentity = c.Global.SMTPAuthIdentity
+			}
+			if ec.RequireTLS == nil {
+				ec.RequireTLS = new(bool)
+				*ec.RequireTLS = c.Global.SMTPRequireTLS
+			}
+		}
+		for _, sc := range rcv.SlackConfigs {
+			if sc.HTTPConfig == nil {
+				sc.HTTPConfig = c.Global.HTTPConfig
+			}
+			if sc.APIURL == nil {
+				if c.Global.SlackAPIURL == nil {
+					return nil, fmt.Errorf("no global Slack API URL set")
+				}
+				sc.APIURL = c.Global.SlackAPIURL
+			}
+		}
+		for _, poc := range rcv.PushoverConfigs {
+			if poc.HTTPConfig == nil {
+				poc.HTTPConfig = c.Global.HTTPConfig
+			}
+		}
+		for _, pdc := range rcv.PagerdutyConfigs {
+			if pdc.HTTPConfig == nil {
+				pdc.HTTPConfig = c.Global.HTTPConfig
+			}
+			if pdc.URL == nil {
+				if c.Global.PagerdutyURL == nil {
+					return nil, fmt.Errorf("no global PagerDuty URL set")
+				}
+				pdc.URL = c.Global.PagerdutyURL
+			}
+		}
+		for _, ogc := range rcv.OpsGenieConfigs {
+			if ogc.HTTPConfig == nil {
+				ogc.HTTPConfig = c.Global.HTTPConfig
+			}
+			if ogc.APIURL == nil {
+				if c.Global.OpsGenieAPIURL == nil {
+					return nil, fmt.Errorf("no global OpsGenie URL set")
+				}
+				ogc.APIURL = c.Global.OpsGenieAPIURL
+			}
+			if !strings.HasSuffix(ogc.APIURL.Path, "/") {
+				ogc.APIURL.Path += "/"
+			}
+			if ogc.APIKey == "" {
+				if c.Global.OpsGenieAPIKey == "" {
+					return nil, fmt.Errorf("no global OpsGenie API Key set")
+				}
+				ogc.APIKey = c.Global.OpsGenieAPIKey
+			}
+		}
+		for _, wcc := range rcv.WechatConfigs {
+			if wcc.HTTPConfig == nil {
+				wcc.HTTPConfig = c.Global.HTTPConfig
+			}
+
+			if wcc.APIURL == nil {
+				if c.Global.WeChatAPIURL == nil {
+					return nil, fmt.Errorf("no global Wechat URL set")
+				}
+				wcc.APIURL = c.Global.WeChatAPIURL
+			}
+
+			if wcc.APISecret == "" {
+				if c.Global.WeChatAPISecret == "" {
+					return nil, fmt.Errorf("no global Wechat ApiSecret set")
+				}
+				wcc.APISecret = c.Global.WeChatAPISecret
+			}
+
+			if wcc.CorpID == "" {
+				if c.Global.WeChatAPICorpID == "" {
+					return nil, fmt.Errorf("no global Wechat CorpID set")
+				}
+				wcc.CorpID = c.Global.WeChatAPICorpID
+			}
+
+			if !strings.HasSuffix(wcc.APIURL.Path, "/") {
+				wcc.APIURL.Path += "/"
+			}
+		}
+		for _, voc := range rcv.VictorOpsConfigs {
+			if voc.HTTPConfig == nil {
+				voc.HTTPConfig = c.Global.HTTPConfig
+			}
+			if voc.APIURL == nil {
+				if c.Global.VictorOpsAPIURL == nil {
+					return nil, fmt.Errorf("no global VictorOps URL set")
+				}
+				voc.APIURL = c.Global.VictorOpsAPIURL
+			}
+			if !strings.HasSuffix(voc.APIURL.Path, "/") {
+				voc.APIURL.Path += "/"
+			}
+			if voc.APIKey == "" {
+				if c.Global.VictorOpsAPIKey == "" {
+					return nil, fmt.Errorf("no global VictorOps API Key set")
+				}
+				voc.APIKey = c.Global.VictorOpsAPIKey
+			}
+		}
+		for _, sns := range rcv.SNSConfigs {
+			if sns.HTTPConfig == nil {
+				sns.HTTPConfig = c.Global.HTTPConfig
+			}
+		}
+
+		for _, telegram := range rcv.TelegramConfigs {
+			if telegram.HTTPConfig == nil {
+				telegram.HTTPConfig = c.Global.HTTPConfig
+			}
+			if telegram.APIUrl == nil {
+				telegram.APIUrl = c.Global.TelegramAPIUrl
+			}
+		}
+		for _, discord := range rcv.DiscordConfigs {
+			if discord.HTTPConfig == nil {
+				discord.HTTPConfig = c.Global.HTTPConfig
+			}
+			if discord.WebhookURL == nil {
+				return nil, fmt.Errorf("no discord webhook URL provided")
+			}
+		}
+		for _, webex := range rcv.WebexConfigs {
+			if webex.APIURL == nil {
+				if c.Global.WebexAPIURL == nil {
+					return nil, fmt.Errorf("no global Webex URL set")
+				}
+
+				webex.APIURL = c.Global.WebexAPIURL
+			}
+		}
+		for _, msteams := range rcv.MSTeamsConfigs {
+			if msteams.HTTPConfig == nil {
+				msteams.HTTPConfig = c.Global.HTTPConfig
+			}
+			if msteams.WebhookURL == nil {
+				return nil, fmt.Errorf("no msteams webhook URL provided")
+			}
+		}
+		names[rcv.Name] = struct{}{}
+	}
+
+	return &c, nil
+}
 
 // GrafanaToUpstreamConfig converts a Grafana alerting configuration into an upstream Alertmanager configuration.
 // It ignores the configuration for Grafana receivers, adding only their names.

--- a/definition/compat_test.go
+++ b/definition/compat_test.go
@@ -2,6 +2,7 @@ package definition
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/alertmanager/config"
@@ -9,6 +10,114 @@ import (
 )
 
 var validConfig = []byte(`{"route":{"receiver":"grafana-default-email","routes":[{"receiver":"grafana-default-email","object_matchers":[["a","=","b"]],"mute_time_intervals":["test1"]}]},"mute_time_intervals":[{"name":"test1","time_intervals":[{"times":[{"start_time":"00:00","end_time":"12:00"}]}]}],"templates":null,"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"uxwfZvtnz","name":"email receiver","type":"email","disableResolveMessage":false,"settings":{"addresses":"<example@email.com>"},"secureFields":{}}]}]}`)
+
+func TestLoadCompat(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		expErr string
+	}{
+		{
+			name:   "no configuration",
+			input:  []byte(``),
+			expErr: "empty input",
+		},
+		{
+			name:   "no routes",
+			input:  []byte(`{}`),
+			expErr: "no routes provided",
+		},
+		{
+			name:   "duplicated receivers",
+			input:  []byte(testConfigDuplicatedReceivers),
+			expErr: "notification config name \"test\" is not unique",
+		},
+		{
+			name:  "no global config",
+			input: []byte(testConfigWithoutGlobal),
+		},
+		{
+			name:   "no slack api url",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "slack_configs")),
+			expErr: "no global Slack API URL set",
+		},
+		{
+			name:   "no Opsgenie api key",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "opsgenie_configs")),
+			expErr: "no global OpsGenie API Key set",
+		},
+		{
+			name:   "no WeChat api secret",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "wechat_configs")),
+			expErr: "no global Wechat ApiSecret set",
+		},
+		{
+			name:   "no VictorOps api key",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "victorops_configs")),
+			expErr: "no global VictorOps API Key set",
+		},
+		{
+			name:   "no Discord url",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "discord_configs")),
+			expErr: "no discord webhook URL provided",
+		},
+		{
+			name:   "no MSTeams url",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "msteams_configs")),
+			expErr: "no msteams webhook URL provided",
+		},
+		{
+			name:   "no smarthost",
+			input:  []byte(fmt.Sprintf(missingValuesTemplate, "email_configs")),
+			expErr: "no global SMTP smarthost set",
+		},
+		{
+			name:  "with global config",
+			input: []byte(testConfigWithGlobal),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := LoadCompat([]byte(test.input))
+			if test.expErr != "" {
+				require.Error(t, err)
+				require.Equal(t, test.expErr, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+
+			// It should add the default global config.
+			require.NotNil(t, c.Global)
+			globalConfig := c.Global
+
+			// All configs should have the default http config set except for Webex.
+			require.Equal(t, c.Receivers[0].DiscordConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].MSTeamsConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].OpsGenieConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].PagerdutyConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].PushoverConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].SNSConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].SlackConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].TelegramConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].VictorOpsConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].WebhookConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+			require.Equal(t, c.Receivers[0].WechatConfigs[0].HTTPConfig, globalConfig.HTTPConfig)
+
+			if len(c.Receivers[0].EmailConfigs) > 0 {
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].Smarthost, globalConfig.SMTPSmarthost)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].From, globalConfig.SMTPFrom)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthUsername, globalConfig.SMTPAuthUsername)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthPassword, globalConfig.SMTPAuthPassword)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthSecret, globalConfig.SMTPAuthSecret)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthIdentity, globalConfig.SMTPAuthIdentity)
+				require.Equal(t, *c.Receivers[0].EmailConfigs[0].RequireTLS, globalConfig.SMTPRequireTLS)
+			}
+		})
+	}
+
+}
 
 func TestGrafanaToUpstreamConfig(t *testing.T) {
 	cfg, err := Load(validConfig)
@@ -56,3 +165,132 @@ func TestPostableApiReceiverToApiReceiver(t *testing.T) {
 	require.Equal(t, json.RawMessage{'b', 'y', 't', 'e', 's'}, i.Settings)
 	require.Equal(t, map[string]string{"key": "value"}, i.SecureSettings)
 }
+
+const testConfigWithoutGlobal = `
+route:
+  receiver: test
+  routes:
+    - receiver: test
+receivers:
+  - name: test
+    discord_configs:
+      - webhook_url: http://test.com
+    msteams_configs:
+      - webhook_url: http://test.com
+    opsgenie_configs:
+      - api_key: test
+    pagerduty_configs:
+      - routing_key: test
+    pushover_configs:
+      - user_key: test
+        token: test
+    slack_configs:
+      - api_url: http://test.com
+    sns_configs:
+      - topic_arn: test
+    telegram_configs:
+      - bot_token: test
+        chat_id: 1
+    victorops_configs:
+      - api_key: test
+        routing_key: test
+    webhook_configs:
+      - url: http://test.com
+    wechat_configs:
+      - api_key: test
+        api_secret: test
+        corp_id: test
+    webex_configs:
+      - api_url: http://test.com
+        room_id: test
+        http_config:
+          bearer_token: test
+`
+
+const testConfigWithGlobal = `
+global:
+  smtp_smarthost: smtp.example.org:587
+  smtp_from: testfrom@test.com
+  resolve_timeout: 5m
+  http_config:
+    follow_redirects: false
+    enable_http2: false
+  smtp_hello: test
+  smtp_require_tls: false
+  pagerduty_url: https://pagerdutytest.com
+  slack_api_url: https://slacktest.com
+  opsgenie_api_url: https://opsgenietest.com
+  opsgenie_api_key: test
+  wechat_api_url: https://wechattest.com
+  wechat_api_secret: test
+  wechat_api_corp_id: test_id
+  victorops_api_url: https://victoropstest.com
+  victorops_api_key: test
+  telegram_api_url: https://telegramtest.com
+  webex_api_url: https://webextest.com
+route:
+  receiver: test
+  routes:
+    - receiver: test
+receivers:
+  - name: test
+    email_configs:
+      - to: test
+    discord_configs:
+      - webhook_url: http://test.com
+    msteams_configs:
+      - webhook_url: http://test.com
+    opsgenie_configs:
+      - send_resolved: true
+    pagerduty_configs:
+      - routing_key: test
+    pushover_configs:
+      - user_key: test
+        token: test
+    slack_configs:
+      - channel: test
+    sns_configs:
+      - topic_arn: test
+    telegram_configs:
+      - bot_token: test
+        chat_id: 1
+    victorops_configs:
+      - routing_key: test
+    webhook_configs:
+      - url: http://test.com
+    wechat_configs:
+      - api_key: test
+    webex_configs:
+      - room_id: test
+        http_config:
+          bearer_token: test
+`
+
+const testConfigDuplicatedReceivers = `
+route:
+  receiver: test
+  routes:
+    - receiver: test
+receivers:
+  - name: test
+  - name: test
+`
+
+const missingValuesTemplate = `
+global:
+  resolve_timeout: 5m
+  http_config:
+    follow_redirects: false
+    enable_http2: false
+route:
+  receiver: test
+  routes:
+    - receiver: test
+receivers:
+  - name: test
+    %s:
+      - send_resolved: false
+        routing_key: test
+        to: test
+        webhook_url_file: test
+`


### PR DESCRIPTION
This PR adds `LoadCompat()`, a function to parse a `PostableApiAlertingConfig` from JSON or YAML and run validations to prevent issues when using it in the Mimir Alertmanager.

Related PR: https://github.com/grafana/mimir/pull/8200