### PR TITLE
Alerting: Update Error to string in TestIntegrationConfigResult and TestTemplatesErrorResult

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -392,11 +392,16 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 			numUnknownErrors++
 		}
 
+		var errString string
+		if err != nil {
+			errString = err.Error()
+		}
+
 		tmp.Configs = append(tmp.Configs, TestIntegrationConfigResult{
 			Name:   next.Config.Name,
 			UID:    next.Config.UID,
 			Status: status,
-			Error:  err.Error(),
+			Error:  errString,
 		})
 		m[next.ReceiverName] = tmp
 	}

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	tmplhtml "html/template"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -360,7 +361,9 @@ type result struct {
 	Error        error
 }
 
-func newTestReceiversResult(alert types.Alert, results []result, receivers []*APIReceiver, notifiedAt time.Time) *TestReceiversResult {
+func newTestReceiversResult(alert types.Alert, results []result, receivers []*APIReceiver, notifiedAt time.Time) (*TestReceiversResult, int) {
+	var numBadRequests, numTimeouts, numUnknownErrors int
+
 	m := make(map[string]TestReceiverResult)
 	for _, receiver := range receivers {
 		// Set up the result for this receiver
@@ -376,11 +379,24 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 		if next.Error != nil {
 			status = "failed"
 		}
+
+		var invalidReceiverErr IntegrationValidationError
+		var receiverTimeoutErr IntegrationTimeoutError
+
+		err := ProcessIntegrationError(next.Config, next.Error)
+		if errors.As(err, &invalidReceiverErr) {
+			numBadRequests += 1
+		} else if errors.As(err, &receiverTimeoutErr) {
+			numTimeouts += 1
+		} else {
+			numUnknownErrors += 1
+		}
+
 		tmp.Configs = append(tmp.Configs, TestIntegrationConfigResult{
 			Name:   next.Config.Name,
 			UID:    next.Config.UID,
 			Status: status,
-			Error:  ProcessIntegrationError(next.Config, next.Error).Error(),
+			Error:  err.Error(),
 		})
 		m[next.ReceiverName] = tmp
 	}
@@ -397,7 +413,21 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 		return v.Receivers[i].Name < v.Receivers[j].Name
 	})
 
-	return v
+	var returnCode int
+	if numBadRequests == len(v.Receivers) {
+		// if all receivers contain invalid configuration
+		returnCode = http.StatusBadRequest
+	} else if numTimeouts == len(v.Receivers) {
+		// if all receivers contain valid configuration but timed out
+		returnCode = http.StatusRequestTimeout
+	} else if numBadRequests+numTimeouts+numUnknownErrors > 0 {
+		returnCode = http.StatusMultiStatus
+	} else {
+		// all receivers were sent a notification without error
+		returnCode = http.StatusOK
+	}
+
+	return v, returnCode
 }
 
 func TestReceivers(
@@ -405,14 +435,14 @@ func TestReceivers(
 	c TestReceiversConfigBodyParams,
 	tmpls []string,
 	buildIntegrationsFunc func(*APIReceiver, *template.Template) ([]*nfstatus.Integration, error),
-	externalURL string) (*TestReceiversResult, error) {
+	externalURL string) (*TestReceiversResult, int, error) {
 
 	now := time.Now() // The start time of the test
 	testAlert := newTestAlert(c, now, now)
 
 	tmpl, err := templateFromContent(tmpls, externalURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get template: %w", err)
+		return nil, 0, fmt.Errorf("failed to get template: %w", err)
 	}
 
 	// All invalid receiver configurations
@@ -447,11 +477,12 @@ func TestReceivers(
 	}
 
 	if len(invalid)+len(jobs) == 0 {
-		return nil, ErrNoReceivers
+		return nil, 0, ErrNoReceivers
 	}
 
 	if len(jobs) == 0 {
-		return newTestReceiversResult(testAlert, invalid, c.Receivers, now), nil
+		res, status := newTestReceiversResult(testAlert, invalid, c.Receivers, now)
+		return res, status, nil
 	}
 
 	numWorkers := maxTestReceiversWorkers
@@ -490,7 +521,7 @@ func TestReceivers(
 	close(resultCh)
 
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	results := make([]result, 0, len(jobs))
@@ -498,7 +529,8 @@ func TestReceivers(
 		results = append(results, next)
 	}
 
-	return newTestReceiversResult(testAlert, append(invalid, results...), c.Receivers, now), nil
+	res, status := newTestReceiversResult(testAlert, append(invalid, results...), c.Receivers, now)
+	return res, status, nil
 }
 
 func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []templates.TemplateDefinition, externalURL string, logger log.Logger) (*TestTemplatesResults, error) {

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -385,11 +385,11 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 
 		err := ProcessIntegrationError(next.Config, next.Error)
 		if errors.As(err, &invalidReceiverErr) {
-			numBadRequests += 1
+			numBadRequests++
 		} else if errors.As(err, &receiverTimeoutErr) {
-			numTimeouts += 1
+			numTimeouts++
 		} else {
-			numUnknownErrors += 1
+			numUnknownErrors++
 		}
 
 		tmp.Configs = append(tmp.Configs, TestIntegrationConfigResult{

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -380,7 +380,7 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 			Name:   next.Config.Name,
 			UID:    next.Config.UID,
 			Status: status,
-			Error:  ProcessIntegrationError(next.Config, next.Error),
+			Error:  ProcessIntegrationError(next.Config, next.Error).Error(),
 		})
 		m[next.ReceiverName] = tmp
 	}
@@ -507,7 +507,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 		return &TestTemplatesResults{
 			Errors: []TestTemplatesErrorResult{{
 				Kind:  InvalidTemplate,
-				Error: err,
+				Error: err.Error(),
 			}},
 		}, nil
 	}
