### PR TITLE
Add EmbeddedContents and use in email notifier

### DIFF
--- a/receivers/email.go
+++ b/receivers/email.go
@@ -2,19 +2,23 @@ package receivers
 
 import (
 	"context"
-	"io"
 )
 
 // SendEmailSettings is the command for sending emails
 type SendEmailSettings struct {
-	To              []string
-	SingleEmail     bool
-	Template        string
-	Subject         string
-	Data            map[string]interface{}
-	ReplyTo         []string
-	EmbeddedFiles   []string
-	EmbeddedReaders map[string]io.Reader
+	To               []string
+	SingleEmail      bool
+	Template         string
+	Subject          string
+	Data             map[string]interface{}
+	ReplyTo          []string
+	EmbeddedFiles    []string
+	EmbeddedContents []EmbeddedContent
+}
+
+type EmbeddedContent struct {
+	Name    string
+	Content []byte
 }
 
 type EmailSender interface {

--- a/receivers/email.go
+++ b/receivers/email.go
@@ -1,16 +1,20 @@
 package receivers
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // SendEmailSettings is the command for sending emails
 type SendEmailSettings struct {
-	To            []string
-	SingleEmail   bool
-	Template      string
-	Subject       string
-	Data          map[string]interface{}
-	ReplyTo       []string
-	EmbeddedFiles []string
+	To              []string
+	SingleEmail     bool
+	Template        string
+	Subject         string
+	Data            map[string]interface{}
+	ReplyTo         []string
+	EmbeddedFiles   []string
+	EmbeddedReaders map[string]io.Reader
 }
 
 type EmailSender interface {

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -60,11 +60,9 @@ func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 	// Extend alerts data with images, if available.
 	var embeddedFiles map[string]io.Reader
 	defer func() {
-		if embeddedFiles != nil {
-			for _, reader := range embeddedFiles {
-				if closer, ok := reader.(io.Closer); ok {
-					closer.Close()
-				}
+		for _, reader := range embeddedFiles {
+			if closer, ok := reader.(io.Closer); ok {
+				closer.Close()
 			}
 		}
 	}()

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -58,7 +58,7 @@ func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 	}
 
 	// Extend alerts data with images, if available.
-	var embeddedFiles map[string]io.Reader
+	embeddedFiles := make(map[string]io.Reader)
 	defer func() {
 		for _, reader := range embeddedFiles {
 			if closer, ok := reader.(io.Closer); ok {

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -114,11 +114,6 @@ func (en *Notifier) SendResolved() bool {
 }
 
 func readFile(path string) ([]byte, error) {
-	_, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/receivers/email_sender.go
+++ b/receivers/email_sender.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"io"
 	"net"
 	"net/mail"
 	"strconv"
@@ -62,13 +63,14 @@ func NewEmailSenderFactory(cfg EmailSenderConfig) func(Metadata) (EmailSender, e
 
 // Message representats an email message.
 type Message struct {
-	To            []string
-	From          string
-	Subject       string
-	Body          map[string]string
-	EmbeddedFiles []string
-	ReplyTo       []string
-	SingleEmail   bool
+	To              []string
+	From            string
+	Subject         string
+	Body            map[string]string
+	EmbeddedFiles   []string
+	EmbeddedReaders map[string]io.Reader
+	ReplyTo         []string
+	SingleEmail     bool
 }
 
 // SendEmail implements the EmailSender interface.
@@ -117,13 +119,14 @@ func (s *defaultEmailSender) buildEmailMessage(cmd *SendEmailSettings) (*Message
 
 	addr := mail.Address{Name: s.cfg.FromName, Address: s.cfg.FromAddress}
 	return &Message{
-		To:            cmd.To,
-		From:          addr.String(),
-		Subject:       subject,
-		Body:          body,
-		EmbeddedFiles: cmd.EmbeddedFiles,
-		ReplyTo:       cmd.ReplyTo,
-		SingleEmail:   cmd.SingleEmail,
+		To:              cmd.To,
+		From:            addr.String(),
+		Subject:         subject,
+		Body:            body,
+		EmbeddedFiles:   cmd.EmbeddedFiles,
+		EmbeddedReaders: cmd.EmbeddedReaders,
+		ReplyTo:         cmd.ReplyTo,
+		SingleEmail:     cmd.SingleEmail,
 	}, nil
 }
 
@@ -216,6 +219,10 @@ func (s *defaultEmailSender) buildEmail(msg *Message) *gomail.Message {
 	// Add embedded files.
 	for _, file := range msg.EmbeddedFiles {
 		m.Embed(file)
+	}
+
+	for name, contents := range msg.EmbeddedReaders {
+		m.EmbedReader(name, contents)
 	}
 
 	// Add reply-to addresses to the email message.


### PR DESCRIPTION
Adds support for embedding `[]byte` in `defaultEmailSender` instead of filenames. This is backwards compatible as it uses a new field `EmbeddedContents` to add an alternative to the existing `EmbeddedFiles` which takes filenames.

Also, uses this new field in the email notifier. 

This is needed because of upcoming changes to the image `Provider` abstraction. It will only expose `[]byte` not files or filenames. In other words, integrations no longer know that the data is coming from disk or not, so filenames and paths are leaked implementation details.

This should be noop functionally.

This will requires corresponding implementation in `grafana/grafana` for local alertmanager: https://github.com/grafana/grafana/pull/99937

<details>
  <summary>Embed confirmed still working</summary>

  ![image](https://github.com/user-attachments/assets/046a3e84-64f1-45f3-a9a9-47e99f1dc7e1)

</details>


