### PR TITLE
Update TestReceivers to use TemplateDefinition

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -392,14 +392,18 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 func TestReceivers(
 	ctx context.Context,
 	c TestReceiversConfigBodyParams,
-	tmpls []string,
+	tmpls []templates.TemplateDefinition,
 	buildIntegrationsFunc func(*APIReceiver, *template.Template) ([]*nfstatus.Integration, error),
 	externalURL string) (*TestReceiversResult, error) {
 
 	now := time.Now() // The start time of the test
 	testAlert := newTestAlert(c, now, now)
 
-	tmpl, err := templateFromContent(tmpls, externalURL)
+	templates := make([]string, len(tmpls))
+	for _, tmpl := range tmpls {
+		templates = append(templates, tmpl.Template)
+	}
+	tmpl, err := templateFromContent(templates, externalURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get template: %w", err)
 	}

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -37,6 +37,7 @@ import (
 	"github.com/grafana/alerting/receivers/webex"
 	"github.com/grafana/alerting/receivers/webhook"
 	"github.com/grafana/alerting/receivers/wecom"
+	"github.com/grafana/alerting/templates"
 )
 
 const (
@@ -106,12 +107,8 @@ func (e IntegrationTimeoutError) Error() string {
 
 func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, error) {
 	am.reloadConfigMtx.RLock()
-
-	tmpls := make([]string, 0, len(am.templates))
-	for _, tc := range am.templates {
-		tmpls = append(tmpls, tc.Template)
-	}
-
+	tmpls := make([]templates.TemplateDefinition, len(am.templates))
+	copy(tmpls, am.templates)
 	am.reloadConfigMtx.RUnlock()
 
 	return TestReceivers(ctx, c, tmpls, am.buildReceiverIntegrationsFunc, am.ExternalURL())


### PR DESCRIPTION
Updates `TestReceivers` to take in a `[]templates.TemplateDefinition` rather than just a `[]string` - this also makes it consistent with `TestTemplate`