### PR TITLE
fix(telegram): parse correctly ChatID and MessageThreadID

### DIFF
--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -28,34 +28,81 @@ type Config struct {
 	DisableNotifications  bool   `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty"`
 }
 
+type unmarshalConfig struct {
+	BotToken              string `json:"bottoken,omitempty" yaml:"bottoken,omitempty"`
+	ChatID                any    `json:"chatid,omitempty" yaml:"chatid,omitempty"`
+	MessageThreadID       any    `json:"message_thread_id,omitempty" yaml:"message_thread_id,omitempty"`
+	Message               string `json:"message,omitempty" yaml:"message,omitempty"`
+	ParseMode             string `json:"parse_mode,omitempty" yaml:"parse_mode,omitempty"`
+	DisableWebPagePreview bool   `json:"disable_web_page_preview,omitempty" yaml:"disable_web_page_preview,omitempty"`
+	ProtectContent        bool   `json:"protect_content,omitempty" yaml:"protect_content,omitempty"`
+	DisableNotifications  bool   `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty"`
+}
+
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
-	err := json.Unmarshal(jsonData, &settings)
+
+	unmarshaledConfig := unmarshalConfig{}
+	err := json.Unmarshal(jsonData, &unmarshaledConfig)
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
+
+	settings.BotToken = unmarshaledConfig.BotToken
+	settings.Message = unmarshaledConfig.Message
+	settings.ParseMode = unmarshaledConfig.ParseMode
+	settings.DisableWebPagePreview = unmarshaledConfig.DisableWebPagePreview
+	settings.ProtectContent = unmarshaledConfig.ProtectContent
+	settings.DisableNotifications = unmarshaledConfig.DisableNotifications
+
 	settings.BotToken = decryptFn("bottoken", settings.BotToken)
 	if settings.BotToken == "" {
 		return settings, errors.New("could not find Bot Token in settings")
 	}
