### PR TITLE
Implement JSON decoder for config structs

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -147,12 +147,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	for _, r := range c.InhibitRules {
-		if err := r.UnmarshalYAML(unmarshal); err != nil {
-			return err
-		}
-	}
-
 	return c.validate()
 }
 

--- a/definition/alertmanager_test.go
+++ b/definition/alertmanager_test.go
@@ -24,9 +24,8 @@ func Test_ApiReceiver_Marshaling(t *testing.T) {
 				Receiver: config.Receiver{
 					Name: "foo",
 					EmailConfigs: []*config.EmailConfig{{
-						To:      "test@test.com",
-						HTML:    config.DefaultEmailConfig.HTML,
-						Headers: map[string]string{},
+						To:   "test@test.com",
+						HTML: config.DefaultEmailConfig.HTML,
 					}},
 				},
 			},
@@ -48,9 +47,8 @@ func Test_ApiReceiver_Marshaling(t *testing.T) {
 				Receiver: config.Receiver{
 					Name: "foo",
 					EmailConfigs: []*config.EmailConfig{{
-						To:      "test@test.com",
-						HTML:    config.DefaultEmailConfig.HTML,
-						Headers: map[string]string{},
+						To:   "test@test.com",
+						HTML: config.DefaultEmailConfig.HTML,
 					}},
 				},
 				PostableGrafanaReceivers: PostableGrafanaReceivers{


### PR DESCRIPTION
The yaml package does not support surrogate pairs ([related issue](https://github.com/go-yaml/yaml/issues/279)), using configurations with emojis results in errors in Grafana, we're using `UnmarshalYAML` under the hood when unmarshaling json. This PR is a quick fix for that.