@@ -557,7 +557,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 			results.Errors = append(results.Errors, TestTemplatesErrorResult{
 				Name:  def,
 				Kind:  ExecutionError,
-				Error: err,
+				Error: err.Error(),
 			})
 		} else {
 			results.Results = append(results.Results, TestTemplatesResult{

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -104,7 +104,7 @@ func (e IntegrationTimeoutError) Error() string {
 	return fmt.Sprintf("the receiver timed out: %s", e.Err)
 }
 
-func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, error) {
+func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, int, error) {
 	am.reloadConfigMtx.RLock()
 
 	tmpls := make([]string, 0, len(am.templates))

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -48,21 +48,21 @@ var (
 )
 
 type TestReceiversResult struct {
-	Alert     types.Alert
-	Receivers []TestReceiverResult
-	NotifedAt time.Time
+	Alert     types.Alert          `json:"alert"`
+	Receivers []TestReceiverResult `json:"receivers"`
+	NotifedAt time.Time            `json:"notifiedAt"`
 }
 
 type TestReceiverResult struct {
-	Name    string
-	Configs []TestIntegrationConfigResult
+	Name    string                        `json:"name"`
+	Configs []TestIntegrationConfigResult `json:"configs"`
 }
 
 type TestIntegrationConfigResult struct {
-	Name   string
-	UID    string
-	Status string
-	Error  error
+	Name   string `json:"name"`
+	UID    string `json:"uid"`
+	Status string `json:"status"`
+	Error  string `json:"error"`
 }
 
 type GrafanaIntegrationConfig struct {

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -42,7 +42,7 @@ type TestTemplatesErrorResult struct {
 	Kind TemplateErrorKind `json:"kind"`
 
 	// Error cause.
-	Error error `json:"error"`
+	Error string `json:"error"`
 }
 
 type TemplateErrorKind string

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -2,9 +2,7 @@ package notify
 
 import (
 	"context"
-	"errors"
 	"testing"
-	"text/template"
 
 	"github.com/grafana/alerting/templates"
 
@@ -85,7 +83,7 @@ func TestTemplateSimple(t *testing.T) {
 			Results: nil,
 			Errors: []TestTemplatesErrorResult{{
 				Kind:  InvalidTemplate,
-				Error: errors.New("template: slack.title:1: unclosed action"),
+				Error: "template: slack.title:1: unclosed action",
 			}},
 		},
 	}, {
@@ -98,12 +96,9 @@ func TestTemplateSimple(t *testing.T) {
 		expected: TestTemplatesResults{
 			Results: nil,
 			Errors: []TestTemplatesErrorResult{{
-				Name: "slack.title",
-				Kind: ExecutionError,
-				Error: template.ExecError{
-					Name: "slack.title",
-					Err:  errors.New(`template: :1:38: executing "slack.title" at <{{template "missing" .}}>: template "missing" not defined`),
-				},
+				Name:  "slack.title",
+				Kind:  ExecutionError,
+				Error: `template: :1:38: executing "slack.title" at <{{template "missing" .}}>: template "missing" not defined`,
 			}},
 		},
 	}, {
@@ -150,12 +145,9 @@ func TestTemplateSimple(t *testing.T) {
 				Text: "Discord Title",
 			}},
 			Errors: []TestTemplatesErrorResult{{
-				Name: "slack.title",
-				Kind: ExecutionError,
-				Error: template.ExecError{
-					Name: "other",
-					Err:  errors.New(`template: :1:91: executing "other" at <{{template "missing" .}}>: template "missing" not defined`),
-				},
+				Name:  "slack.title",
+				Kind:  ExecutionError,
+				Error: `template: :1:91: executing "other" at <{{template "missing" .}}>: template "missing" not defined`,
 			}},
 		},
 	},
@@ -227,7 +219,7 @@ func TestTemplateSpecialCases(t *testing.T) {
 			Results: nil,
 			Errors: []TestTemplatesErrorResult{{
 				Kind:  InvalidTemplate,
-				Error: errors.New(`template: slack.title:1: template: multiple definition of template "slack.title"`),
+				Error: `template: slack.title:1: template: multiple definition of template "slack.title"`,
 			}},
 		},
 	}, {
@@ -346,12 +338,9 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		expected: TestTemplatesResults{
 			Results: nil,
 			Errors: []TestTemplatesErrorResult{{
-				Name: "slack.title",
-				Kind: ExecutionError,
-				Error: template.ExecError{
-					Name: "slack.title",
-					Err:  errors.New(`template: :1:38: executing "slack.title" at <{{template "slack.alternate_title" .}}>: template "slack.alternate_title" not defined`),
-				},
+				Name:  "slack.title",
+				Kind:  ExecutionError,
+				Error: `template: :1:38: executing "slack.title" at <{{template "slack.alternate_title" .}}>: template "slack.alternate_title" not defined`,
 			}},
 		},
 	}, {


### PR DESCRIPTION
Also adds JSON tags for `TestReceiversResult`, `TestReceiverResult` and `TestIntegrationConfigResult` so they are lower case