-	if settings.ChatID == "" {
+
+	switch chatID := unmarshaledConfig.ChatID.(type) {
+	case string:
+		settings.ChatID = chatID
+
+	case float64:
+		settings.ChatID = strconv.Itoa(int(chatID))
+
+	case nil:
 		return settings, errors.New("could not find Chat Id in settings")
+
+	default:
+		return settings, errors.New("chat id must be either a string or an int")
 	}
+
 	if settings.Message == "" {
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
 	var messageThreadID int
-	if settings.MessageThreadID != "" {
-		messageThreadID, err = strconv.Atoi(settings.MessageThreadID)
+	switch id := unmarshaledConfig.MessageThreadID.(type) {
+	case string:
+		messageThreadID, err = strconv.Atoi(id)
 		if err != nil {
 			return settings, errors.New("message thread id must be an integer")
 		}
 
+	case float64:
+		messageThreadID = int(id)
+
+	case nil:
+
+	default:
+		return settings, errors.New("message thread id must be either a string or an int")
+	}
+
+	if messageThreadID != 0 {
 		if messageThreadID != int(int32(messageThreadID)) {
 			return settings, errors.New("message thread id must be an int32")
 		}
+
+		settings.MessageThreadID = strconv.Itoa(messageThreadID)
 	}
+
 	// if field is missing, then we fall back to the previous default: HTML
 	if settings.ParseMode == "" {
 		settings.ParseMode = DefaultTelegramParseMode

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -38,13 +38,33 @@ func TestNewConfig(t *testing.T) {
 			settings:          `{ "bottoken" : "12345" }`,
 			expectedInitError: `could not find Chat Id in settings`,
 		},
-
 		{
-			name:     "Minimal valid configuration",
-			settings: `{ "bottoken": "test-token", "chatid": "test-chat-id" }`,
+			name:              "Error if chatid is not a string or an int",
+			settings:          `{ "bottoken": "12345", "chatid" : {} }`,
+			expectedInitError: `chat id must be either a string or an int`,
+		},
+		{
+			name:     "should be able to parse an int ChatID",
+			settings: `{"chatid": 12345678}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
 			expectedConfig: Config{
 				BotToken:              "test-token",
-				ChatID:                "test-chat-id",
+				ChatID:                "12345678",
+				Message:               templates.DefaultMessageEmbed,
+				ParseMode:             "HTML",
+				DisableWebPagePreview: false,
+				ProtectContent:        false,
+				DisableNotifications:  false,
+			},
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{ "bottoken": "test-token", "chatid": "-1312" }`,
+			expectedConfig: Config{
+				BotToken:              "test-token",
+				ChatID:                "-1312",
 				Message:               templates.DefaultMessageEmbed,
 				ParseMode:             DefaultTelegramParseMode,
 				DisableWebPagePreview: false,
@@ -54,13 +74,13 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			name:     "Minimal valid configuration from secrets",
-			settings: `{"chatid": "test-chat-id" }`,
+			settings: `{"chatid": "-1312" }`,
 			secureSettings: map[string][]byte{
 				"bottoken": []byte("test-token"),
 			},
 			expectedConfig: Config{
 				BotToken:              "test-token",
-				ChatID:                "test-chat-id",
+				ChatID:                "-1312",
 				Message:               templates.DefaultMessageEmbed,
 				ParseMode:             DefaultTelegramParseMode,
 				DisableWebPagePreview: false,
@@ -70,13 +90,13 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			name:     "Should overwrite token from secrets",
-			settings: `{"bottoken": "token", "chatid" : "test-chat-id" }`,
+			settings: `{"bottoken": "token", "chatid" : "-1312" }`,
 			secureSettings: map[string][]byte{
 				"bottoken": []byte("test-token-key"),
 			},
 			expectedConfig: Config{
 				BotToken:              "test-token-key",
-				ChatID:                "test-chat-id",
+				ChatID:                "-1312",
 				Message:               templates.DefaultMessageEmbed,
 				ParseMode:             DefaultTelegramParseMode,
 				DisableWebPagePreview: false,
@@ -87,7 +107,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "All empty fields = minimal valid configuration",
 			settings: `{
-				"chatid" :"chat-id",
+				"chatid" :"-1312",
 				"message" :"",
 				"parse_mode" :"",
 				"disable_notifications" : null
@@ -97,7 +117,7 @@ func TestNewConfig(t *testing.T) {
 			},
 			expectedConfig: Config{
 				BotToken:              "test-token",
-				ChatID:                "chat-id",
+				ChatID:                "-1312",
 				Message:               templates.DefaultMessageEmbed,
 				ParseMode:             DefaultTelegramParseMode,
 				DisableWebPagePreview: false,
@@ -191,7 +211,24 @@ func TestNewConfig(t *testing.T) {
 			},
 		},
 		{
-			name:     "should fail if message_thread_id is not an int",
+			name:     "should be able to parse an int MessageThreadID",
+			settings: `{"chatid": -1312, "message_thread_id": 12345678}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:              "test-token",
+				ChatID:                "-1312",
+				MessageThreadID:       "12345678",
+				Message:               templates.DefaultMessageEmbed,
+				ParseMode:             "HTML",
+				DisableWebPagePreview: false,
+				ProtectContent:        false,
+				DisableNotifications:  false,
+			},
+		},
+		{
+			name:     "should fail if message_thread_id is not an int #1",
 			settings: `{"chatid": "12345678", "message_thread_id": "notanint"}`,
 			secureSettings: map[string][]byte{
 				"bottoken": []byte("test-token"),
@@ -199,8 +236,24 @@ func TestNewConfig(t *testing.T) {
 			expectedInitError: "message thread id must be an integer",
 		},
 		{
+			name:     "should fail if message_thread_id is not an int #2",
+			settings: `{"chatid": "12345678", "message_thread_id": {}}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedInitError: "message thread id must be either a string or an int",
+		},
+		{
 			name:     "should fail if message_thread_id is not a valid int32",
 			settings: `{"chatid": "12345678", "message_thread_id": "21474836471"}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedInitError: "message thread id must be an int32",
+		},
+		{
+			name:     "should fail if message_thread_id is not a valid int32",
+			settings: `{"chatid": -1312, "message_thread_id": 21474836471}`,
 			secureSettings: map[string][]byte{
 				"bottoken": []byte("test-token"),
 			},


### PR DESCRIPTION
With this commit, the ChatID and MessageThreadID configuration of the Telegram notifier now can be configured either with a string or an integer, without any breaking changes for anyone consuming this library or the end users using it in their configuration files.

Fixes grafana/grafana#69950

# Reasoning

The [Telegram API specification](https://core.telegram.org/bots/api/#sendmessage) tells us that ChatID can be an Integer or a String and MessageThreadID must be an integer.

<hr>

In the PR grafana/grafana#63085, Grafana started to interpret correctly numbers and booleans from environment variables when provisioning files. So before the change, the following got evaluated:

`ENV="1"` -> `"1"` (string)

And after the change it evaluated as:

`ENV="1"` -> `1` (integer)

<hr>

With this new change, it is currently impossible to provision Telegram's ChatID or MessageThredID, since they're integers, and get parsed as such, like so:

`TELEGRAM_CHAT_ID="-1234"` -> `-1234`

And then grafana (using this library to parse the Telegram configuration), throws the following error:

```
failure parsing contact points: my-telegram: failed to validate integration "my-telegram" (UID telegram-1) of type "telegram": failed to unmarshal settings: json: cannot unmarshal number into Go struct field Config.chatid of type string
```

# Implementation details

In order to avoid introducing breaking changes, I've opted to duplicate the `Config` structure, making it private and transforming `ChatID` and `MessageThreadID` to the type `any`. Afterwards, the configuration value gets parsed and transformed back to a string, ensuring both `string` and `int` variants work.
 

# Other implementations explored

I've also explored two other options:

1. Rollback the changes introduced at grafana/grafana#63085. I've discarted this option since it was introduced for a reason and would also introduce breaking changes for all the users that now are using that featue.
2. Change the `ChatID` and `MessageThreadID` from `string` to `int`. I've also discarted this option, since it would introduce breaking changes for all the users that are already configuring Telegram using a `string` in the provisioning templates.

That's why I've opted for duplicating the struct, which is ugly but gets the work done and, more importantly, doesn't introduce any breaking change.

Let me know what you think! This issue is forcing us to stay at Grafana 9.3, which has some security vulnerabilities and not the latest features.

Thank you,

Néfix Estrada
IsardVDI