### PR TITLE
Alerting: Use rule uid in silenceURL template instead of alertname and folder

### DIFF
--- a/receivers/pushover/pushover_test.go
+++ b/receivers/pushover/pushover_test.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	images2 "github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
@@ -71,7 +72,7 @@ func TestNotify(t *testing.T) {
 				"title":      "[FIRING:1]  (val1)",
 				"url":        "http://localhost/alerting/list",
 				"url_title":  "Show alert rule",
-				"message":    "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
+				"message":    "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Drule+uid&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
 				"attachment": "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\b\x04\x00\x00\x00\xb5\x1c\f\x02\x00\x00\x00\vIDATx\xdacd`\x00\x00\x00\x06\x00\x020\x81\xd0/\x00\x00\x00\x00IEND\xaeB`\x82",
 				"html":       "1",
 			},
@@ -109,7 +110,7 @@ func TestNotify(t *testing.T) {
 				"title":     "[FIRING:1]  (val1)",
 				"url":       "http://localhost/alerting/list",
 				"url_title": "Show alert rule",
-				"message":   "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
+				"message":   "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Drule+uid&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
 				"html":      "1",
 			},
 			expMsgError: nil,
@@ -146,7 +147,7 @@ func TestNotify(t *testing.T) {
 				"title":      "Alerts firing: 1",
 				"url":        "http://localhost/alerting/list",
 				"url_title":  "Show alert rule",
-				"message":    "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
+				"message":    "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Drule+uid&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh",
 				"attachment": "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\b\x04\x00\x00\x00\xb5\x1c\f\x02\x00\x00\x00\vIDATx\xdacd`\x00\x00\x00\x06\x00\x020\x81\xd0/\x00\x00\x00\x00IEND\xaeB`\x82",
 				"html":       "1",
 			},

--- a/receivers/sensugo/sensugo_test.go
+++ b/receivers/sensugo/sensugo_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/require"
 
 	images2 "github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
@@ -71,7 +72,7 @@ func TestNotify(t *testing.T) {
 							"ruleURL":  "http://localhost/alerting/list",
 						},
 					},
-					"output":   "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+					"output":   "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Drule+uid&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 					"issued":   timeNow().Unix(),
 					"interval": 86400,
 					"status":   2,

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -167,7 +167,7 @@ Labels:
 Annotations:
  - ann1 = annv1
 Source: http://localhost/alert1?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval1&orgId=1
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Druleuid1&matcher=lbl1%3Dval1&orgId=1
 Dashboard: http://localhost/grafana/d/dbuid123?orgId=1
 Panel: http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123
 
@@ -178,7 +178,7 @@ Labels:
 Annotations:
  - ann1 = annv2
 Source: http://localhost/alert2
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Druleuid1&matcher=lbl1%3Dval2
 
 Value: A=1234
 Labels:
