### PR TITLE
Add NoopDecode function for non-base64-encoded secrets

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -36,7 +36,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 		for notifierType, cfg := range AllKnownConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(notifierType))
 		}
-		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, GetDecryptedValueFnForTesting)
+		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, GetDecryptedValueFnForTesting)
 		require.NoError(t, err)
 		return parsed, len(recCfg.Integrations)
 	}


### PR DESCRIPTION
When the Mimir Alertmanager uses Grafana integrations, secrets are not base64-encoded. We rely on an [error returned from the decoding function](https://github.com/grafana/alerting/blob/267368fd1968774d47b9553d113f9438eeeeed0c/notify/receivers.go#L247-L254) to tell whether secrets are base64-decoded or not (check [here](https://github.com/grafana/alerting/blob/267368fd1968774d47b9553d113f9438eeeeed0c/notify/receivers.go#L249-L253)). This works fine in most cases, but some non-base64-encoded strings will still be valid base64. In these cases, the decoding function will apply base64-decoding rules and output gibberish, thus breaking integrations.

This PR adds a `NoopDecode` function to be used by the Mimir Alertmanager. This function converts a `map[string]string` into a `map[string][]byte` without trying to decode the values.

Related Mimir PR: https://github.com/grafana/mimir/pull/10427