### PR TITLE
Update TestTemplate function

### DIFF
--- a/notify/templates.go
+++ b/notify/templates.go
@@ -1,17 +1,13 @@
 package notify
 
 import (
-	"bytes"
 	"context"
-	tmplhtml "html/template"
 	"net/url"
 	tmpltext "text/template"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/alerting/templates"
-	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
-	"github.com/prometheus/common/model"
 )
 
 type TestTemplatesConfigBodyParams struct {
@@ -65,72 +61,11 @@ const (
 // TestTemplate tests the given template string against the given alerts. Existing templates are used to provide context for the test.
 // If an existing template of the same filename as the one being tested is found, it will not be used as context.
 func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams) (*TestTemplatesResults, error) {
-	definitions, err := parseTestTemplate(c.Name, c.Template)
-	if err != nil {
-		return &TestTemplatesResults{
-			Errors: []TestTemplatesErrorResult{{
-				Kind:  InvalidTemplate,
-				Error: err,
-			}},
-		}, nil
-	}
+	am.reloadConfigMtx.RLock()
+	tmpls := am.templates
+	am.reloadConfigMtx.RUnlock()
 
-	// Recreate the current template replacing the definition blocks that are being tested. This is so that any blocks that were removed don't get defined.
-	var found bool
-	templateContents := make([]string, 0, len(am.templates)+1)
-	for _, td := range am.templates {
-		if td.Name == c.Name {
-			// Template already exists, test with the new definition replacing the old one.
-			templateContents = append(templateContents, c.Template)
-			found = true
-			continue
-		}
-		templateContents = append(templateContents, td.Template)
-	}
-
-	if !found {
-		// Template is a new one, add it to the list.
-		templateContents = append(templateContents, c.Template)
-	}
-
-	// Capture the underlying text template so we can use ExecuteTemplate.
-	var newTextTmpl *tmpltext.Template
-	var captureTemplate template.Option = func(text *tmpltext.Template, _ *tmplhtml.Template) {
-		newTextTmpl = text
-	}
-	newTmpl, err := templateFromContent(templateContents, am.ExternalURL(), captureTemplate)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare the context.
-	alerts := OpenAPIAlertsToAlerts(c.Alerts)
-	ctx = notify.WithReceiverName(ctx, DefaultReceiverName)
-	ctx = notify.WithGroupLabels(ctx, model.LabelSet{DefaultGroupLabel: DefaultGroupLabelValue})
-
-	promTmplData := notify.GetTemplateData(ctx, newTmpl, alerts, am.logger)
-	data := templates.ExtendData(promTmplData, am.logger)
-
-	// Iterate over each definition in the template and evaluate it.
-	var results TestTemplatesResults
-	for _, def := range definitions {
-		var buf bytes.Buffer
-		err := newTextTmpl.ExecuteTemplate(&buf, def, data)
-		if err != nil {
-			results.Errors = append(results.Errors, TestTemplatesErrorResult{
-				Name:  def,
-				Kind:  ExecutionError,
-				Error: err,
-			})
-		} else {
-			results.Results = append(results.Results, TestTemplatesResult{
-				Name: def,
-				Text: buf.String(),
-			})
-		}
-	}
-
-	return &results, nil
+	return TestTemplate(ctx, c, tmpls, am.ExternalURL(), am.logger)
 }
 
 func (am *GrafanaAlertmanager) GetTemplate() (*template.Template, error) {

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -62,7 +62,8 @@ const (
 // If an existing template of the same filename as the one being tested is found, it will not be used as context.
 func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams) (*TestTemplatesResults, error) {
 	am.reloadConfigMtx.RLock()
-	tmpls := am.templates
+	tmpls := make([]templates.TemplateDefinition, len(am.templates))
+	copy(tmpls, am.templates)
 	am.reloadConfigMtx.RUnlock()
 
 	return TestTemplate(ctx, c, tmpls, am.ExternalURL(), am.logger)


### PR DESCRIPTION
This PR refactors `func (am *GrafanaAlertmanager) TestTemplate` to extract a lot of the functionality out into a standalone `TestTemplate` function so that it can be called from Mimir.