### PR TITLE
Fix Telegram integration to send photos in message thread along with text

### DIFF
--- a/images/testing.go
+++ b/images/testing.go
@@ -11,13 +11,23 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/alerting/models"
 	"github.com/prometheus/alertmanager/types"
+
+	"github.com/grafana/alerting/models"
 )
 
 type FakeProvider struct {
 	Images []*Image
 	Bytes  []byte
+}
+
+func (f *FakeProvider) GetImageFileName(token string) string {
+	for _, image := range f.Images {
+		if image.Token == token {
+			return filepath.Base(image.Path)
+		}
+	}
+	return ""
 }
 
 // GetImage returns an image with the same token.
@@ -76,7 +86,7 @@ func getImageURI(alert *types.Alert) (string, error) {
 
 // NewFakeProvider returns an image provider with N test images.
 // Each image has a token and a URL, but does not have a file on disk.
-func NewFakeProvider(n int) Provider {
+func NewFakeProvider(n int) *FakeProvider {
 	p := FakeProvider{}
 	for i := 1; i <= n; i++ {
 		p.Images = append(p.Images, &Image{
@@ -93,7 +103,7 @@ func NewFakeProvider(n int) Provider {
 // PNG on disk. The test should call deleteFunc to delete the images from disk
 // at the end of the test.
 // nolint:deadcode,unused
-func NewFakeProviderWithFile(t *testing.T, n int) Provider {
+func NewFakeProviderWithFile(t *testing.T, n int) *FakeProvider {
 	var (
 		files []string
 		p     FakeProvider

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -57,7 +57,7 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 			return fmt.Errorf("failed to build message: %w", err)
 		}
 		for k, v := range msg {
-			if err := writeField(w, k, v); err != nil {
+			if err := w.WriteField(k, v); err != nil {
 				return fmt.Errorf("failed to create form field: %w", err)
 			}
 		}
@@ -147,16 +147,16 @@ func (tn *Notifier) newWebhookSyncCmd(action string, fn func(writer *multipart.W
 		}
 	}
 
-	if err := writeField(w, "chat_id", tn.settings.ChatID); err != nil {
+	if err := w.WriteField("chat_id", tn.settings.ChatID); err != nil {
 		return nil, err
 	}
 	if tn.settings.MessageThreadID != "" {
-		if err := writeField(w, "message_thread_id", tn.settings.MessageThreadID); err != nil {
+		if err := w.WriteField("message_thread_id", tn.settings.MessageThreadID); err != nil {
 			return nil, err
 		}
 	}
 	if tn.settings.DisableNotifications {
-		if err := writeField(w, "disable_notification", "true"); err != nil {
+		if err := w.WriteField("disable_notification", "true"); err != nil {
 			return nil, err
 		}
 	}
@@ -182,15 +182,4 @@ func (tn *Notifier) newWebhookSyncCmd(action string, fn func(writer *multipart.W
 
 func (tn *Notifier) SendResolved() bool {
 	return !tn.GetDisableResolveMessage()
-}
-
-func writeField(w *multipart.Writer, fieldName string, value string) error {
-	fw, err := w.CreateFormField("message_thread_id")
-	if err != nil {
-		return err
-	}
-	if _, err := fw.Write([]byte(value)); err != nil {
-		return err
-	}
-	return nil
 }

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -74,7 +74,7 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	}
 
 	// Create the cmd to upload each image
-	_ = images.WithStoredImages(ctx, tn.log, tn.images, func(index int, image images.Image) error {
+	_ = images.WithStoredImages(ctx, tn.log, tn.images, func(_ int, image images.Image) error {
 		cmd, err = tn.newWebhookSyncCmd("sendPhoto", func(w *multipart.Writer) error {
 			f, err := os.Open(image.Path)
 			if err != nil {

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -57,12 +57,8 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 			return fmt.Errorf("failed to build message: %w", err)
 		}
 		for k, v := range msg {
-			fw, err := w.CreateFormField(k)
-			if err != nil {
+			if err := writeField(w, k, v); err != nil {
 				return fmt.Errorf("failed to create form field: %w", err)
-			}
-			if _, err := fw.Write([]byte(v)); err != nil {
-				return fmt.Errorf("failed to write value: %w", err)
 			}
 		}
 		return nil
@@ -157,11 +153,7 @@ func (tn *Notifier) newWebhookSyncCmd(action string, fn func(writer *multipart.W
 		}
 	}
 
-	fw, err := w.CreateFormField("chat_id")
-	if err != nil {
-		return nil, err
-	}
-	if _, err := fw.Write([]byte(tn.settings.ChatID)); err != nil {
+	if err := writeField(w, "chat_id", tn.settings.ChatID); err != nil {
 		return nil, err
 	}
 
@@ -186,4 +178,15 @@ func (tn *Notifier) newWebhookSyncCmd(action string, fn func(writer *multipart.W
 
 func (tn *Notifier) SendResolved() bool {
 	return !tn.GetDisableResolveMessage()
+}
+
+func writeField(w *multipart.Writer, fieldName string, value string) error {
+	fw, err := w.CreateFormField("message_thread_id")
+	if err != nil {
+		return err
+	}
+	if _, err := fw.Write([]byte(value)); err != nil {
+		return err
+	}
+	return nil
 }

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -124,9 +124,6 @@ func (tn *Notifier) buildTelegramMessage(ctx context.Context, as []*types.Alert)
 
 	m := make(map[string]string)
 	m["text"] = messageText
-	if tn.settings.MessageThreadID != "" {
-		m["message_thread_id"] = tn.settings.MessageThreadID
-	}
 	if tn.settings.ParseMode != "" {
 		m["parse_mode"] = tn.settings.ParseMode
 	}
@@ -135,9 +132,6 @@ func (tn *Notifier) buildTelegramMessage(ctx context.Context, as []*types.Alert)
 	}
 	if tn.settings.ProtectContent {
 		m["protect_content"] = "true"
-	}
-	if tn.settings.DisableNotifications {
-		m["disable_notification"] = "true"
 	}
 	return m, nil
 }
@@ -155,6 +149,16 @@ func (tn *Notifier) newWebhookSyncCmd(action string, fn func(writer *multipart.W
 
 	if err := writeField(w, "chat_id", tn.settings.ChatID); err != nil {
 		return nil, err
+	}
+	if tn.settings.MessageThreadID != "" {
+		if err := writeField(w, "message_thread_id", tn.settings.MessageThreadID); err != nil {
+			return nil, err
+		}
+	}
+	if tn.settings.DisableNotifications {
+		if err := writeField(w, "disable_notification", "true"); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := fn(w); err != nil {

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -27,6 +27,9 @@ const telegramMaxMessageLenRunes = 4096
 
 // Notifier is responsible for sending
 // alert notifications to Telegram.
+// It uses two API endpoints
+// - https://core.telegram.org/bots/api#sendphoto for sending images (only if alerts contain references to them)
+// - https://core.telegram.org/bots/api#sendmessage for sending text message
 type Notifier struct {
 	*receivers.Base
 	log      logging.Logger

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -7,7 +7,6 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -29,12 +28,8 @@ func TestNotify(t *testing.T) {
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
-	//goland:noinspection ALL
-	image1, _ := images.GetImage(context.Background(), "test-image-1")
-	image1Name := filepath.Base(image1.Path)
-	//goland:noinspection ALL
-	image2, _ := images.GetImage(context.Background(), "test-image-2")
-	image2Name := filepath.Base(image2.Path)
+	image1Name := images.GetImageFileName("test-image-1")
+	image2Name := images.GetImageFileName("test-image-2")
 
 	cases := []struct {
 		name        string

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"context"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -28,8 +29,10 @@ func TestNotify(t *testing.T) {
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
+	//goland:noinspection ALL
 	image1, _ := images.GetImage(context.Background(), "test-image-1")
 	image1Name := filepath.Base(image1.Path)
+	//goland:noinspection ALL
 	image2, _ := images.GetImage(context.Background(), "test-image-2")
 	image2Name := filepath.Base(image2.Path)
 
@@ -192,11 +195,12 @@ func TestNotify(t *testing.T) {
 				data := map[string]string{}
 				for {
 					p, err := reader.NextPart()
-					if err == io.EOF {
+					if errors.Is(err, io.EOF) {
 						break
 					}
 					require.NoError(t, err)
 					slurp, err := io.ReadAll(p)
+					require.NoError(t, err)
 					fieldName := p.FormName()
 					photoName := p.FileName()
 					if assert.NotEmpty(t, fieldName) {

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -2,13 +2,18 @@ package telegram
 
 import (
 	"context"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	images2 "github.com/grafana/alerting/images"
@@ -23,13 +28,18 @@ func TestNotify(t *testing.T) {
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
+	image1, _ := images.GetImage(context.Background(), "test-image-1")
+	image1Name := filepath.Base(image1.Path)
+	image2, _ := images.GetImage(context.Background(), "test-image-2")
+	image2Name := filepath.Base(image2.Path)
 
 	cases := []struct {
 		name        string
 		settings    Config
 		alerts      []*types.Alert
-		expMsg      map[string]string
+		expMsg      []map[string]string
 		expMsgError error
+		expImages   int
 	}{
 		{
 			name: "A single alert with default template",
@@ -52,14 +62,20 @@ func TestNotify(t *testing.T) {
 					},
 				},
 			},
-			expMsg: map[string]string{
+			expMsg: []map[string]string{{
+				"chat_id":                  "someid",
 				"message_thread_id":        "threadid",
 				"parse_mode":               "Markdown",
 				"text":                     "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: a URL\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 				"disable_web_page_preview": "true",
 				"protect_content":          "true",
 				"disable_notification":     "true",
-			},
+			}, {
+				"chat_id":              "someid",
+				"message_thread_id":    "threadid",
+				"disable_notification": "true",
+				"photo":                image1Name,
+			}},
 			expMsgError: nil,
 		}, {
 			name: "Multiple alerts with custom template",
@@ -83,11 +99,19 @@ func TestNotify(t *testing.T) {
 					},
 				},
 			},
-			expMsg: map[string]string{
+			expMsg: []map[string]string{{
+				"chat_id":    "someid",
 				"parse_mode": "HTML",
 				"text":       "__Custom Firing__\n2 Firing\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: a URL\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
-			},
+			}, {
+				"chat_id": "someid",
+				"photo":   image1Name,
+			}, {
+				"chat_id": "someid",
+				"photo":   image2Name,
+			}},
 			expMsgError: nil,
+			expImages:   2,
 		}, {
 			name: "Truncate long message",
 			settings: Config{
@@ -103,10 +127,11 @@ func TestNotify(t *testing.T) {
 					},
 				},
 			},
-			expMsg: map[string]string{
+			expMsg: []map[string]string{{
+				"chat_id":    "someid",
 				"parse_mode": "HTML",
 				"text":       strings.Repeat("1", 4096-1) + "…",
-			},
+			}},
 			expMsgError: nil,
 		},
 	}
@@ -131,18 +156,60 @@ func TestNotify(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			ok, err := n.Notify(ctx, c.alerts...)
-			require.NoError(t, err)
-			require.True(t, ok)
-
-			msg, err := n.buildTelegramMessage(ctx, c.alerts)
+			recoverableErr, err := n.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
+				assert.False(t, recoverableErr)
 				require.Error(t, err)
 				require.Equal(t, c.expMsgError.Error(), err.Error())
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, c.expMsg, msg)
+
+			require.NotEmpty(t, notificationService.WebhookCalls, "webhook expected to be called but it wasn't")
+			require.Lenf(t, notificationService.WebhookCalls, len(c.expMsg), "expected %d requests to be made but got %d", len(c.expMsg), len(notificationService.WebhookCalls))
+
+			t.Run("message should go first", func(t *testing.T) {
+				msgCmd := notificationService.WebhookCalls[0]
+				assert.Equal(t, "https://api.telegram.org/bot"+c.settings.BotToken+"/sendMessage", msgCmd.URL)
+			})
+			if len(c.expMsg) > 1 {
+				t.Run("should send one request per image", func(t *testing.T) {
+					for i, call := range notificationService.WebhookCalls[1:] {
+						assert.Equalf(t, "https://api.telegram.org/bot"+c.settings.BotToken+"/sendPhoto", call.URL, "request at index %d was expected to be sendPhoto", i)
+					}
+				})
+			}
+
+			for i, call := range notificationService.WebhookCalls {
+				if !assert.Containsf(t, call.HTTPHeader, "Content-Type", "request at index %d did not contain Content-Type header", i) {
+					continue
+				}
+				mediaType, params, err := mime.ParseMediaType(call.HTTPHeader["Content-Type"])
+				assert.NoError(t, err)
+				assert.Equal(t, "multipart/form-data", mediaType)
+
+				reader := multipart.NewReader(strings.NewReader(call.Body), params["boundary"])
+				data := map[string]string{}
+				for {
+					p, err := reader.NextPart()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					slurp, err := io.ReadAll(p)
+					fieldName := p.FormName()
+					photoName := p.FileName()
+					if assert.NotEmpty(t, fieldName) {
+						if len(photoName) > 0 {
+							assert.NotEmptyf(t, slurp, "Content of the photo %s at in request at index %d is empty but it should not", photoName, i)
+							data[fieldName] = photoName
+						} else {
+							data[fieldName] = string(slurp)
+						}
+					}
+				}
+				assert.Equalf(t, c.expMsg[i], data, "form-data at index %d does not match expected one", i)
+			}
 		})
 	}
 }

--- a/receivers/testing.go
+++ b/receivers/testing.go
@@ -5,12 +5,14 @@ import (
 )
 
 type NotificationServiceMock struct {
-	Webhook     SendWebhookSettings
-	EmailSync   SendEmailSettings
-	ShouldError error
+	WebhookCalls []SendWebhookSettings
+	Webhook      SendWebhookSettings
+	EmailSync    SendEmailSettings
+	ShouldError  error
 }
 
 func (ns *NotificationServiceMock) SendWebhook(_ context.Context, cmd *SendWebhookSettings) error {
+	ns.WebhookCalls = append(ns.WebhookCalls, *cmd)
 	ns.Webhook = *cmd
 	return ns.ShouldError
 }


### PR DESCRIPTION
Currently, when a user specifies setting `message_thread_id`, only text messages are sent to the specified thread while images are sent to the parent chat. 
This PR fixes the integration to send the photos into the same thread. Also, PR refactors unit tests to make sure that all requests are asserted.

Fixes https://github.com/grafana/grafana/issues/87785
Related to #143 