@@ -238,7 +238,7 @@ Annotations:
 
 Source: [http://localhost/alert1?orgId=1](http://localhost/alert1?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval1&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval1&orgId=1)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Druleuid1&matcher=lbl1%3Dval1&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Druleuid1&matcher=lbl1%3Dval1&orgId=1)
 
 Dashboard: [http://localhost/grafana/d/dbuid123?orgId=1](http://localhost/grafana/d/dbuid123?orgId=1)
 
@@ -256,7 +256,7 @@ Annotations:
 
 Source: [http://localhost/alert2](http://localhost/alert2)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Druleuid1&matcher=lbl1%3Dval2](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Druleuid1&matcher=lbl1%3Dval2)
 
 
 

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alerting/models"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
@@ -20,8 +21,10 @@ func TestDefaultTemplateString(t *testing.T) {
 		{ // Firing with dashboard and panel ID.
 			Alert: model.Alert{
 				Labels: model.LabelSet{
-					"alertname": "alert1",
-					"lbl1":      "val1",
+					"alertname":             "alert1",
+					"lbl1":                  "val1",
+					models.FolderTitleLabel: "folder1",
+					models.RuleUIDLabel:     "ruleuid1",
 				},
 				Annotations: model.LabelSet{
 					"ann1":             "annv1",
@@ -38,8 +41,9 @@ func TestDefaultTemplateString(t *testing.T) {
 		}, { // Firing without dashboard and panel ID.
 			Alert: model.Alert{
 				Labels: model.LabelSet{
-					"alertname": "alert1",
-					"lbl1":      "val2",
+					"alertname":         "alert1",
+					"lbl1":              "val2",
+					models.RuleUIDLabel: "ruleuid1", // No folder available.
 				},
 				Annotations: model.LabelSet{
 					"ann1":             "annv2",
@@ -53,8 +57,9 @@ func TestDefaultTemplateString(t *testing.T) {
 		}, { // Firing with OrgID and without dashboard and panel ID.
 			Alert: model.Alert{
 				Labels: model.LabelSet{
-					"alertname": "alert1",
-					"lbl1":      "val3",
+					"alertname":             "alert1",
+					"lbl1":                  "val3",
+					models.FolderTitleLabel: "folder1",
 				},
 				Annotations: model.LabelSet{
 					"ann1":             "annv3",
@@ -157,11 +162,12 @@ func TestDefaultTemplateString(t *testing.T) {
 Value: A=1234
 Labels:
  - alertname = alert1
+ - grafana_folder = folder1
  - lbl1 = val1
 Annotations:
  - ann1 = annv1
 Source: http://localhost/alert1?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval1&orgId=1
 Dashboard: http://localhost/grafana/d/dbuid123?orgId=1
 Panel: http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123
 
@@ -177,11 +183,12 @@ Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matc
 Value: A=1234
 Labels:
  - alertname = alert1
+ - grafana_folder = folder1
  - lbl1 = val3
 Annotations:
  - ann1 = annv3
 Source: http://localhost/alert3?orgId=1
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3&orgId=1
+Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval3&orgId=1
 
 
 **Resolved**
@@ -223,6 +230,7 @@ Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matc
 Value: A=1234
 Labels:
  - alertname = alert1
+ - grafana_folder = folder1
  - lbl1 = val1
 
 Annotations:
@@ -230,7 +238,7 @@ Annotations:
 
 Source: [http://localhost/alert1?orgId=1](http://localhost/alert1?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval1&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval1&orgId=1)
 
 Dashboard: [http://localhost/grafana/d/dbuid123?orgId=1](http://localhost/grafana/d/dbuid123?orgId=1)
 
@@ -255,6 +263,7 @@ Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&mat
 Value: A=1234
 Labels:
  - alertname = alert1
+ - grafana_folder = folder1
  - lbl1 = val3
 
 Annotations:
@@ -262,7 +271,7 @@ Annotations:
 
 Source: [http://localhost/alert3?orgId=1](http://localhost/alert3?orgId=1)
 
-Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3&orgId=1)
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval3&orgId=1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=grafana_folder%3Dfolder1&matcher=lbl1%3Dval3&orgId=1)
 
 
 

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -230,15 +230,15 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	return extended
 }
 
-func generateSilenceURL(alert template.Alert, baseUrl url.URL, externalPath string) string {
-	baseUrl.Path = path.Join(externalPath, "/alerting/silence/new")
+func generateSilenceURL(alert template.Alert, baseURL url.URL, externalPath string) string {
+	baseURL.Path = path.Join(externalPath, "/alerting/silence/new")
 
 	query := make(url.Values)
 	query.Add("alertmanager", "grafana")
 
-	ruleUid := alert.Labels[models.RuleUIDLabel]
-	if ruleUid != "" {
-		query.Add("matcher", models.RuleUIDLabel+"="+ruleUid)
+	ruleUID := alert.Labels[models.RuleUIDLabel]
+	if ruleUID != "" {
+		query.Add("matcher", models.RuleUIDLabel+"="+ruleUID)
 	}
 
 	for _, pair := range alert.Labels.SortedPairs() {
@@ -248,21 +248,21 @@ func generateSilenceURL(alert template.Alert, baseUrl url.URL, externalPath stri
 
 		// If the alert has a rule uid available, it can more succinctly and accurately replace alertname + folder labels.
 		// In addition, using rule uid is more compatible with minimal permission RBAC users as they require the rule uid to silence.
-		if ruleUid != "" && (pair.Name == models.FolderTitleLabel || pair.Name == model.AlertNameLabel) {
+		if ruleUID != "" && (pair.Name == models.FolderTitleLabel || pair.Name == model.AlertNameLabel) {
 			continue
 		}
 
 		query.Add("matcher", pair.Name+"="+pair.Value)
 	}
 
-	baseUrl.RawQuery = query.Encode()
+	baseURL.RawQuery = query.Encode()
 
 	orgID := alert.Annotations[models.OrgIDAnnotation]
 	if len(orgID) > 0 {
-		_ = setOrgIDQueryParam(&baseUrl, orgID)
+		_ = setOrgIDQueryParam(&baseURL, orgID)
 	}
 
-	return baseUrl.String()
+	return baseURL.String()
 }
 
 func setOrgIDQueryParam(url *url.URL, orgID string) string {

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -230,6 +230,7 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	return extended
 }
 
+// generateSilenceURL generates a URL to silence the given alert in Grafana.
 func generateSilenceURL(alert template.Alert, baseURL url.URL, externalPath string) string {
 	baseURL.Path = path.Join(externalPath, "/alerting/silence/new")
 


### PR DESCRIPTION
When possible use rule uid instead of alertname and grafana_folder when templating the silenceURL as this has better compatibility with minimal permission RBAC users.

Example before: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalways+firing+screenshot&matcher=grafana_folder%3Dtest&orgId=1 
Example after: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Dae9zjkfxiyk1sa&orgId=1

Relates to: https://github.com/grafana/grafana/issues/99115