### PR TITLE
Fix parsing of secrets in AWS SNS

### DIFF
--- a/receivers/sns/config.go
+++ b/receivers/sns/config.go
@@ -45,7 +45,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	}
 
 	if settings.TargetARN != "" {
-		_, err = arn.Parse(settings.TopicARN)
+		_, err = arn.Parse(settings.TargetARN)
 		if err != nil {
 			return Config{}, errors.New("invalid target ARN provided")
 		}
@@ -61,13 +61,10 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
-	if settings.Sigv4.AccessKey != "" || settings.Sigv4.SecretKey != "" {
-		if settings.Sigv4.AccessKey == "" || settings.Sigv4.SecretKey == "" {
-			return Config{}, errors.New("must specify both access key and secret key")
-		}
-		settings.Sigv4.AccessKey = decryptFn("accessKey", settings.Sigv4.AccessKey)
-		settings.Sigv4.SecretKey = decryptFn("secretKey", settings.Sigv4.SecretKey)
+	settings.Sigv4.AccessKey = decryptFn("sigv4.access_key", settings.Sigv4.AccessKey)
+	settings.Sigv4.SecretKey = decryptFn("sigv4.secret_key", settings.Sigv4.SecretKey)
+	if settings.Sigv4.AccessKey == "" && settings.Sigv4.SecretKey != "" || settings.Sigv4.AccessKey != "" && settings.Sigv4.SecretKey == "" {
+		return Config{}, errors.New("must specify both access key and secret key")
 	}
-
 	return settings, nil
 }

--- a/receivers/sns/config_test.go
+++ b/receivers/sns/config_test.go
@@ -27,6 +27,39 @@ func TestNewConfig(t *testing.T) {
 			expectedInitError: "must specify topicArn, targetArn, or phone number",
 		},
 		{
+			name: "Minimal valid configuration, topicArn",
+			settings: `{
+				"topic_arn": "arn:aws:sns:region:0123456789:SNSTopicName"
+			}`,
+			expected: Config{
+				TopicARN: "arn:aws:sns:region:0123456789:SNSTopicName",
+				Subject:  templates.DefaultMessageTitleEmbed,
+				Message:  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Minimal valid configuration, targetArn",
+			settings: `{
+				"target_arn": "arn:aws:sns:region:0123456789:SNSTargetName"
+			}`,
+			expected: Config{
+				TargetARN: "arn:aws:sns:region:0123456789:SNSTargetName",
+				Subject:   templates.DefaultMessageTitleEmbed,
+				Message:   templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "Minimal valid configuration, phoneNumber",
+			settings: `{
+				"phone_number": "555-555-5555"
+			}`,
+			expected: Config{
+				PhoneNumber: "555-555-5555",
+				Subject:     templates.DefaultMessageTitleEmbed,
+				Message:     templates.DefaultMessageEmbed,
+			},
+		},
+		{
 			name: "Auth type is set to credentials profile if profile provided",
 			settings: `{
 				"topic_arn": "arn:aws:sns:region:0123456789:SNSTopicName",
@@ -83,6 +116,20 @@ func TestNewConfig(t *testing.T) {
 				}
 			}`,
 			expectedInitError: "must specify both access key and secret key",
+		},
+		{
+			name: "Validation fails if TopicARN is invalid",
+			settings: `{
+				"topic_arn": "SNSTopicName"
+			}`,
+			expectedInitError: "invalid topic ARN provided",
+		},
+		{
+			name: "Validation fails if TargetARN is invalid",
+			settings: `{
+				"target_arn": "SNSTargetName"
+			}`,
+			expectedInitError: "invalid target ARN provided",
 		},
 		{
 			name: "Should be able to read secrets",
@@ -179,6 +226,7 @@ func TestNewConfig(t *testing.T) {
 				require.ErrorContains(t, err, c.expectedInitError)
 				return
 			}
+			require.NoError(t, err)
 			require.Equal(t, c.expected, sn)
 		})
 	}

--- a/receivers/sns/testing.go
+++ b/receivers/sns/testing.go
@@ -17,3 +17,9 @@ const FullValidConfigForTesting = `{
 		"role_arn": "arn:aws:iam:us-east-1:0123456789:role/my-role"
 	}
 }`
+
+// FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
+const FullValidSecretsForTesting = `{
+	"sigv4.access_key": "secret-access-key",
+	"sigv4.secret_key": "secret-secret-key"
+}`


### PR DESCRIPTION
This PR fixes logic for extracting secrets for fields SigV4.AccessKey and SigV4.SecretKey. This does not break anything because problem the secrets are not correctly extracted from the settings due to bug https://github.com/grafana/grafana/issues/92033