### PR TITLE
Alerting: Adding color option for slack receiver

### DIFF
--- a/receivers/slack/config.go
+++ b/receivers/slack/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	MentionChannel string                          `json:"mentionChannel,omitempty" yaml:"mentionChannel,omitempty"`
 	MentionUsers   receivers.CommaSeparatedStrings `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty"`
 	MentionGroups  receivers.CommaSeparatedStrings `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
+	Color          string                          `json:"color,omitempty" yaml:"color,omitempty"`
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
@@ -67,6 +68,8 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if settings.Title == "" {
 		settings.Title = templates.DefaultMessageTitleEmbed
 	}
-
+	if settings.Color == "" {
+		settings.Color = templates.DefaultMessageColor
+	}
 	return settings, nil
 }

--- a/receivers/slack/config_test.go
+++ b/receivers/slack/config_test.go
@@ -54,6 +54,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -75,6 +76,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -93,6 +95,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -114,6 +117,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -149,6 +153,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -178,6 +183,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "here",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -199,6 +205,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "channel",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -224,6 +231,7 @@ func TestNewConfig(t *testing.T) {
 					"user-3",
 				},
 				MentionGroups: nil,
+				Color:         templates.DefaultMessageColor,
 			},
 		},
 		{
@@ -249,6 +257,29 @@ func TestNewConfig(t *testing.T) {
 					"users-2",
 					"users-3",
 				},
+				Color: templates.DefaultMessageColor,
+			},
+		},
+		{
+			name:     "Should parse color",
+			settings: `{ "recipient" : "test-recipient" , "color": "{{ if eq .Status \"firing\" }}#33a2ff{{ else }}#36a64f{{ end }}"}`,
+			secureSettings: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "test-token",
+				Recipient:      "test-recipient",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      "",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+				Color:          `{{ if eq .Status "firing" }}#33a2ff{{ else }}#36a64f{{ end }}`,
 			},
 		},
 		{
@@ -267,6 +298,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "channel",
 				MentionUsers:   []string{"test-mentionUsers"},
 				MentionGroups:  []string{"test-mentionGroups"},
+				Color:          "test-color",
 			},
 		},
 		{
@@ -286,6 +318,7 @@ func TestNewConfig(t *testing.T) {
 				MentionChannel: "channel",
 				MentionUsers:   []string{"test-mentionUsers"},
 				MentionGroups:  []string{"test-mentionGroups"},
+				Color:          "test-color",
 			},
 		},
 	}

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -258,7 +258,7 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 		// https://api.slack.com/messaging/composing/layouts#when-to-use-attachments
 		Attachments: []attachment{
 			{
-				Color:      receivers.GetAlertStatusColor(types.Alerts(alerts...).Status()),
+				Color:      tmpl(sn.settings.Color),
 				Title:      title,
 				Fallback:   title,
 				Footer:     "Grafana v" + sn.appVersion,

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -49,6 +49,7 @@ func TestNotify_IncomingWebhook(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -88,6 +89,7 @@ func TestNotify_IncomingWebhook(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -128,6 +130,7 @@ func TestNotify_IncomingWebhook(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -218,6 +221,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -257,6 +261,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -297,6 +302,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -343,6 +349,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -389,6 +396,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -433,6 +441,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -453,7 +462,7 @@ func TestNotify_PostMessage(t *testing.T) {
 					Fields:     nil,
 					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
-					Color:      "#D63232",
+					Color:      "",
 				},
 			},
 		},
@@ -472,6 +481,7 @@ func TestNotify_PostMessage(t *testing.T) {
 			MentionChannel: "",
 			MentionUsers:   nil,
 			MentionGroups:  nil,
+			Color:          templates.DefaultMessageColor,
 		},
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
@@ -493,6 +503,46 @@ func TestNotify_PostMessage(t *testing.T) {
 					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
+				},
+			},
+		},
+	}, {
+		name: "Message is sent to with custom color",
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            APIURL,
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           templates.DefaultMessageEmbed,
+			Title:          templates.DefaultMessageTitleEmbed,
+			Username:       "Grafana",
+			IconEmoji:      ":emoji:",
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+			Color:          `{{ if eq .Status "firing" }}#33a2ff{{ else }}#36a64f{{ end }}`,
+		},
+		alerts: []*types.Alert{{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		}},
+		expectedMessage: &slackMessage{
+			Channel:   "#test",
+			Username:  "Grafana",
+			IconEmoji: ":emoji:",
+			Attachments: []attachment{
+				{
+					Title:      "[FIRING:1]  (val1)",
+					TitleLink:  "http://localhost/alerting/list",
+					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n",
+					Fallback:   "[FIRING:1]  (val1)",
+					Fields:     nil,
+					Footer:     "Grafana v" + appVersion,
+					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
+					Color:      "#33a2ff",
 				},
 			},
 		},
@@ -561,6 +611,7 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 				MentionChannel: "",
 				MentionUsers:   nil,
 				MentionGroups:  nil,
+				Color:          templates.DefaultMessageColor,
 			},
 			alerts: []*types.Alert{{
 				Alert: model.Alert{

--- a/receivers/slack/testing.go
+++ b/receivers/slack/testing.go
@@ -13,7 +13,8 @@ const FullValidConfigForTesting = `{
 	"icon_url": "http://localhost/icon_url",
 	"mentionChannel": "channel",
 	"mentionUsers": "test-mentionUsers",
-	"mentionGroups": "test-mentionGroups"
+	"mentionGroups": "test-mentionGroups",
+	"color": "test-color"
 }`
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -9,6 +9,7 @@ import (
 const (
 	DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
 	DefaultMessageEmbed      = `{{ template "default.message" . }}`
+	DefaultMessageColor      = `{{ if eq .Status "firing" }}#D63232{{ else }}#36a64f{{ end }}`
 )
 
 var DefaultTemplateString = `


### PR DESCRIPTION
This PR adds the option to customize the color of the slack message. It's designed to follow the same structure as [Alertmanager](https://prometheus.io/docs/alerting/0.27/configuration/#slack_config).

Closes https://github.com/grafana/alerting/issues/251
Related to https://github.com/grafana/grafana/pull/99615