### PR TITLE
Add JSON struct tags to TestTemplatesResults

### DIFF
--- a/notify/templates.go
+++ b/notify/templates.go
@@ -22,8 +22,8 @@ type TestTemplatesConfigBodyParams struct {
 }
 
 type TestTemplatesResults struct {
-	Results []TestTemplatesResult
-	Errors  []TestTemplatesErrorResult
+	Results []TestTemplatesResult      `json:"results"`
+	Errors  []TestTemplatesErrorResult `json:"errors"`
 }
 
 type TestTemplatesResult struct {


### PR DESCRIPTION
JSON field names in `TestTemplatesResults` were being capitalized, explicitly setting them with JSON struct tags.