### PR TITLE
Fix: Check and clear `tmplErr` after executing the title template (Slack integration)

### DIFF
--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -315,6 +315,10 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 		}
 		sn.log.Warn("Truncated title", "key", key, "max_runes", slackMaxTitleLenRunes)
 	}
+	if tmplErr != nil {
+		sn.log.Warn("failed to template Slack title", "error", tmplErr.Error())
+		tmplErr = nil
+	}
 
 	req := &slackMessage{
 		Channel:   tmpl(sn.settings.Recipient),
@@ -400,7 +404,7 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (stri
 		return "", fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Type", "application/json; charset=utf-8")
 	request.Header.Set("User-Agent", "Grafana")
 	if sn.settings.Token == "" {
 		if sn.settings.URL == APIURL {

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -470,6 +470,45 @@ func TestNotify_PostMessage(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Errors in templates, message is sent",
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            APIURL,
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           `{{ template "undefined" . }}`,
+			Title:          `{{ template "undefined" . }}`,
+			Username:       `{{ template "undefined" . }}`,
+			IconEmoji:      `{{ template "undefined" . }}`,
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
+		alerts: []*types.Alert{{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		}},
+		expectedMessage: &slackMessage{
+			Channel:   "#test",
+			Username:  "",
+			IconEmoji: "",
+			Attachments: []attachment{
+				{
+					Title:      "",
+					TitleLink:  "http://localhost/alerting/list",
+					Text:       "",
+					Fallback:   "",
+					Fields:     nil,
+					Footer:     "Grafana v" + appVersion,
+					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
+					Color:      "#D63232",
+				},
+			},
+		},
+	}, {
 		name: "Message is sent to custom URL",
 		settings: Config{
 			EndpointURL:    "https://example.com/api",


### PR DESCRIPTION
Because of [how we handle templating errors](https://github.com/grafana/alerting/blob/6c25eb6eff103307621ef51bfa90192d839e96db/templates/template_data.go#L232-L243), a bad `title` template in a Slack receiver results in no value for the `channel` field. If a title template fails to be executed and we're using a bot token, we'll get back an error from the Slack API and the notification won't be sent.

```json
{
  "ok": false,
  "error": "invalid_arguments",
  "warning": "missing_charset",
  "response_metadata": {
    "messages": [
      "[ERROR] missing required field: channel"
    ],
    "warnings": [
      "missing_charset"
    ]
  }
}
```

This PR addresses this issue by clearing the error before we continue templating other fields. It also removes the `missing_charset` warning by sending `Content-Type": "application/json; charset=utf-8`.

Fixes https://github.com/grafana/grafana/issues/80224