### PR TITLE
Ensure ActiveTimeIntervals are propagated similar to MuteTimeIntervals

### DIFF
--- a/definition/alertmanager_test.go
+++ b/definition/alertmanager_test.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
 )
 
 func Test_ApiReceiver_Marshaling(t *testing.T) {
@@ -834,7 +835,7 @@ func Test_ConfigUnmashaling(t *testing.T) {
 		},
 		{
 			desc: "undefined mute time names in routes should error",
-			err:  errors.New("undefined time interval \"test2\" used in route"),
+			err:  errors.New("undefined mute time interval \"test2\" used in route"),
 			input: `
 				{
 				  "route": {
@@ -856,6 +857,65 @@ func Test_ConfigUnmashaling(t *testing.T) {
 					  ]
 				  },
 				  "mute_time_intervals": [
+					{
+					  "name": "test1",
+					  "time_intervals": [
+						{
+						  "times": [
+							{
+							  "start_time": "00:00",
+							  "end_time": "12:00"
+							}
+						  ]
+						}
+					  ]
+					}
+				  ],
+				  "templates": null,
+				  "receivers": [
+					{
+					  "name": "grafana-default-email",
+					  "grafana_managed_receiver_configs": [
+						{
+						  "uid": "uxwfZvtnz",
+						  "name": "email receiver",
+						  "type": "email",
+						  "disableResolveMessage": false,
+						  "settings": {
+							"addresses": "<example@email.com>"
+						  },
+						  "secureFields": {}
+						}
+					  ]
+					}
+				  ]
+				}
+			`,
+		},
+		{
+			desc: "undefined active time names in routes should error",
+			err:  errors.New("undefined active time interval \"test2\" used in route"),
+			input: `
+				{
+				  "route": {
+					"receiver": "grafana-default-email",
+					"routes": [
+						{
+						  "receiver": "grafana-default-email",
+						  "object_matchers": [
+							[
+							  "a",
+							  "=",
+							  "b"
+							]
+						  ],
+						  "active_time_intervals": [
+							"test2"
+						  ]
+						}
+					  ]
+				  },
+				  "time_intervals": [
 					{
 					  "name": "test1",
 					  "time_intervals": [

--- a/definition/alertmanager_validation.go
+++ b/definition/alertmanager_validation.go
@@ -85,6 +85,8 @@ func (r *Route) ValidateReceivers(receivers map[string]struct{}) error {
 	return nil
 }
 
+// ValidateMuteTimes validates that all mute time intervals referenced by the route exist.
+// TODO: Can be removed once grafana/grafan uses ValidateTimeIntervals instead.
 func (r *Route) ValidateMuteTimes(timeIntervals map[string]struct{}) error {
 	for _, name := range r.MuteTimeIntervals {
 		if _, exists := timeIntervals[name]; !exists {
@@ -100,14 +102,20 @@ func (r *Route) ValidateMuteTimes(timeIntervals map[string]struct{}) error {
 	return nil
 }
 
-func (r *Route) ValidateActiveTimes(timeIntervals map[string]struct{}) error {
+// ValidateTimeIntervals checks that all time intervals referenced by the route exist in the provided map.
+func (r *Route) ValidateTimeIntervals(timeIntervals map[string]struct{}) error {
+	for _, name := range r.MuteTimeIntervals {
+		if _, exists := timeIntervals[name]; !exists {
+			return fmt.Errorf("mute time interval '%s' does not exist", name)
+		}
+	}
 	for _, name := range r.ActiveTimeIntervals {
 		if _, exists := timeIntervals[name]; !exists {
 			return fmt.Errorf("active time interval '%s' does not exist", name)
 		}
 	}
 	for _, child := range r.Routes {
-		err := child.ValidateActiveTimes(timeIntervals)
+		err := child.ValidateTimeIntervals(timeIntervals)
 		if err != nil {
 			return err
 		}

--- a/definition/alertmanager_validation.go
+++ b/definition/alertmanager_validation.go
@@ -66,6 +66,9 @@ func (r *Route) Validate() error {
 	if len(r.MuteTimeIntervals) > 0 {
 		return fmt.Errorf("root route must not have any mute time intervals")
 	}
+	if len(r.ActiveTimeIntervals) > 0 {
+		return fmt.Errorf("root route must not have any active time intervals")
+	}
 	return r.ValidateChild()
 }
 
@@ -82,14 +85,29 @@ func (r *Route) ValidateReceivers(receivers map[string]struct{}) error {
 	return nil
 }
 
-func (r *Route) ValidateMuteTimes(muteTimes map[string]struct{}) error {
+func (r *Route) ValidateMuteTimes(timeIntervals map[string]struct{}) error {
 	for _, name := range r.MuteTimeIntervals {
-		if _, exists := muteTimes[name]; !exists {
+		if _, exists := timeIntervals[name]; !exists {
 			return fmt.Errorf("mute time interval '%s' does not exist", name)
 		}
 	}
 	for _, child := range r.Routes {
-		err := child.ValidateMuteTimes(muteTimes)
+		err := child.ValidateMuteTimes(timeIntervals)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Route) ValidateActiveTimes(timeIntervals map[string]struct{}) error {
+	for _, name := range r.ActiveTimeIntervals {
+		if _, exists := timeIntervals[name]; !exists {
+			return fmt.Errorf("active time interval '%s' does not exist", name)
+		}
+	}
+	for _, child := range r.Routes {
+		err := child.ValidateActiveTimes(timeIntervals)
 		if err != nil {
 			return err
 		}

--- a/definition/alertmanager_validation_test.go
+++ b/definition/alertmanager_validation_test.go
@@ -3,8 +3,9 @@ package definition
 import (
 	"testing"
 
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/common/model"
 )
 
 func TestValidateRoutes(t *testing.T) {
@@ -222,6 +223,15 @@ func TestValidateRoutes(t *testing.T) {
 					MuteTimeIntervals: []string{"10"},
 				},
 				expMsg: "must not have any mute time intervals",
+			},
+			{
+				desc: "active time intervals present",
+				route: Route{
+					Receiver:            "foo",
+					GroupByStr:          []string{"..."},
+					ActiveTimeIntervals: []string{"10"},
+				},
+				expMsg: "must not have any active time intervals",
 			},
 			{
 				desc: "validation error that is not specific to root",


### PR DESCRIPTION
Currently `ActiveTimeIntervals` are not validated or propagated in the same way as `MuteTimeIntervals`. This fixes that discrepancy and improves testing around complex route compats.

Followup to https://github.com/grafana/alerting/pull/229
Related to https://github.com/grafana/mimir/issues/8954