### PR TITLE
Add TLS, QoS and retain options to the MQTT receiver

### DIFF
--- a/receivers/mqtt/config.go
+++ b/receivers/mqtt/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	Password      string                   `json:"password,omitempty" yaml:"password,omitempty"`
 	QoS           receivers.OptionalNumber `json:"qos,omitempty" yaml:"qos,omitempty"`
 	Retain        bool                     `json:"retain,omitempty" yaml:"retain,omitempty"`
-	TLS           *receivers.TLSConfig     `json:"tls,omitempty" yaml:"tls,omitempty"`
+	TLSConfig     *receivers.TLSConfig     `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty"`
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
@@ -68,10 +68,10 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 
 	settings.Password = decryptFn("password", settings.Password)
 
-	if settings.TLS != nil {
-		settings.TLS.CACertificate = decryptFn("tlsCACertificate", settings.TLS.CACertificate)
-		settings.TLS.ClientCertificate = decryptFn("tlsClientCertificate", settings.TLS.ClientCertificate)
-		settings.TLS.ClientKey = decryptFn("tlsClientKey", settings.TLS.ClientKey)
+	if settings.TLSConfig != nil {
+		settings.TLSConfig.CACertificate = decryptFn("tlsCACertificate", settings.TLSConfig.CACertificate)
+		settings.TLSConfig.ClientCertificate = decryptFn("tlsClientCertificate", settings.TLSConfig.ClientCertificate)
+		settings.TLSConfig.ClientKey = decryptFn("tlsClientKey", settings.TLSConfig.ClientKey)
 	}
 
 	return settings, nil

--- a/receivers/mqtt/config.go
+++ b/receivers/mqtt/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net/url"
 
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
@@ -75,6 +76,12 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	settings.TLSConfig.CACertificate = decryptFn("tlsConfig.caCertificate", settings.TLSConfig.CACertificate)
 	settings.TLSConfig.ClientCertificate = decryptFn("tlsConfig.clientCertificate", settings.TLSConfig.ClientCertificate)
 	settings.TLSConfig.ClientKey = decryptFn("tlsConfig.clientKey", settings.TLSConfig.ClientKey)
+
+	parsedURL, err := url.Parse(settings.BrokerURL)
+	if err != nil {
+		return Config{}, errors.New("Failed to parse broker URL")
+	}
+	settings.TLSConfig.ServerName = parsedURL.Hostname()
 
 	return settings, nil
 }

