### PR TITLE
Include screenshot URL to Telegram message

### DIFF
--- a/receivers/telegram/config.go
+++ b/receivers/telegram/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	DisableWebPagePreview bool   `json:"disable_web_page_preview,omitempty" yaml:"disable_web_page_preview,omitempty"`
 	ProtectContent        bool   `json:"protect_content,omitempty" yaml:"protect_content,omitempty"`
 	DisableNotifications  bool   `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty"`
+	IncludeScreenshotURL  bool   `json:"include_screenshot_url,omitempty" yaml:"include_screenshot_url,omitempty"`
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {

--- a/receivers/telegram/config_test.go
+++ b/receivers/telegram/config_test.go
@@ -50,6 +50,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{
@@ -66,6 +67,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{
@@ -82,6 +84,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{
@@ -103,6 +106,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{
@@ -117,6 +121,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: true,
 				ProtectContent:        true,
 				DisableNotifications:  true,
+				IncludeScreenshotURL:  true,
 			},
 		},
 		{
@@ -132,6 +137,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: true,
 				ProtectContent:        true,
 				DisableNotifications:  true,
+				IncludeScreenshotURL:  true,
 			},
 		},
 		{
@@ -156,6 +162,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{
@@ -172,6 +179,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{
@@ -188,6 +196,7 @@ func TestNewConfig(t *testing.T) {
 				DisableWebPagePreview: false,
 				ProtectContent:        false,
 				DisableNotifications:  false,
+				IncludeScreenshotURL:  false,
 			},
 		},
 		{

--- a/receivers/telegram/telegram.go
+++ b/receivers/telegram/telegram.go
@@ -123,7 +123,7 @@ func (tn *Notifier) buildTelegramMessage(ctx context.Context, as []*types.Alert)
 	if tn.settings.IncludeScreenshotURL {
 		_ = images.WithStoredImages(ctx, tn.log, tn.images, func(_ int, image images.Image) error {
 			if len(image.URL) != 0 {
-				rawMessage += image.URL
+				rawMessage += " " + image.URL
 			}
 			return nil
 		}, as...)

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -50,6 +50,7 @@ func TestNotify(t *testing.T) {
 				DisableWebPagePreview: true,
 				ProtectContent:        true,
 				DisableNotifications:  true,
+				IncludeScreenshotURL:  false,
 			},
 			alerts: []*types.Alert{
 				{
@@ -129,6 +130,38 @@ func TestNotify(t *testing.T) {
 				"chat_id":    "someid",
 				"parse_mode": "HTML",
 				"text":       strings.Repeat("1", 4096-1) + "…",
+			}},
+			expMsgError: nil,
+		}, {
+			name: "A single alert with default template and inline image URL",
+			settings: Config{
+				BotToken:              "abcdefgh0123456789",
+				ChatID:                "someid",
+				MessageThreadID:       "threadid",
+				Message:               templates.DefaultMessageEmbed,
+				ParseMode:             "Markdown",
+				DisableWebPagePreview: true,
+				ProtectContent:        true,
+				DisableNotifications:  true,
+				IncludeScreenshotURL:  true,
+			},
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
+						GeneratorURL: "a URL",
+					},
+				},
+			},
+			expMsg: []map[string]string{{
+				"chat_id":                  "someid",
+				"message_thread_id":        "threadid",
+				"parse_mode":               "Markdown",
+				"text":                     "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: a URL\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n https://www.example.com/test-image-1",
+				"disable_web_page_preview": "true",
+				"protect_content":          "true",
+				"disable_notification":     "true",
 			}},
 			expMsgError: nil,
 		},

--- a/receivers/telegram/testing.go
+++ b/receivers/telegram/testing.go
@@ -9,7 +9,8 @@ const FullValidConfigForTesting = `{
 	"parse_mode" :"html",
 	"disable_web_page_preview" :true,
 	"protect_content" :true,
-	"disable_notifications" :true
+	"disable_notifications" :true,
+	"include_screenshot_url" :true
 }`
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets


### PR DESCRIPTION
This PR is for adding screenshot URL to Telegram messages.

This PR introduces `IncludeScreenshotURL` for a Telegram channel. When switch it on, all images will be sent to Telegram into 1 message as URLs. When switch it off, an image will be sent with the separate message.

Fixes #123