### PR TITLE
Update TestReceivers function

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -85,9 +85,6 @@ type GrafanaAlertmanager struct {
 	silencer        *silence.Silencer
 	silences        *silence.Silences
 
-	// template is the current parsed template used for notification rendering.
-	// template *templates.Template
-
 	// timeIntervals is the set of all time_intervals and mute_time_intervals from
 	// the configuration.
 	timeIntervals map[string][]timeinterval.TimeInterval
@@ -335,9 +332,6 @@ func GetReceivers(receivers []*nfstatus.Receiver) []models.Receiver {
 	return apiReceivers
 }
 
-// TODO: Get rid of am.template (it's unnecessary now)
-// TODO: Refactor types (lower priority)
-
 // job contains all metadata required to test a receiver
 type job struct {
 	Config       *GrafanaIntegrationConfig
@@ -355,7 +349,7 @@ type result struct {
 func newTestReceiversResult(alert types.Alert, results []result, receivers []*APIReceiver, notifiedAt time.Time) *TestReceiversResult {
 	m := make(map[string]TestReceiverResult)
 	for _, receiver := range receivers {
-		// set up the result for this receiver
+		// Set up the result for this receiver
 		m[receiver.Name] = TestReceiverResult{
 			Name: receiver.Name,
 			// A Grafana receiver can have multiple nested receivers
@@ -407,9 +401,9 @@ func TestReceivers(
 		return nil, fmt.Errorf("failed to get template: %w", err)
 	}
 
-	// all invalid receiver configurations
+	// All invalid receiver configurations
 	invalid := make([]result, 0, len(c.Receivers))
-	// all receivers that need to be sent test notifications
+	// All receivers that need to be sent test notifications
 	jobs := make([]job, 0, len(c.Receivers))
 
 	for _, receiver := range c.Receivers {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -105,10 +105,15 @@ func (e IntegrationTimeoutError) Error() string {
 }
 
 func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, error) {
+	am.reloadConfigMtx.RLock()
+
 	tmpls := make([]string, 0, len(am.templates))
 	for _, tc := range am.templates {
 		tmpls = append(tmpls, tc.Template)
 	}
+
+	am.reloadConfigMtx.RUnlock()
+
 	return TestReceivers(ctx, c, tmpls, am.buildReceiverIntegrationsFunc, am.ExternalURL())
 }
 

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -7,16 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/dispatch"
-	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/alertmanager"
@@ -40,7 +37,6 @@ import (
 	"github.com/grafana/alerting/receivers/webex"
 	"github.com/grafana/alerting/receivers/webhook"
 	"github.com/grafana/alerting/receivers/wecom"
-	"github.com/grafana/alerting/templates"
 )
 
 const (
@@ -109,165 +105,11 @@ func (e IntegrationTimeoutError) Error() string {
 }
 
 func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, error) {
-	// now represents the start time of the test
-	now := time.Now()
-	testAlert := newTestAlert(c, now, now)
-
-	tmpl, err := am.getTemplate()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get template: %w", err)
+	tmpls := make([]string, 0, len(am.templates))
+	for _, tc := range am.templates {
+		tmpls = append(tmpls, tc.Template)
 	}
-
-	// job contains all metadata required to test a receiver
-	type job struct {
-		Config       *GrafanaIntegrationConfig
-		ReceiverName string
-		Notifier     notify.Notifier
-	}
-
-	// result contains the receiver that was tested and an error that is non-nil if the test failed
-	type result struct {
-		Config       *GrafanaIntegrationConfig
-		ReceiverName string
-		Error        error
-	}
-
-	newTestReceiversResult := func(alert types.Alert, results []result, notifiedAt time.Time) *TestReceiversResult {
-		m := make(map[string]TestReceiverResult)
-		for _, receiver := range c.Receivers {
-			// set up the result for this receiver
-			m[receiver.Name] = TestReceiverResult{
-				Name: receiver.Name,
-				// A Grafana receiver can have multiple nested receivers
-				Configs: make([]TestIntegrationConfigResult, 0, len(receiver.Integrations)),
-			}
-		}
-		for _, next := range results {
-			tmp := m[next.ReceiverName]
-			status := "ok"
-			if next.Error != nil {
-				status = "failed"
-			}
-			tmp.Configs = append(tmp.Configs, TestIntegrationConfigResult{
-				Name:   next.Config.Name,
-				UID:    next.Config.UID,
-				Status: status,
-				Error:  ProcessIntegrationError(next.Config, next.Error),
-			})
-			m[next.ReceiverName] = tmp
-		}
-		v := new(TestReceiversResult)
-		v.Alert = alert
-		v.Receivers = make([]TestReceiverResult, 0, len(c.Receivers))
-		v.NotifedAt = notifiedAt
-		for _, next := range m {
-			v.Receivers = append(v.Receivers, next)
-		}
-
-		// Make sure the return order is deterministic.
-		sort.Slice(v.Receivers, func(i, j int) bool {
-			return v.Receivers[i].Name < v.Receivers[j].Name
-		})
-
-		return v
-	}
-
-	// invalid keeps track of all invalid receiver configurations
-	invalid := make([]result, 0, len(c.Receivers))
-	// jobs keeps track of all receivers that need to be sent test notifications
-	jobs := make([]job, 0, len(c.Receivers))
-
-	for _, receiver := range c.Receivers {
-		for _, next := range receiver.Integrations {
-			n, err := am.buildSingleIntegration(next, tmpl)
-			if err != nil {
-				invalid = append(invalid, result{
-					Config:       next,
-					ReceiverName: next.Name,
-					Error:        err,
-				})
-			} else {
-				jobs = append(jobs, job{
-					Config:       next,
-					ReceiverName: receiver.Name,
-					Notifier:     n,
-				})
-			}
-		}
-	}
-
-	if len(invalid)+len(jobs) == 0 {
-		return nil, ErrNoReceivers
-	}
-
-	if len(jobs) == 0 {
-		return newTestReceiversResult(testAlert, invalid, now), nil
-	}
-
-	numWorkers := maxTestReceiversWorkers
-	if numWorkers > len(jobs) {
-		numWorkers = len(jobs)
-	}
-
-	resultCh := make(chan result, len(jobs))
-	workCh := make(chan job, len(jobs))
-	for _, job := range jobs {
-		workCh <- job
-	}
-	close(workCh)
-
-	g, ctx := errgroup.WithContext(ctx)
-	for i := 0; i < numWorkers; i++ {
-		g.Go(func() error {
-			for next := range workCh {
-				ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d",
-					next.ReceiverName,
-					testAlert.Labels.Fingerprint(),
-					now.Unix()))
-				ctx = notify.WithGroupLabels(ctx, testAlert.Labels)
-				ctx = notify.WithReceiverName(ctx, next.ReceiverName)
-				v := result{
-					Config:       next.Config,
-					ReceiverName: next.ReceiverName,
-				}
-				if _, err := next.Notifier.Notify(ctx, &testAlert); err != nil {
-					v.Error = err
-				}
-				resultCh <- v
-			}
-			return nil
-		})
-	}
-	err = g.Wait() // nolint
-	close(resultCh)
-
-	if err != nil {
-		return nil, err
-	}
-
-	results := make([]result, 0, len(jobs))
-	for next := range resultCh {
-		results = append(results, next)
-	}
-
-	return newTestReceiversResult(testAlert, append(invalid, results...), now), nil
-}
-
-func (am *GrafanaAlertmanager) buildSingleIntegration(r *GrafanaIntegrationConfig, tmpl *templates.Template) (*Integration, error) {
-	apiReceiver := &APIReceiver{
-		GrafanaIntegrations: GrafanaIntegrations{
-			Integrations: []*GrafanaIntegrationConfig{r},
-		},
-	}
-	integrations, err := am.buildReceiverIntegrationsFunc(apiReceiver, tmpl)
-	if err != nil {
-		return nil, err
-	}
-	if len(integrations) == 0 {
-		// This should not happen, but it is better to return some error rather than having a panic.
-		return nil, errors.New("failed to build integration")
-	}
-	return integrations[0], nil
+	return TestReceivers(ctx, c, tmpls, am.buildReceiverIntegrationsFunc, am.ExternalURL())
 }
 
 func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time) types.Alert {

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -134,6 +134,8 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 }
 
 func (am *GrafanaAlertmanager) GetTemplate() (*template.Template, error) {
+	am.reloadConfigMtx.RLock()
+
 	seen := make(map[string]struct{})
 	tmpls := make([]string, 0, len(am.templates))
 	for _, tc := range am.templates {
@@ -144,6 +146,8 @@ func (am *GrafanaAlertmanager) GetTemplate() (*template.Template, error) {
 		tmpls = append(tmpls, tc.Template)
 		seen[tc.Name] = struct{}{}
 	}
+
+	am.reloadConfigMtx.RUnlock()
 
 	tmpl, err := templateFromContent(tmpls, am.ExternalURL())
 	if err != nil {

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -19,7 +19,7 @@ type TestTemplatesConfigBodyParams struct {
 	// Template string to test.
 	Template string
 
-	// Name of the template file.
+	// Name of the template.
 	Name string
 }
 

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	tmplhtml "html/template"
+	"net/url"
 	tmpltext "text/template"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/alerting/templates"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
@@ -96,7 +98,7 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 	var captureTemplate template.Option = func(text *tmpltext.Template, _ *tmplhtml.Template) {
 		newTextTmpl = text
 	}
-	newTmpl, err := am.TemplateFromContent(templateContents, captureTemplate)
+	newTmpl, err := templateFromContent(templateContents, am.ExternalURL(), captureTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -131,6 +133,26 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 	return &results, nil
 }
 
+func (am *GrafanaAlertmanager) GetTemplate() (*template.Template, error) {
+	seen := make(map[string]struct{})
+	tmpls := make([]string, 0, len(am.templates))
+	for _, tc := range am.templates {
+		if _, ok := seen[tc.Name]; ok {
+			level.Warn(am.logger).Log("msg", "template with same name is defined multiple times, skipping...", "template_name", tc.Name)
+			continue
+		}
+		tmpls = append(tmpls, tc.Template)
+		seen[tc.Name] = struct{}{}
+	}
+
+	tmpl, err := templateFromContent(tmpls, am.ExternalURL())
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpl, nil
+}
+
 // parseTestTemplate parses the test template and returns the top-level definitions that should be interpolated as results.
 func parseTestTemplate(name string, text string) ([]string, error) {
 	tmpl, err := tmpltext.New(name).Funcs(tmpltext.FuncMap(template.DefaultFuncs)).Parse(text)
@@ -144,4 +166,18 @@ func parseTestTemplate(name string, text string) ([]string, error) {
 	}
 
 	return topLevel, nil
+}
+
+// TemplateFromContent returns a *Template based on defaults and the provided template contents.
+func templateFromContent(tmpls []string, externalURL string, options ...template.Option) (*templates.Template, error) {
+	tmpl, err := templates.FromContent(tmpls, options...)
+	if err != nil {
+		return nil, err
+	}
+	extURL, err := url.Parse(externalURL)
+	if err != nil {
+		return nil, err
+	}
+	tmpl.ExternalURL = extURL
+	return tmpl, nil
 }


### PR DESCRIPTION
This PR refactors `func (am *GrafanaAlertmanager)` to extract a lot of the functionality out into a standalone `TestReceivers` function so that it can be called from Mimir.

There is also some slight refactoring around templates, the `template` member within `GrafanaAlertmanager` has been removed as it is no longer required. Also, `templateFromContent` has been turned into a standalone helper function to no longer rely on any state, so that it can be used in multiple places.