### PR TITLE
[Enhancement] Make `APIURL` for Pushover configurable

### DIFF
--- a/receivers/pushover/config.go
+++ b/receivers/pushover/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Config struct {
+	APIURL           string
 	UserKey          string
 	APIToken         string
 	AlertingPriority int64
@@ -27,6 +28,7 @@ type Config struct {
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	rawSettings := struct {
+		APIURL           string                   `json:"apiURL,omitempty" yaml:"apiURL,omitempty"`
 		UserKey          string                   `json:"userKey,omitempty" yaml:"userKey,omitempty"`
 		APIToken         string                   `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
 		AlertingPriority receivers.OptionalNumber `json:"priority,omitempty" yaml:"priority,omitempty"`

--- a/receivers/pushover/config_test.go
+++ b/receivers/pushover/config_test.go
@@ -42,6 +42,7 @@ func TestNewConfig(t *testing.T) {
 			name:     "Minimal valid configuration",
 			settings: `{"userKey": "test-user-key", "apiToken" : "test-api-token" }`,
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -64,6 +65,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -86,6 +88,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -103,6 +106,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "All empty fields = minimal valid configuration",
 			settings: `{
+				"apiURL": "",
 				"userKey": "",
 				"apiToken": "",
 				"priority": "",
@@ -121,6 +125,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -139,6 +144,7 @@ func TestNewConfig(t *testing.T) {
 			name:     "Extracts all fields",
 			settings: FullValidConfigForTesting,
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 1,
@@ -158,6 +164,7 @@ func TestNewConfig(t *testing.T) {
 			settings:       FullValidConfigForTesting,
 			secureSettings: receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-secret-user-key",
 				APIToken:         "test-secret-api-token",
 				AlertingPriority: 1,
@@ -185,6 +192,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 1,
@@ -253,6 +261,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -277,6 +286,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -301,6 +311,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,
@@ -325,6 +336,7 @@ func TestNewConfig(t *testing.T) {
 				"apiToken": []byte("test-api-token"),
 			},
 			expectedConfig: Config{
+				APIURL:           "",
 				UserKey:          "test-user-key",
 				APIToken:         "test-api-token",
 				AlertingPriority: 0,

--- a/receivers/pushover/pushover.go
+++ b/receivers/pushover/pushover.go
@@ -67,6 +67,9 @@ func (pn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		return false, err
 	}
 
+	if pn.settings.APIURL != "" {
+		APIURL = pn.settings.APIURL
+	}
 	cmd := &receivers.SendWebhookSettings{
 		URL:        APIURL,
 		HTTPMethod: "POST",

--- a/receivers/pushover/pushover_test.go
+++ b/receivers/pushover/pushover_test.go
@@ -42,6 +42,7 @@ func TestNotify(t *testing.T) {
 		{
 			name: "Correct config with single alert",
 			settings: Config{
+				APIURL:           "",
 				UserKey:          "<userKey>",
 				APIToken:         "<apiToken>",
 				AlertingPriority: 0,
@@ -80,6 +81,7 @@ func TestNotify(t *testing.T) {
 		{
 			name: "Upload is false",
 			settings: Config{
+				APIURL:           "",
 				UserKey:          "<userKey>",
 				APIToken:         "<apiToken>",
 				AlertingPriority: 0,
@@ -117,6 +119,7 @@ func TestNotify(t *testing.T) {
 		{
 			name: "Custom title",
 			settings: Config{
+				APIURL:           "",
 				UserKey:          "<userKey>",
 				APIToken:         "<apiToken>",
 				AlertingPriority: 0,
@@ -155,6 +158,7 @@ func TestNotify(t *testing.T) {
 		{
 			name: "Custom config with multiple alerts",
 			settings: Config{
+				APIURL:           "",
 				UserKey:          "<userKey>",
 				APIToken:         "<apiToken>",
 				AlertingPriority: 2,

--- a/receivers/pushover/testing.go
+++ b/receivers/pushover/testing.go
@@ -2,6 +2,7 @@ package pushover
 
 // FullValidConfigForTesting is a string representation of a JSON object that contains all fields supported by the notifier Config. It can be used without secrets.
 const FullValidConfigForTesting = `{
+	"apiURL": "",
 	"priority": 1,
 	"okPriority": 2,
 	"retry": 555,


### PR DESCRIPTION
I'm proposing an enhancement to the Pushover receiver, namely the ability to configure the `APIURL`. My motivation for that is that I'm using [an open-source alternative to Pushover](https://github.com/mrusme/overpush) which mimics its `messages.json` endpoint and is hence a drop-in replacement for Pushover.

I would like to be able to configure Grafana to use it as an alert receiver. The only thing that is missing in order to do so, is the ability to configure the `APIURL`.

Kindly consider this enhancement. If approved, I'm willing to go ahead and PR the required changes in the other Grafana components for this to work. Thank you.