### PR TITLE
Change GetReceivers interface to use API types.

### DIFF
--- a/models/receivers.go
+++ b/models/receivers.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"github.com/go-openapi/strfmt"
+)
+
+// Type definitions for the Grafana extended version of the /receivers API.
+
+type Receiver struct {
+	// Whether the receiver is used in a route or not.
+	Active bool `json:"active"`
+
+	// Integrations configured for this receiver.
+	Integrations []Integration `json:"integrations"`
+
+	// Name of the receiver.
+	Name string `json:"name"`
+}
+
+type Integration struct {
+	// A timestamp indicating the last attempt to deliver a notification regardless of the outcome.
+	// Format: date-time
+	LastNotifyAttempt strfmt.DateTime `json:"lastNotifyAttempt,omitempty"`
+
+	// Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).
+	LastNotifyAttemptDuration string `json:"lastNotifyAttemptDuration,omitempty"`
+
+	// Error string for the last attempt to deliver a notification. Empty if the last attempt was successful.
+	LastNotifyAttemptError string `json:"lastNotifyAttemptError,omitempty"`
+
+	// Name of the integration.
+	Name string `json:"name"`
+
+	// Whether the integration is configured to send resolved notifications.
+	SendResolved bool `json:"sendResolved"`
+}


### PR DESCRIPTION
This change pulls in the modified API types from the `grafana/prometheus-alertmanager` fork ([PR](https://github.com/grafana/prometheus-alertmanager/pull/31/files)), which Grafana uses for it's `/receivers` interface. This will allow us to drop that PR from the fork.

Additionally:
- I have tweaked the types slightly, leaving out the pointers. These aren't needed.
- Changed the `GetReceivers` function to return the API types, not the internal Alertmanager types.
- Make public the logic of creating the API response into a function (`GetReceivers`), as this will be needed in Mimir.
