### PR TITLE
Invert dependency between definitions and notify packages

### DIFF
--- a/definition/compat.go
+++ b/definition/compat.go
@@ -1,11 +1,9 @@
 package definition
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/grafana/alerting/notify"
 	"github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v3"
 )
@@ -232,26 +230,5 @@ func GrafanaToUpstreamConfig(cfg *PostableApiAlertingConfig) config.Config {
 		Templates:         cfg.Config.Templates,
 		MuteTimeIntervals: cfg.Config.MuteTimeIntervals,
 		TimeIntervals:     cfg.Config.TimeIntervals,
-	}
-}
-
-func PostableAPIReceiverToAPIReceiver(r *PostableApiReceiver) *notify.APIReceiver {
-	integrations := notify.GrafanaIntegrations{
-		Integrations: make([]*notify.GrafanaIntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
-	}
-	for _, p := range r.GrafanaManagedReceivers {
-		integrations.Integrations = append(integrations.Integrations, &notify.GrafanaIntegrationConfig{
-			UID:                   p.UID,
-			Name:                  p.Name,
-			Type:                  p.Type,
-			DisableResolveMessage: p.DisableResolveMessage,
-			Settings:              json.RawMessage(p.Settings),
-			SecureSettings:        p.SecureSettings,
-		})
-	}
-
-	return &notify.APIReceiver{
-		ConfigReceiver:      r.Receiver,
-		GrafanaIntegrations: integrations,
 	}
 }

--- a/definition/compat_test.go
+++ b/definition/compat_test.go
@@ -1,11 +1,9 @@
 package definition
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,36 +132,6 @@ func TestGrafanaToUpstreamConfig(t *testing.T) {
 	for i, r := range cfg.Receivers {
 		require.Equal(t, r.Name, upstream.Receivers[i].Name)
 	}
-}
-
-func TestPostableApiReceiverToApiReceiver(t *testing.T) {
-	postableReceiver := &PostableApiReceiver{
-		Receiver: config.Receiver{
-			Name: "test",
-		},
-		PostableGrafanaReceivers: PostableGrafanaReceivers{
-			GrafanaManagedReceivers: []*PostableGrafanaReceiver{{
-				UID:                   "abc",
-				Name:                  "test",
-				Type:                  "slack",
-				DisableResolveMessage: true,
-				Settings:              RawMessage{'b', 'y', 't', 'e', 's'},
-				SecureSettings:        map[string]string{"key": "value"},
-			}},
-		},
-	}
-	receiver := PostableAPIReceiverToAPIReceiver(postableReceiver)
-
-	require.Equal(t, "test", receiver.Name)
-	require.Equal(t, 1, len(receiver.GrafanaIntegrations.Integrations))
-
-	i := receiver.GrafanaIntegrations.Integrations[0]
-	require.Equal(t, "abc", i.UID)
-	require.Equal(t, "test", i.Name)
-	require.Equal(t, "slack", i.Type)
-	require.Equal(t, true, i.DisableResolveMessage)
-	require.Equal(t, json.RawMessage{'b', 'y', 't', 'e', 's'}, i.Settings)
-	require.Equal(t, map[string]string{"key": "value"}, i.SecureSettings)
 }
 
 const testConfigWithoutGlobal = `

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -1,0 +1,28 @@
+package notify
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/alerting/definition"
+)
+
+func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) *APIReceiver {
+	integrations := GrafanaIntegrations{
+		Integrations: make([]*GrafanaIntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
+	}
+	for _, p := range r.GrafanaManagedReceivers {
+		integrations.Integrations = append(integrations.Integrations, &GrafanaIntegrationConfig{
+			UID:                   p.UID,
+			Name:                  p.Name,
+			Type:                  p.Type,
+			DisableResolveMessage: p.DisableResolveMessage,
+			Settings:              json.RawMessage(p.Settings),
+			SecureSettings:        p.SecureSettings,
+		})
+	}
+
+	return &APIReceiver{
+		ConfigReceiver:      r.Receiver,
+		GrafanaIntegrations: integrations,
+	}
+}

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -1,0 +1,40 @@
+package notify
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostableApiReceiverToApiReceiver(t *testing.T) {
+	postableReceiver := &definition.PostableApiReceiver{
+		Receiver: config.Receiver{
+			Name: "test",
+		},
+		PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+			GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{{
+				UID:                   "abc",
+				Name:                  "test",
+				Type:                  "slack",
+				DisableResolveMessage: true,
+				Settings:              definition.RawMessage{'b', 'y', 't', 'e', 's'},
+				SecureSettings:        map[string]string{"key": "value"},
+			}},
+		},
+	}
+	receiver := PostableAPIReceiverToAPIReceiver(postableReceiver)
+
+	require.Equal(t, "test", receiver.Name)
+	require.Equal(t, 1, len(receiver.GrafanaIntegrations.Integrations))
+
+	i := receiver.GrafanaIntegrations.Integrations[0]
+	require.Equal(t, "abc", i.UID)
+	require.Equal(t, "test", i.Name)
+	require.Equal(t, "slack", i.Type)
+	require.Equal(t, true, i.DisableResolveMessage)
+	require.Equal(t, json.RawMessage{'b', 'y', 't', 'e', 's'}, i.Settings)
+	require.Equal(t, map[string]string{"key": "value"}, i.SecureSettings)
+}


### PR DESCRIPTION
Definitions in this repo, just like definitions in grafana, needs to have the smallest possible set of dependencies. This is because go-swagger traverses every package in its dependency list, and can sometimes pick up things that shouldn't be included.

The usual pattern taken from grafana/grafana is to put type conversion code in the package needing to convert from/to definitions, that way definitions doesn't depend on random other packages.