--- a/receivers/mqtt/config.go
+++ b/receivers/mqtt/config.go
@@ -16,19 +16,16 @@ const (
 )
 
 type Config struct {
-	BrokerURL            string                   `json:"brokerUrl,omitempty" yaml:"brokerUrl,omitempty"`
-	ClientID             string                   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	Topic                string                   `json:"topic,omitempty" yaml:"topic,omitempty"`
-	Message              string                   `json:"message,omitempty" yaml:"message,omitempty"`
-	MessageFormat        string                   `json:"messageFormat,omitempty" yaml:"messageFormat,omitempty"`
-	Username             string                   `json:"username,omitempty" yaml:"username,omitempty"`
-	Password             string                   `json:"password,omitempty" yaml:"password,omitempty"`
-	QoS                  receivers.OptionalNumber `json:"qos,omitempty" yaml:"qos,omitempty"`
-	InsecureSkipVerify   bool                     `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
-	Retain               bool                     `json:"retain,omitempty" yaml:"retain,omitempty"`
-	TLSCACertificate     string                   `json:"tlsCACertificate,omitempty" yaml:"tlsCACertificate,omitempty"`
-	TLSClientCertificate string                   `json:"tlsClientCertificate,omitempty" yaml:"tlsClientCertificate,omitempty"`
-	TLSClientKey         string                   `json:"tlsClientKey,omitempty" yaml:"tlsClientKey,omitempty"`
+	BrokerURL     string                   `json:"brokerUrl,omitempty" yaml:"brokerUrl,omitempty"`
+	ClientID      string                   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	Topic         string                   `json:"topic,omitempty" yaml:"topic,omitempty"`
+	Message       string                   `json:"message,omitempty" yaml:"message,omitempty"`
+	MessageFormat string                   `json:"messageFormat,omitempty" yaml:"messageFormat,omitempty"`
+	Username      string                   `json:"username,omitempty" yaml:"username,omitempty"`
+	Password      string                   `json:"password,omitempty" yaml:"password,omitempty"`
+	QoS           receivers.OptionalNumber `json:"qos,omitempty" yaml:"qos,omitempty"`
+	Retain        bool                     `json:"retain,omitempty" yaml:"retain,omitempty"`
+	TLS           *receivers.TLSConfig     `json:"tls,omitempty" yaml:"tls,omitempty"`
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
@@ -70,9 +67,12 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	}
 
 	settings.Password = decryptFn("password", settings.Password)
-	settings.TLSCACertificate = decryptFn("tlsCACertificate", settings.TLSCACertificate)
-	settings.TLSClientCertificate = decryptFn("tlsClientCertificate", settings.TLSClientCertificate)
-	settings.TLSClientKey = decryptFn("tlsClientKey", settings.TLSClientKey)
+
+	if settings.TLS != nil {
+		settings.TLS.CACertificate = decryptFn("tlsCACertificate", settings.TLS.CACertificate)
+		settings.TLS.ClientCertificate = decryptFn("tlsClientCertificate", settings.TLS.ClientCertificate)
+		settings.TLS.ClientKey = decryptFn("tlsClientKey", settings.TLS.ClientKey)
+	}
 
 	return settings, nil
 }

--- a/receivers/mqtt/config.go
+++ b/receivers/mqtt/config.go
@@ -68,11 +68,13 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 
 	settings.Password = decryptFn("password", settings.Password)
 
-	if settings.TLSConfig != nil {
-		settings.TLSConfig.CACertificate = decryptFn("tlsCACertificate", settings.TLSConfig.CACertificate)
-		settings.TLSConfig.ClientCertificate = decryptFn("tlsClientCertificate", settings.TLSConfig.ClientCertificate)
-		settings.TLSConfig.ClientKey = decryptFn("tlsClientKey", settings.TLSConfig.ClientKey)
+	if settings.TLSConfig == nil {
+		settings.TLSConfig = &receivers.TLSConfig{}
 	}
+
+	settings.TLSConfig.CACertificate = decryptFn("tlsConfig.caCertificate", settings.TLSConfig.CACertificate)
+	settings.TLSConfig.ClientCertificate = decryptFn("tlsConfig.clientCertificate", settings.TLSConfig.ClientCertificate)
+	settings.TLSConfig.ClientKey = decryptFn("tlsConfig.clientKey", settings.TLSConfig.ClientKey)
 
 	return settings, nil
 }

--- a/receivers/mqtt/config_test.go
+++ b/receivers/mqtt/config_test.go
@@ -47,6 +47,7 @@ func TestNewConfig(t *testing.T) {
 				BrokerURL:     "tcp://localhost:1883",
 				Topic:         "grafana/alerts",
 				MessageFormat: MessageFormatJSON,
+				TLSConfig:     &receivers.TLSConfig{},
 			},
 		},
 		{
@@ -71,6 +72,7 @@ func TestNewConfig(t *testing.T) {
 				Topic:         "grafana/alerts",
 				MessageFormat: MessageFormatJSON,
 				ClientID:      "test-client-id",
+				TLSConfig:     &receivers.TLSConfig{},
 			},
 		},
 		{
@@ -86,6 +88,28 @@ func TestNewConfig(t *testing.T) {
 				MessageFormat: MessageFormatJSON,
 				Username:      "grafana",
 				Password:      "testpasswd",
+				TLSConfig:     &receivers.TLSConfig{},
+			},
+		},
+		{
+			name:     "Configuration with tlsConfig",
+			settings: `{ "brokerUrl" : "tcp://localhost:1883", "topic": "grafana/alerts"}`,
+			secureSettings: map[string][]byte{
+				"tlsConfig.caCertificate":     []byte("test-ca-cert"),
+				"tlsConfig.clientCertificate": []byte("test-client-cert"),
+				"tlsConfig.clientKey":         []byte("test-client-key"),
+			},
+			expectedConfig: Config{
+				Message:       templates.DefaultMessageEmbed,
+				BrokerURL:     "tcp://localhost:1883",
+				Topic:         "grafana/alerts",
+				MessageFormat: MessageFormatJSON,
+				TLSConfig: &receivers.TLSConfig{
+					InsecureSkipVerify: false,
+					CACertificate:      "test-ca-cert",
+					ClientKey:          "test-client-key",
+					ClientCertificate:  "test-client-cert",
+				},
 			},
 		},
 	}

--- a/receivers/mqtt/config_test.go
+++ b/receivers/mqtt/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alerting/receivers"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -50,13 +51,15 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			name:     "Configuration with insecureSkipVerify",
-			settings: `{ "brokerUrl" : "tcp://localhost:1883", "topic": "grafana/alerts", "insecureSkipVerify": true}`,
+			settings: `{ "brokerUrl" : "tcp://localhost:1883", "topic": "grafana/alerts", "tls": {"insecureSkipVerify": true}}`,
 			expectedConfig: Config{
-				Message:            templates.DefaultMessageEmbed,
-				BrokerURL:          "tcp://localhost:1883",
-				Topic:              "grafana/alerts",
-				MessageFormat:      MessageFormatJSON,
-				InsecureSkipVerify: true,
+				Message:       templates.DefaultMessageEmbed,
+				BrokerURL:     "tcp://localhost:1883",
+				Topic:         "grafana/alerts",
+				MessageFormat: MessageFormatJSON,
+				TLS: &receivers.TLSConfig{
+					InsecureSkipVerify: true,
+				},
 			},
 		},
 		{

--- a/receivers/mqtt/config_test.go
+++ b/receivers/mqtt/config_test.go
@@ -51,13 +51,13 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			name:     "Configuration with insecureSkipVerify",
-			settings: `{ "brokerUrl" : "tcp://localhost:1883", "topic": "grafana/alerts", "tls": {"insecureSkipVerify": true}}`,
+			settings: `{ "brokerUrl" : "tcp://localhost:1883", "topic": "grafana/alerts", "tlsConfig": {"insecureSkipVerify": true}}`,
 			expectedConfig: Config{
 				Message:       templates.DefaultMessageEmbed,
 				BrokerURL:     "tcp://localhost:1883",
 				Topic:         "grafana/alerts",
 				MessageFormat: MessageFormatJSON,
-				TLS: &receivers.TLSConfig{
+				TLSConfig: &receivers.TLSConfig{
 					InsecureSkipVerify: true,
 				},
 			},

--- a/receivers/mqtt/config_test.go
+++ b/receivers/mqtt/config_test.go
@@ -47,7 +47,9 @@ func TestNewConfig(t *testing.T) {
 				BrokerURL:     "tcp://localhost:1883",
 				Topic:         "grafana/alerts",
 				MessageFormat: MessageFormatJSON,
-				TLSConfig:     &receivers.TLSConfig{},
+				TLSConfig: &receivers.TLSConfig{
+					ServerName: "localhost",
+				},
 			},
 		},
 		{
@@ -60,6 +62,7 @@ func TestNewConfig(t *testing.T) {
 				MessageFormat: MessageFormatJSON,
 				TLSConfig: &receivers.TLSConfig{
 					InsecureSkipVerify: true,
+					ServerName:         "localhost",
 				},
 			},
 		},
@@ -72,7 +75,9 @@ func TestNewConfig(t *testing.T) {
 				Topic:         "grafana/alerts",
 				MessageFormat: MessageFormatJSON,
 				ClientID:      "test-client-id",
-				TLSConfig:     &receivers.TLSConfig{},
+				TLSConfig: &receivers.TLSConfig{
+					ServerName: "localhost",
+				},
 			},
 		},
 		{
@@ -88,7 +93,9 @@ func TestNewConfig(t *testing.T) {
 				MessageFormat: MessageFormatJSON,
 				Username:      "grafana",
 				Password:      "testpasswd",
-				TLSConfig:     &receivers.TLSConfig{},
+				TLSConfig: &receivers.TLSConfig{
+					ServerName: "localhost",
+				},
 			},
 		},
 		{
@@ -106,6 +113,7 @@ func TestNewConfig(t *testing.T) {
 				MessageFormat: MessageFormatJSON,
 				TLSConfig: &receivers.TLSConfig{
 					InsecureSkipVerify: false,
+					ServerName:         "localhost",
 					CACertificate:      "test-ca-cert",
 					ClientKey:          "test-client-key",
 					ClientCertificate:  "test-client-cert",

--- a/receivers/mqtt/mqtt.go
+++ b/receivers/mqtt/mqtt.go
@@ -71,7 +71,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	var tlsCfg *tls.Config
 	if n.settings.TLSConfig != nil {
-		tlsCfg, err = n.settings.TLSConfig.ToTLSConfig()
+		tlsCfg, err = n.settings.TLSConfig.ToCryptoTLSConfig()
 	}
 	if err != nil {
 		n.log.Error("Failed to build TLS config", "error", err.Error())

--- a/receivers/mqtt/mqtt.go
+++ b/receivers/mqtt/mqtt.go
@@ -114,7 +114,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 }
 
 func (n *Notifier) buildTLSConfig() (*tls.Config, error) {
-	if n.settings.TLS == nil {
+	if n.settings.TLSConfig == nil {
 		return nil, nil
 	}
 
@@ -125,17 +125,17 @@ func (n *Notifier) buildTLSConfig() (*tls.Config, error) {
 	}
 
 	tlsCfg := &tls.Config{
-		InsecureSkipVerify: n.settings.TLS.InsecureSkipVerify,
+		InsecureSkipVerify: n.settings.TLSConfig.InsecureSkipVerify,
 		ServerName:         parsedURL.Hostname(),
 	}
 
-	if n.settings.TLS.CACertificate != "" {
+	if n.settings.TLSConfig.CACertificate != "" {
 		tlsCfg.RootCAs = x509.NewCertPool()
-		tlsCfg.RootCAs.AppendCertsFromPEM([]byte(n.settings.TLS.CACertificate))
+		tlsCfg.RootCAs.AppendCertsFromPEM([]byte(n.settings.TLSConfig.CACertificate))
 	}
 
-	if n.settings.TLS.ClientCertificate != "" || n.settings.TLS.ClientKey != "" {
-		cert, err := tls.X509KeyPair([]byte(n.settings.TLS.ClientCertificate), []byte(n.settings.TLS.ClientKey))
+	if n.settings.TLSConfig.ClientCertificate != "" || n.settings.TLSConfig.ClientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(n.settings.TLSConfig.ClientCertificate), []byte(n.settings.TLSConfig.ClientKey))
 		if err != nil {
 			n.log.Error("Failed to load client certificate", "error", err.Error())
 			return nil, err

--- a/receivers/mqtt/mqtt_test.go
+++ b/receivers/mqtt/mqtt_test.go
@@ -293,7 +293,7 @@ func TestNotify(t *testing.T) {
 				Topic:         "alert1",
 				Message:       templates.DefaultMessageEmbed,
 				MessageFormat: MessageFormatJSON,
-				TLS: &receivers.TLSConfig{
+				TLSConfig: &receivers.TLSConfig{
 					InsecureSkipVerify: true,
 					CACertificate:      testRsaCertPem,
 					ClientCertificate:  testRsaCertPem,
@@ -363,23 +363,23 @@ func TestNotify(t *testing.T) {
 			require.Equal(t, c.settings.ClientID, mockMQTTClient.clientID)
 			require.Equal(t, c.settings.BrokerURL, mockMQTTClient.brokerURL)
 
-			if c.settings.TLS == nil {
+			if c.settings.TLSConfig == nil {
 				require.Nil(t, mockMQTTClient.tlsCfg)
 			} else {
 				require.NotNil(t, mockMQTTClient.tlsCfg)
-				require.Equal(t, mockMQTTClient.tlsCfg.InsecureSkipVerify, c.settings.TLS.InsecureSkipVerify)
+				require.Equal(t, mockMQTTClient.tlsCfg.InsecureSkipVerify, c.settings.TLSConfig.InsecureSkipVerify)
 
 				// Check if the client certificate and key are set correctly.
-				if c.settings.TLS.ClientCertificate != "" && c.settings.TLS.ClientKey != "" {
-					clientCert, err := tls.X509KeyPair([]byte(c.settings.TLS.ClientCertificate), []byte(c.settings.TLS.ClientKey))
+				if c.settings.TLSConfig.ClientCertificate != "" && c.settings.TLSConfig.ClientKey != "" {
+					clientCert, err := tls.X509KeyPair([]byte(c.settings.TLSConfig.ClientCertificate), []byte(c.settings.TLSConfig.ClientKey))
 					require.NoError(t, err)
 					require.Equal(t, clientCert, mockMQTTClient.tlsCfg.Certificates[0])
 				}
 
 				// Check if the CA certificate is set correctly.
-				if c.settings.TLS.CACertificate != "" {
+				if c.settings.TLSConfig.CACertificate != "" {
 					expectedRootCAs := x509.NewCertPool()
-					expectedRootCAs.AppendCertsFromPEM([]byte(c.settings.TLS.CACertificate))
+					expectedRootCAs.AppendCertsFromPEM([]byte(c.settings.TLSConfig.CACertificate))
 					require.True(t, mockMQTTClient.tlsCfg.RootCAs.Equal(expectedRootCAs))
 				}
 			}
@@ -415,7 +415,7 @@ func TestNew(t *testing.T) {
 				Password:  "pass",
 				BrokerURL: "tcp://127.0.0.1:1883",
 				ClientID:  "test-grafana",
-				TLS: &receivers.TLSConfig{
+				TLSConfig: &receivers.TLSConfig{
 					InsecureSkipVerify: true,
 				},
 			},

--- a/receivers/mqtt/testing.go
+++ b/receivers/mqtt/testing.go
@@ -7,11 +7,19 @@ const FullValidConfigForTesting = `{
 	"messageFormat": "json",
 	"clientId": "grafana-test-client-id",
 	"username": "test-username",
+	"insecureSkipVerify": false,
+	"qos": 0,
+	"retain": false,
 	"password": "test-password",
-	"insecureSkipVerify": false
+	"tlsCACertificate": "test-tls-ca-certificate",
+	"tlsClientCertificate": "test-tls-client-certificate",
+	"tlsClientKey": "test-tls-client-key"
 }`
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
 const FullValidSecretsForTesting = `{
-	"password": "test-password"
+	"password": "test-password",
+	"tlsCACertificate": "test-tls-ca-certificate",
+	"tlsClientCertificate": "test-tls-client-certificate",
+	"tlsClientKey": "test-tls-client-key"
 }`

--- a/receivers/mqtt/testing.go
+++ b/receivers/mqtt/testing.go
@@ -7,19 +7,18 @@ const FullValidConfigForTesting = `{
 	"messageFormat": "json",
 	"clientId": "grafana-test-client-id",
 	"username": "test-username",
-	"insecureSkipVerify": false,
-	"qos": 0,
+	"qos": "0",
 	"retain": false,
 	"password": "test-password",
-	"tlsCACertificate": "test-tls-ca-certificate",
-	"tlsClientCertificate": "test-tls-client-certificate",
-	"tlsClientKey": "test-tls-client-key"
+	"tls": {
+		"insecureSkipVerify": false,
+		"caCertificate": "test-tls-ca-certificate",
+		"clientCertificate": "test-tls-client-certificate",
+		"clientKey": "test-tls-client-key"
+	}
 }`
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
 const FullValidSecretsForTesting = `{
-	"password": "test-password",
-	"tlsCACertificate": "test-tls-ca-certificate",
-	"tlsClientCertificate": "test-tls-client-certificate",
-	"tlsClientKey": "test-tls-client-key"
+	"password": "test-password"
 }`

--- a/receivers/mqtt/testing.go
+++ b/receivers/mqtt/testing.go
@@ -10,7 +10,7 @@ const FullValidConfigForTesting = `{
 	"qos": "0",
 	"retain": false,
 	"password": "test-password",
-	"tls": {
+	"tlsConfig": {
 		"insecureSkipVerify": false,
 		"caCertificate": "test-tls-ca-certificate",
 		"clientCertificate": "test-tls-client-certificate",

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -51,7 +51,7 @@ type TLSConfig struct {
 	ServerName         string
 }
 
-func (cfg *TLSConfig) ToTLSConfig() (*tls.Config, error) {
+func (cfg *TLSConfig) ToCryptoTLSConfig() (*tls.Config, error) {
 	tlsCfg := &tls.Config{
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
 		ServerName:         cfg.ServerName,

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -41,6 +41,13 @@ type HTTPCfg struct {
 	Password string
 }
 
+type TLSConfig struct {
+	CACertificate      string `json:"caCertificate,omitempty" yaml:"caCertificate,omitempty"`
+	ClientCertificate  string `json:"clientCertificate,omitempty" yaml:"clientCertificate,omitempty"`
+	ClientKey          string `json:"clientKey,omitempty" yaml:"clientKey,omitempty"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
+}
+
 // SendHTTPRequest sends an HTTP request.
 // Stubbable by tests.
 //

--- a/receivers/util_test.go
+++ b/receivers/util_test.go
@@ -1,0 +1,108 @@
+package receivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test certificates from https://github.com/golang/go/blob/4f852b9734249c063928b34a02dd689e03a8ab2c/src/crypto/tls/tls_test.go#L34
+const (
+	testRsaCertPem = `-----BEGIN CERTIFICATE-----
+MIIB0zCCAX2gAwIBAgIJAI/M7BYjwB+uMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTIwOTEyMjE1MjAyWhcNMTUwOTEyMjE1MjAyWjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANLJ
+hPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wok/4xIA+ui35/MmNa
+rtNuC+BdZ1tMuVCPFZcCAwEAAaNQME4wHQYDVR0OBBYEFJvKs8RfJaXTH08W+SGv
+zQyKn0H8MB8GA1UdIwQYMBaAFJvKs8RfJaXTH08W+SGvzQyKn0H8MAwGA1UdEwQF
+MAMBAf8wDQYJKoZIhvcNAQEFBQADQQBJlffJHybjDGxRMqaRmDhX0+6v02TUKZsW
+r5QuVbpQhH6u+0UgcW0jp9QwpxoPTLTWGXEWBBBurxFwiCBhkQ+V
+-----END CERTIFICATE-----`
+
+	testRsaKeyPem = `-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANLJhPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wo
+k/4xIA+ui35/MmNartNuC+BdZ1tMuVCPFZcCAwEAAQJAEJ2N+zsR0Xn8/Q6twa4G
+6OB1M1WO+k+ztnX/1SvNeWu8D6GImtupLTYgjZcHufykj09jiHmjHx8u8ZZB/o1N
+MQIhAPW+eyZo7ay3lMz1V01WVjNKK9QSn1MJlb06h/LuYv9FAiEA25WPedKgVyCW
+SmUwbPw8fnTcpqDWE3yTO3vKcebqMSsCIBF3UmVue8YU3jybC3NxuXq3wNm34R8T
+xVLHwDXh/6NJAiEAl2oHGGLz64BuAfjKrqwz7qMYr9HCLIe/YsoWq/olzScCIQDi
+D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
+-----END RSA PRIVATE KEY-----`
+)
+
+func TestNewTLSConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         TLSConfig
+		expectError bool
+	}{
+		{
+			name:        "empty TLSConfig",
+			cfg:         TLSConfig{},
+			expectError: false,
+		},
+		{
+			name: "valid CA certificate",
+			cfg: TLSConfig{
+				CACertificate: string(testRsaCertPem),
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid CA certificate",
+			cfg: TLSConfig{
+				CACertificate: "invalid-cert",
+			},
+			expectError: true,
+		},
+		{
+			name: "valid client certificate and key",
+			cfg: TLSConfig{
+				ClientCertificate: string(testRsaCertPem),
+				ClientKey:         string(testRsaKeyPem),
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid client certificate",
+			cfg: TLSConfig{
+				ClientCertificate: string(testRsaCertPem),
+			},
+			expectError: true,
+		},
+		{
+			name: "set InsecureSkipVerify and ServerName",
+			cfg: TLSConfig{
+				InsecureSkipVerify: true,
+				ServerName:         "example.com",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tlsCfg, err := tt.cfg.ToTLSConfig()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, tlsCfg)
+			} else {
+				require.NoError(t, err)
+
+				require.Equal(t, tt.cfg.InsecureSkipVerify, tlsCfg.InsecureSkipVerify, "InsecureSkipVerify mismatch")
+				require.Equal(t, tt.cfg.ServerName, tlsCfg.ServerName, "ServerName mismatch")
+
+				if tt.cfg.CACertificate != "" {
+					require.NotNil(t, tlsCfg.RootCAs, "expected RootCAs to be initialized, but it was nil")
+				}
+
+				if tt.cfg.ClientCertificate != "" && tt.cfg.ClientKey != "" {
+					require.NotEmpty(t, tlsCfg.Certificates, "expected Certificates to be set, but it was empty")
+				}
+			}
+		})
+	}
+}

--- a/receivers/util_test.go
+++ b/receivers/util_test.go
@@ -84,7 +84,7 @@ func TestNewTLSConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tlsCfg, err := tt.cfg.ToTLSConfig()
+			tlsCfg, err := tt.cfg.ToCryptoTLSConfig()
 
 			if tt.expectError {
 				require.Error(t, err)


### PR DESCRIPTION
Add TLS, QoS and Retain parameters to the MQTT receiver.

Grafana PR: https://github.com/grafana/grafana/pull/92331

Related: https://github.com/grafana/grafana/issues/16858 and https://github.com/grafana/alerting/pull/227