### PR TITLE
SNS receiver: truncate subject in case it's over 100 characters

### DIFF
--- a/receivers/sns/sns.go
+++ b/receivers/sns/sns.go
@@ -160,7 +160,7 @@ func (s *Notifier) createPublishInput(ctx context.Context, tmpl func(string) str
 
 	messageToSend, isTrunc, err := validateAndTruncateString(tmpl(s.settings.Message), messageSizeLimit)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("message validation failed: %v", err)
 	}
 	if isTrunc {
 		// If we truncated the message we need to add a message attribute showing that it was truncated.
@@ -169,7 +169,7 @@ func (s *Notifier) createPublishInput(ctx context.Context, tmpl func(string) str
 
 	subject, subjIsTrunc, err := validateAndTruncateString(tmpl(s.settings.Subject), 100)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("subject validation failed: %v", err)
 	}
 	if subjIsTrunc {
 		// If we truncated the subject we need to add a message attribute showing that it was truncated.
@@ -187,12 +187,12 @@ func (s *Notifier) createPublishInput(ctx context.Context, tmpl func(string) str
 
 func validateAndTruncateString(message string, maxMessageSizeInBytes int) (string, bool, error) {
 	if !utf8.ValidString(message) {
-		return "", false, fmt.Errorf("non utf8 encoded message string")
+		return "", false, fmt.Errorf("non utf8 encoded string")
 	}
 	if len(message) <= maxMessageSizeInBytes {
 		return message, false, nil
 	}
-	// If the message is larger than our specified size we have to truncate.
+	// If the given string is larger than our specified size we have to truncate.
 	truncated := make([]byte, maxMessageSizeInBytes)
 	copy(truncated, message)
 	return string(truncated), true, nil

--- a/receivers/sns/sns.go
+++ b/receivers/sns/sns.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
+const subjectSizeLimit = 100
+
 // Notifier is responsible for sending
 // alert notifications to Amazon SNS.
 type Notifier struct {
@@ -167,7 +169,7 @@ func (s *Notifier) createPublishInput(ctx context.Context, tmpl func(string) str
 		messageAttributes["truncated"] = &sns.MessageAttributeValue{DataType: aws.String("String"), StringValue: aws.String("true")}
 	}
 
-	subject, subjIsTrunc, err := validateAndTruncateString(tmpl(s.settings.Subject), 100)
+	subject, subjIsTrunc, err := validateAndTruncateString(tmpl(s.settings.Subject), subjectSizeLimit)
 	if err != nil {
 		return nil, fmt.Errorf("subject validation failed: %v", err)
 	}

--- a/receivers/sns/sns_test.go
+++ b/receivers/sns/sns_test.go
@@ -102,4 +102,46 @@ func TestCreatePublishInput(t *testing.T) {
 		require.Equal(t, stringWithManyCharacters[:1600], *snsInput.Message)
 		require.Equal(t, "true", *snsInput.MessageAttributes["truncated"].StringValue)
 	})
+
+	t.Run("with truncated subject", func(t *testing.T) {
+		stringWithManyCharacters := strings.Repeat("abcd", 500)
+		settings := Config{
+			PhoneNumber: "123-456-7890",
+			Message:     "abcd",
+			Subject:     stringWithManyCharacters,
+		}
+		snsNotifier := &Notifier{
+			Base: &receivers.Base{
+				Name:                  "AWS SNS",
+				Type:                  "sns",
+				UID:                   "",
+				DisableResolveMessage: false,
+			},
+			log:      &logging.FakeLogger{},
+			tmpl:     tmpl,
+			settings: settings,
+		}
+		alerts := []*types.Alert{
+			{
+				Alert: model.Alert{
+					Labels:      model.LabelSet{"alertname": "AlwaysFiring", "severity": "warning"},
+					Annotations: model.LabelSet{"runbook_url": "http://fix.me", "__dashboardUid__": "abc", "__panelId__": "5"},
+				},
+			},
+		}
+
+		var tmplErr error
+		data := notify.GetTemplateData(context.Background(), tmpl, alerts, snsNotifier.log)
+		tmplFn := notify.TmplText(tmpl, data, &tmplErr)
+
+		snsInput, err := snsNotifier.createPublishInput(context.Background(), tmplFn)
+		require.NoError(t, err)
+		require.NoError(t, tmplErr)
+
+		require.Equal(t, "AWS SNS", snsNotifier.Name)
+		require.Equal(t, "sns", snsNotifier.Type)
+		require.Equal(t, "abcd", *snsInput.Message)
+		require.Equal(t, stringWithManyCharacters[:100], *snsInput.Subject)
+		require.Equal(t, "true", *snsInput.MessageAttributes["subject_truncated"].StringValue)
+	})
 }


### PR DESCRIPTION
## Context
- As per https://github.com/grafana/support-escalations/issues/13632, the SNS API limits the `Subject` field to 100 characters
- Given we allow templating for this, it can be tricky for customers to make sure they're not going over it
- We also truncate the message according to the SNS API limits, so it makes sense to follow this behavior for the `Subject`