### PR TITLE
Update Microsoft Teams to handle workflow responses differently

### DIFF
--- a/receivers/teams/models.go
+++ b/receivers/teams/models.go
@@ -1,0 +1,10 @@
+package teams
+
+type errorResponse struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -316,6 +316,7 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	if err != nil {
 		return false, fmt.Errorf("failed to parse URL: %w", err)
 	}
+	// TODO: remove it after August 15. Office webhooks are deprecated and are removed on August 15, https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/
 	if strings.HasSuffix(parsed.Host, "webhook.office.com") {
 		// Teams sometimes does not use status codes to show when a request has failed. Instead, the
 		// response can contain an error message, irrespective of status code (i.e. https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#rate-limiting-for-connectors)

--- a/receivers/teams/teams.go
+++ b/receivers/teams/teams.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -49,6 +51,7 @@ type AdaptiveCardsMessage struct {
 
 // NewAdaptiveCardsMessage returns a message prepared for adaptive cards.
 // https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#send-adaptive-cards-using-an-incoming-webhook
+// more info https://learn.microsoft.com/en-us/connectors/teams/?tabs=text1#microsoft-teams-webhook
 func NewAdaptiveCardsMessage(card AdaptiveCard) AdaptiveCardsMessage {
 	return AdaptiveCardsMessage{
 		Attachments: []AdaptiveCardsAttachment{{
@@ -309,9 +312,17 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	}
 
 	cmd := &receivers.SendWebhookSettings{URL: u, Body: string(b)}
-	// Teams sometimes does not use status codes to show when a request has failed. Instead, the
-	// response can contain an error message, irrespective of status code (i.e. https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#rate-limiting-for-connectors)
-	cmd.Validation = validateResponse
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	if strings.HasSuffix(parsed.Host, "webhook.office.com") {
+		// Teams sometimes does not use status codes to show when a request has failed. Instead, the
+		// response can contain an error message, irrespective of status code (i.e. https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#rate-limiting-for-connectors)
+		cmd.Validation = validateOfficeWebhookResponse
+	} else {
+		cmd.Validation = validateResponse(tn.log)
+	}
 
 	if err := tn.ns.SendWebhook(ctx, cmd); err != nil {
 		return false, errors.Wrap(err, "send notification to Teams")
@@ -321,13 +332,28 @@ func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 }
 
 //nolint:revive
-func validateResponse(b []byte, statusCode int) error {
+func validateOfficeWebhookResponse(b []byte, statusCode int) error {
 	// The request succeeded if the response is "1"
 	// https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#send-messages-using-curl-and-powershell
 	if !bytes.Equal(b, []byte("1")) {
 		return errors.New(string(b))
 	}
 	return nil
+}
+
+func validateResponse(l logging.Logger) func(b []byte, statusCode int) error {
+	return func(b []byte, statusCode int) error {
+		if statusCode/100 == 2 {
+			return nil
+		}
+		l.Error("failed to send notification and parse response", "statusCode", statusCode, "body", string(b))
+		errResponse := errorResponse{}
+		err := json.Unmarshal(b, &errResponse)
+		if err != nil {
+			return fmt.Errorf("failed to send notification, got status code %d, check logs for more details", statusCode)
+		}
+		return fmt.Errorf("failed to send notification, got status code %d: (%s) %s", statusCode, errResponse.Error.Code, errResponse.Error.Message)
+	}
 }
 
 func (tn *Notifier) SendResolved() bool {

--- a/receivers/teams/teams_test.go
+++ b/receivers/teams/teams_test.go
@@ -296,9 +296,9 @@ func TestNotify(t *testing.T) {
 	}
 }
 
-func Test_ValidateResponse(t *testing.T) {
-	require.NoError(t, validateResponse([]byte("1"), rand.Int()))
-	err := validateResponse([]byte("some error message"), rand.Int())
+func TestValidateWebhookResponse(t *testing.T) {
+	require.NoError(t, validateOfficeWebhookResponse([]byte("1"), rand.Int()))
+	err := validateOfficeWebhookResponse([]byte("some error message"), rand.Int())
 	require.Error(t, err)
 	require.Equal(t, "some error message", err.Error())
 }


### PR DESCRIPTION
MS Teams offers multiple ways of sending notifications:
- Office 365 Incoming Webhook ([deprecated](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/), EOL on August 15, 2024)
- Workflows [link](https://make.preview.powerautomate.com/galleries/public/templates/d271a6f01c2545a28348d8f2cddf4c8f/post-to-a-channel-when-a-webhook-request-is-received) and [link](https://make.preview.powerautomate.com/galleries/public/templates/34ac6c11796143e1807d6e16c4c28050/post-to-a-chat-when-a-webhook-request-is-received)

Currently, the MS teams integration supports sending to both because it uses Adaptive Cards payload but handles response only from the Office Webhook ([link](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-messages-using-curl-and-powershell)), and treats all responses that do not have character `1` in the response as failed requests. 

The workflow webhook does not follow this contract, and it causes successful requests to be considered as failed.

This PR fixes the response handling. It proposes different logic for handling responses that is applied based on the URL. If the URL host ends with ".webhook.office.com, " the request is considered an Incoming Webhook. 
I think this is a safe assumption because in the case of a false-negative match, the status is calculated by status code.

Related to: https://github.com/grafana/grafana/issues/90139