### PR TITLE
Alertmanager: add sent by to default email template

### DIFF
--- a/receivers/email_sender.go
+++ b/receivers/email_sender.go
@@ -33,7 +33,6 @@ type EmailSenderConfig struct {
 	SkipVerify     bool
 	StartTLSPolicy string
 	StaticHeaders  map[string]string
-	Version        string
 	SentBy         string
 }
 
@@ -130,7 +129,6 @@ func (s *defaultEmailSender) buildEmailMessage(cmd *SendEmailSettings) (*Message
 
 func (s *defaultEmailSender) setDefaultTemplateData(data map[string]any) {
 	data["AppUrl"] = s.cfg.ExternalURL
-	data["BuildVersion"] = s.cfg.Version
 	data["Subject"] = map[string]any{}
 	data["SentBy"] = s.cfg.SentBy
 	dataCopy := map[string]any{}

--- a/receivers/email_sender.go
+++ b/receivers/email_sender.go
@@ -34,6 +34,7 @@ type EmailSenderConfig struct {
 	StartTLSPolicy string
 	StaticHeaders  map[string]string
 	Version        string
+	SentBy         string
 }
 
 type defaultEmailSender struct {
@@ -131,6 +132,7 @@ func (s *defaultEmailSender) setDefaultTemplateData(data map[string]any) {
 	data["AppUrl"] = s.cfg.ExternalURL
 	data["BuildVersion"] = s.cfg.Version
 	data["Subject"] = map[string]any{}
+	data["SentBy"] = s.cfg.SentBy
 	dataCopy := map[string]any{}
 	for k, v := range data {
 		dataCopy[k] = v

--- a/receivers/email_sender_test.go
+++ b/receivers/email_sender_test.go
@@ -27,7 +27,7 @@ func TestBuildEmailMessage(t *testing.T) {
 	testValue := "test-value"
 	testData := map[string]interface{}{"Value": testValue}
 	externalURL := "http://test.org"
-	buildVersion := "testVersion"
+	sentBy := "Grafana testVersion"
 
 	tests := []struct {
 		name          string
@@ -51,30 +51,30 @@ func TestBuildEmailMessage(t *testing.T) {
 			name:          "subject in template, template data provided",
 			contentTypes:  []string{"text/plain"},
 			data:          testData,
-			template:      fmt.Sprintf("{{ define %q -}} {{ Subject .Subject .TemplateData %q }} {{ .AppUrl }} {{ .BuildVersion }} {{- end }}", "test_template.txt", "{{ .Value }}"),
+			template:      fmt.Sprintf("{{ define %q -}} {{ Subject .Subject .TemplateData %q }} {{ .AppUrl }} {{ .SentBy }} {{- end }}", "test_template.txt", "{{ .Value }}"),
 			templateName:  "test_template",
 			embeddedFiles: []string{"embedded-1", "embedded-2"},
 			expSubject:    testValue,
-			expBody:       fmt.Sprintf("%s %s %s", testValue, externalURL, buildVersion),
+			expBody:       fmt.Sprintf("%s %s %s", testValue, externalURL, sentBy),
 		},
 		{
 			name:         "subject via config, template data provided",
 			contentTypes: []string{"text/html"},
 			data:         testData,
 			subject:      "test_subject",
-			template:     fmt.Sprintf("{{ define %q -}} {{ .TemplateData.Value }} {{ .AppUrl }} {{ .BuildVersion }} {{- end }}", "test_template.html"),
+			template:     fmt.Sprintf("{{ define %q -}} {{ .TemplateData.Value }} {{ .AppUrl }} {{ .SentBy }} {{- end }}", "test_template.html"),
 			templateName: "test_template",
 			expSubject:   "test_subject",
-			expBody:      fmt.Sprintf("%s %s %s", testValue, externalURL, buildVersion),
+			expBody:      fmt.Sprintf("%s %s %s", testValue, externalURL, sentBy),
 		},
 		{
 			name:         "default data only",
 			contentTypes: []string{"text/plain"},
 			subject:      "test_subject",
-			template:     fmt.Sprintf("{{ define %q -}} {{ .TemplateData.Value }} {{ .AppUrl }} {{ .BuildVersion }} {{- end }}", "test_template.txt"),
+			template:     fmt.Sprintf("{{ define %q -}} {{ .TemplateData.Value }} {{ .AppUrl }} {{ .SentBy }} {{- end }}", "test_template.txt"),
 			templateName: "test_template",
 			expSubject:   "test_subject",
-			expBody:      fmt.Sprintf(" %s %s", externalURL, buildVersion),
+			expBody:      fmt.Sprintf(" %s %s", externalURL, sentBy),
 		},
 		{
 			name:         "attempting to execute an undefined template",
@@ -90,7 +90,7 @@ func TestBuildEmailMessage(t *testing.T) {
 			s, err := NewEmailSenderFactory(EmailSenderConfig{
 				ContentTypes: test.contentTypes,
 				ExternalURL:  externalURL,
-				Version:      buildVersion,
+				SentBy:       sentBy,
 			})(Metadata{})
 			require.NoError(t, err)
 			ds, ok := s.(*defaultEmailSender)
@@ -125,7 +125,6 @@ func TestBuildEmailMessage(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestCreateDialer(t *testing.T) {

--- a/receivers/templates/ng_alert_notification.html
+++ b/receivers/templates/ng_alert_notification.html
@@ -1260,11 +1260,7 @@
                   <tbody>
                     <tr>
                       <td align="center" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        {{ if .SentBy }}
                         <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #000000;">&copy; {{ now | date "2006" }} Grafana Labs. Sent by <a href="{{ .AppUrl }}" style="color: #6E9FFF;">{{ .SentBy }}</a>.</div>
-                        {{ else }}
-                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #000000;">&copy; {{ now | date "2006" }} Grafana Labs. Sent by <a href="{{ .AppUrl }}" style="color: #6E9FFF;">Grafana v{{ .BuildVersion }}</a>.</div>
-                        {{ end }}
                       </td>
                     </tr>
                   </tbody>

--- a/receivers/templates/ng_alert_notification.html
+++ b/receivers/templates/ng_alert_notification.html
@@ -1260,7 +1260,11 @@
                   <tbody>
                     <tr>
                       <td align="center" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        {{ if .SentBy }}
+                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #000000;">&copy; {{ now | date "2006" }} Grafana Labs. Sent by <a href="{{ .AppUrl }}" style="color: #6E9FFF;">{{ .SentBy }}</a>.</div>
+                        {{ else }}
                         <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #000000;">&copy; {{ now | date "2006" }} Grafana Labs. Sent by <a href="{{ .AppUrl }}" style="color: #6E9FFF;">Grafana v{{ .BuildVersion }}</a>.</div>
+                        {{ end }}
                       </td>
                     </tr>
                   </tbody>

--- a/receivers/templates/ng_alert_notification.txt
+++ b/receivers/templates/ng_alert_notification.txt
@@ -63,8 +63,4 @@ Annotations: {{ template "__default_sorted_pairs" $annotations }}
 {{- end }}
 
 
-{{- if .SentBy -}}
 Sent by {{.SentBy}} (c) {{now | date "2006"}} Grafana Labs
-{{- else -}}
-Sent by Grafana v{{.BuildVersion}} (c) {{now | date "2006"}} Grafana Labs
-{{- end -}}

--- a/receivers/templates/ng_alert_notification.txt
+++ b/receivers/templates/ng_alert_notification.txt
@@ -63,4 +63,8 @@ Annotations: {{ template "__default_sorted_pairs" $annotations }}
 {{- end }}
 
 
+{{- if .SentBy -}}
+Sent by {{.SentBy}} (c) {{now | date "2006"}} Grafana Labs
+{{- else -}}
 Sent by Grafana v{{.BuildVersion}} (c) {{now | date "2006"}} Grafana Labs
+{{- end -}}


### PR DESCRIPTION
- The remote AM is not adding the build version to the email settings as it should.
- https://github.com/grafana/mimir/pull/9987 was doing that, but the result is misleading
- For that reason, we've decided to instead add a new parameter do the footer text can be customized

Part of: https://github.com/grafana/alerting-squad/issues/873

