### PR TITLE
templates: add (org-aware) AlertingListURL to ExternalData and fix Slack receiver

### DIFF
--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -154,6 +154,45 @@ func TestNotify_IncomingWebhook(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Message is sent with orgId",
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            "https://example.com/hooks/xxxx",
+			Token:          "",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
+		alerts: []*types.Alert{{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1", "__orgId__": "123"},
+			},
+		}},
+		expectedMessage: &slackMessage{
+			Channel:   "#test",
+			Username:  "Grafana",
+			IconEmoji: ":emoji:",
+			Attachments: []attachment{
+				{
+					Title:      "[FIRING:1]  (val1)",
+					TitleLink:  "http://localhost/alerting/list?orgId=123",
+					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=123\n",
+					Fallback:   "[FIRING:1]  (val1)",
+					Fields:     nil,
+					Footer:     "Grafana v" + appVersion,
+					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
+					Color:      "#D63232",
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/templates/template_data_test.go
+++ b/templates/template_data_test.go
@@ -1,0 +1,52 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/prometheus/alertmanager/template"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/logging"
+	"github.com/grafana/alerting/models"
+)
+
+func TestParseAlertingListURL(t *testing.T) {
+	testcases := []struct {
+		name        string
+		data        *Data
+		expectedURI string
+	}{
+		{
+			name: "without org annotation",
+			data: &Data{
+				ExternalURL: "http://localhost:3000",
+			},
+			expectedURI: "http://localhost:3000/alerting/list",
+		},
+		{
+			name: "with org annotation",
+			data: &Data{
+				ExternalURL: "http://localhost:3000",
+				CommonAnnotations: template.KV{
+					models.OrgIDAnnotation: "1234",
+				},
+			},
+			expectedURI: "http://localhost:3000/alerting/list?orgId=1234",
+		},
+		{
+			name: "with invalid external URL",
+			data: &Data{
+				ExternalURL: `http%//invalid@url.com`,
+			},
+			expectedURI: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualURI := parseAlertingListURL(tc.data, &logging.FakeLogger{})
+
+			require.Equal(t, tc.expectedURI, actualURI)
+		})
+	}
+}


### PR DESCRIPTION
Some of the receivers use the /alerting/list for grouping alerts when their generator URLs aren't the same.

However these alerting list URLs are not "org-aware".

Instead of passing an orgId to every receiver constructor, we can enrich the template (extended) data with a URL that has the `?orgID=N` in case it exists in the common annotations, to be reused by any receiver.

I've also updated the Slack receiver as an example, since it fixes [#69248](https://github.com/grafana/grafana/issues/69248). If you approve of the approach, I can update the other receivers.