### PR TITLE
New image Provider abstraction to allow for remote AM screenshots

### DIFF
--- a/images/images.go
+++ b/images/images.go
@@ -15,16 +15,7 @@ var (
 	// the maximum number of images has been iterated.
 	ErrImagesDone = errors.New("images done")
 
-	// ErrImagesNoPath is returned whenever an image is found but has no path on disk.
-	ErrImagesNoPath = errors.New("no path for image")
-
-	// ErrImagesNoURL is returned whenever an image is found but has no URL.
-	ErrImagesNoURL = errors.New("no URL for image")
-
 	ErrImagesUnavailable = errors.New("alert screenshots are unavailable")
-
-	// ErrNoImageForAlert is returned when no image is associated to a given alert.
-	ErrNoImageForAlert = errors.New("no image for alert")
 )
 
 type ImageContent struct {

--- a/images/images.go
+++ b/images/images.go
@@ -51,18 +51,3 @@ type Provider interface {
 	// GetImage takes an alert and returns its associated image.
 	GetImage(ctx context.Context, alert types.Alert) (*Image, error)
 }
-
-type UnavailableProvider struct{}
-
-// GetImage returns the image with the corresponding token, or ErrImageNotFound.
-func (u *UnavailableProvider) GetImage(context.Context, string) (*Image, error) {
-	return nil, ErrImagesUnavailable
-}
-
-func (u *UnavailableProvider) GetImageURL(context.Context, *types.Alert) (string, error) {
-	return "", ErrImagesUnavailable
-}
-
-func (u *UnavailableProvider) GetRawImage(context.Context, *types.Alert) (io.ReadCloser, string, error) {
-	return nil, "", ErrImagesUnavailable
-}

--- a/images/providers.go
+++ b/images/providers.go
@@ -1,0 +1,52 @@
+package images
+
+import (
+	"context"
+	"errors"
+
+	"github.com/grafana/alerting/models"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// ErrImageUploadNotSupported is returned when image uploading is not supported.
+var ErrImageUploadNotSupported = errors.New("image upload is not supported")
+
+type UnavailableProvider struct{}
+
+var _ Provider = (*UnavailableProvider)(nil)
+
+func (u *UnavailableProvider) GetImage(_ context.Context, _ types.Alert) (*Image, error) {
+	return nil, ErrImagesUnavailable
+}
+
+// URLProvider is a provider that stores a direct reference to an image's public URL in an alert's annotations.
+// The URL is not validated against a database record, so retrieving raw image data is blocked in an attempt
+// to prevent malicious access to untrusted URLs.
+type URLProvider struct{}
+
+var _ Provider = (*URLProvider)(nil)
+
+// GetImage returns the image associated with a given alert.
+// The URL should be treated as untrusted and notifiers should pass the URL directly without attempting to download
+// the image data.
+func (u *URLProvider) GetImage(_ context.Context, alert types.Alert) (*Image, error) {
+	url := GetImageURL(alert)
+	if url == "" {
+		return nil, nil
+	}
+
+	return &Image{
+		URL: url,
+		RawData: func(_ context.Context) (ImageContent, error) {
+			// Raw images are not available for alerts provided directly by annotations as the image data is non-local.
+			// While it might be possible to download the image data, it's generally not safe to do so as the URL is
+			// not guaranteed to be trusted.
+			return ImageContent{}, ErrImageUploadNotSupported
+		},
+	}, nil
+}
+
+// GetImageURL is a helper function to retrieve the image url from the alert annotations.
+func GetImageURL(alert types.Alert) string {
+	return string(alert.Annotations[models.ImageURLAnnotation])
+}

--- a/images/providers_test.go
+++ b/images/providers_test.go
@@ -1,0 +1,74 @@
+package images
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prometheus/alertmanager/types"
+)
+
+func TestUnavailableProvider_GetImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		alert    types.Alert
+		expImage *Image
+		expError error
+	}{
+		{
+			name:     "Given alert, expect error",
+			alert:    newAlertWithImageURL("https://test"),
+			expImage: nil,
+			expError: ErrImagesUnavailable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			p := &UnavailableProvider{}
+			img, err := p.GetImage(context.Background(), test.alert)
+			assert.Equal(tt, test.expImage, img)
+			assert.Equal(tt, test.expError, err)
+		})
+	}
+}
+
+func TestURLProvider_GetImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		alert    types.Alert
+		expImage *Image
+	}{
+		{
+			name:     "Given alert without image URI, expect nil",
+			alert:    types.Alert{},
+			expImage: nil,
+		},
+		{
+			name:     "Given alert with image URI, expect image",
+			alert:    newAlertWithImageURL("https://test"),
+			expImage: &Image{URL: "https://test"},
+		},
+		{
+			name:     "Given alert with image token, expect nil", // Token is irrelevant for this provider.
+			alert:    newAlertWithImageToken("test-token"),
+			expImage: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			p := &URLProvider{}
+			img, err := p.GetImage(context.Background(), test.alert)
+			assert.NoError(tt, err)
+			if test.expImage == nil {
+				assert.Nil(tt, img)
+				return
+			}
+			assert.Equal(tt, test.expImage.URL, img.URL)
+			_, err = img.RawData(context.Background())
+			assert.Equal(tt, ErrImageUploadNotSupported, err)
+		})
+	}
+}

--- a/images/providers_test.go
+++ b/images/providers_test.go
@@ -122,13 +122,3 @@ func TestTokenProvider_GetImage(t *testing.T) {
 		})
 	}
 }
-
-type FakeTokenStore struct {
-	Images map[string]*Image
-}
-
-var _ TokenStore = (*FakeTokenStore)(nil)
-
-func (f FakeTokenStore) GetImage(ctx context.Context, token string) (*Image, error) {
-	return f.Images[token], nil
-}

--- a/images/providers_test.go
+++ b/images/providers_test.go
@@ -69,7 +69,7 @@ func TestURLProvider_GetImage(t *testing.T) {
 			}
 			assert.Equal(tt, test.expImage.URL, img.URL)
 			_, err = img.RawData(context.Background())
-			assert.Equal(tt, ErrImageUploadNotSupported, err)
+			assert.ErrorIs(tt, err, ErrImageUploadNotSupported)
 		})
 	}
 }

--- a/images/testing.go
+++ b/images/testing.go
@@ -1,162 +1,85 @@
 package images
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
+	"github.com/grafana/alerting/logging"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/models"
 )
 
-type FakeProvider struct {
-	Images []*Image
-	Bytes  []byte
+type FakeTokenStore struct {
+	Images map[string]*Image
 }
 
-func (f *FakeProvider) GetImageFileName(token string) string {
-	for _, image := range f.Images {
-		if image.Token == token {
-			return filepath.Base(image.Path)
-		}
-	}
-	return ""
+var _ TokenStore = (*FakeTokenStore)(nil)
+
+func (f FakeTokenStore) GetImage(_ context.Context, token string) (*Image, error) {
+	return f.Images[token], nil
 }
 
-// GetImage returns an image with the same token.
-func (f *FakeProvider) GetImage(_ context.Context, token string) (*Image, error) {
-	for _, img := range f.Images {
-		if img.Token == token {
-			return img, nil
-		}
-	}
-	return nil, ErrImageNotFound
+func NewFakeProvider(n int) Provider {
+	return NewTokenProvider(NewFakeTokenStore(n), &logging.FakeLogger{})
 }
 
-// GetImageURL returns the URL of the image associated with a given alert.
-func (f *FakeProvider) GetImageURL(_ context.Context, alert *types.Alert) (string, error) {
-	uri, err := getImageURI(alert)
-	if err != nil {
-		return "", err
-	}
-
-	for _, img := range f.Images {
-		if img.Token == uri || img.URL == uri {
-			if !img.HasURL() {
-				return "", ErrImagesNoURL
-			}
-			return img.URL, nil
-		}
-	}
-	return "", ErrImageNotFound
+func NewFakeProviderWithFile(t *testing.T, n int) Provider {
+	return NewTokenProvider(NewFakeTokenStoreWithFile(t, n), &logging.FakeLogger{})
 }
 
-// GetRawImage returns an io.Reader to read the bytes of the image associated with a given alert.
-func (f *FakeProvider) GetRawImage(_ context.Context, alert *types.Alert) (io.ReadCloser, string, error) {
-	uri, err := getImageURI(alert)
-	if err != nil {
-		return nil, "", err
-	}
-
-	uriString := string(uri)
-	for _, img := range f.Images {
-		if img.Token == uriString || img.URL == uriString {
-			filename := filepath.Base(img.Path)
-			return io.NopCloser(bytes.NewReader(f.Bytes)), filename, nil
-		}
-	}
-	return nil, "", ErrImageNotFound
+func NewFakeTokenStoreFromImages(images map[string]*Image) *FakeTokenStore {
+	return &FakeTokenStore{Images: images}
 }
 
-// getImageURI is a helper function to retrieve the image URI from the alert annotations as a string.
-func getImageURI(alert *types.Alert) (string, error) {
-	uri, ok := alert.Annotations[models.ImageTokenAnnotation]
-	if !ok {
-		return "", ErrNoImageForAlert
+// NewFakeTokenStore returns an token store with N test images.
+// Each image has a URL, but does not have a file on disk.
+// They are mapped to the token test-image-%d
+func NewFakeTokenStore(n int) *FakeTokenStore {
+	p := FakeTokenStore{
+		Images: make(map[string]*Image),
 	}
-	return string(uri), nil
-}
-
-// NewFakeProvider returns an image provider with N test images.
-// Each image has a token and a URL, but does not have a file on disk.
-func NewFakeProvider(n int) *FakeProvider {
-	p := FakeProvider{}
 	for i := 1; i <= n; i++ {
-		p.Images = append(p.Images, &Image{
-			Token:     fmt.Sprintf("test-image-%d", i),
-			URL:       fmt.Sprintf("https://www.example.com/test-image-%d.jpg", i),
-			CreatedAt: time.Now().UTC(),
-		})
+		token := fmt.Sprintf("test-image-%d", i)
+		p.Images[token] = &Image{
+			URL: fmt.Sprintf("https://www.example.com/test-image-%d.jpg", i),
+			RawData: func(_ context.Context) (ImageContent, error) {
+				return ImageContent{}, ErrImagesUnavailable
+			},
+		}
 	}
 	return &p
 }
 
-// NewFakeProviderWithFile returns an image provider with N test images.
-// Each image has a token, path and a URL, where the path is 1x1 transparent
-// PNG on disk. The test should call deleteFunc to delete the images from disk
-// at the end of the test.
-// nolint:deadcode,unused
-func NewFakeProviderWithFile(t *testing.T, n int) *FakeProvider {
-	var (
-		files []string
-		p     FakeProvider
-	)
-
-	t.Cleanup(func() {
-		// remove all files from disk
-		for _, f := range files {
-			if err := os.Remove(f); err != nil {
-				t.Logf("failed to delete file: %s", err)
-			}
-		}
-	})
-
-	for i := 1; i <= n; i++ {
-		file, err := newTestImage()
-		if err != nil {
-			t.Fatalf("failed to create test image: %s", err)
-		}
-		files = append(files, file)
-		p.Images = append(p.Images, &Image{
-			Token:     fmt.Sprintf("test-image-%d", i),
-			Path:      file,
-			URL:       fmt.Sprintf("https://www.example.com/test-image-%d", i),
-			CreatedAt: time.Now().UTC(),
-		})
+// NewFakeTokenStoreWithFile returns an image provider with N test images.
+// Each image has a URL and raw data.
+// They are mapped to the token test-image-%d
+func NewFakeTokenStoreWithFile(t *testing.T, n int) *FakeTokenStore {
+	p := FakeTokenStore{
+		Images: make(map[string]*Image),
 	}
-
-	return &p
-}
-
-func newTestImage() (string, error) {
-	f, err := os.CreateTemp("", "test-image-*.png")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp image: %s", err)
-	}
-
 	// 1x1 transparent PNG
 	b, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=")
 	if err != nil {
-		return f.Name(), fmt.Errorf("failed to decode PNG data: %s", err)
+		t.Fatalf("failed to decode PNG data: %s", err)
 	}
 
-	if _, err := f.Write(b); err != nil {
-		return f.Name(), fmt.Errorf("failed to write to file: %s", err)
+	for i := 1; i <= n; i++ {
+		token := fmt.Sprintf("test-image-%d", i)
+		p.Images[token] = &Image{
+			URL: fmt.Sprintf("https://www.example.com/test-image-%d", i),
+			RawData: func(_ context.Context) (ImageContent, error) {
+				return ImageContent{
+					Name:    fmt.Sprintf("test-image-%d.jpg", i),
+					Content: b,
+				}, nil
+			},
+		}
 	}
-
-	if err := f.Close(); err != nil {
-		return f.Name(), fmt.Errorf("failed to close file: %s", err)
-	}
-
-	return f.Name(), nil
+	return &p
 }
 
 func newAlertWithImageURL(url string) types.Alert {

--- a/images/testing.go
+++ b/images/testing.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/models"
 )
@@ -156,4 +157,24 @@ func newTestImage() (string, error) {
 	}
 
 	return f.Name(), nil
+}
+
+func newAlertWithImageURL(url string) types.Alert {
+	return types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ImageURLAnnotation: model.LabelValue(url),
+			},
+		},
+	}
+}
+
+func newAlertWithImageToken(token string) types.Alert {
+	return types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ImageTokenAnnotation: model.LabelValue(token),
+			},
+		},
+	}
 }

--- a/images/util_test.go
+++ b/images/util_test.go
@@ -3,12 +3,12 @@ package images
 import (
 	"context"
 	"testing"
-	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/models"
@@ -29,15 +29,18 @@ func TestWithStoredImages(t *testing.T) {
 			},
 		},
 	}}
-	imageProvider := &FakeProvider{Images: []*Image{{
-		Token:     "test-image-1",
-		URL:       "https://www.example.com/test-image-1.jpg",
-		CreatedAt: time.Now().UTC(),
-	}, {
-		Token:     "test-image-2",
-		URL:       "https://www.example.com/test-image-2.jpg",
-		CreatedAt: time.Now().UTC(),
-	}}}
+	imageProvider := &TokenProvider{
+		store: NewFakeTokenStoreFromImages(map[string]*Image{
+			"test-image-1": {
+				URL: "https://www.example.com/test-image-1.jpg",
+			},
+			"test-image-2": {
+				URL: "https://www.example.com/test-image-2.jpg",
+			},
+		},
+		),
+		logger: &logging.FakeLogger{},
+	}
 
 	var (
 		err error

--- a/images/utils.go
+++ b/images/utils.go
@@ -37,9 +37,9 @@ func getImage(ctx context.Context, l logging.Logger, imageProvider Provider, ale
 
 // WithStoredImages retrieves the image for each alert and then calls forEachFunc
 // with the index of the alert and the retrieved image struct. If the alert does
-// not have an image then forEachFunc will not be
-// called for that alert. If forEachFunc returns an error, WithStoredImages will return
-// the error and not iterate the remaining alerts. A forEachFunc can return ErrImagesDone
+// not have an image then forEachFunc will not be called for that alert.
+// If forEachFunc returns an error, WithStoredImages will return the error
+// and not iterate the remaining alerts. A forEachFunc can return ErrImagesDone
 // to stop the iteration of remaining alerts if the intended image or maximum number of
 // images have been found.
 func WithStoredImages(ctx context.Context, l logging.Logger, imageProvider Provider, forEachFunc forEachImageFunc, alerts ...*types.Alert) error {

--- a/images/utils.go
+++ b/images/utils.go
@@ -5,11 +5,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/prometheus/alertmanager/types"
-	"github.com/prometheus/common/model"
-
 	"github.com/grafana/alerting/logging"
-	"github.com/grafana/alerting/models"
+	"github.com/prometheus/alertmanager/types"
 )
 
 const (
@@ -24,19 +21,14 @@ type forEachImageFunc func(index int, image Image) error
 //
 //nolint:revive
 func getImage(ctx context.Context, l logging.Logger, imageProvider Provider, alert types.Alert) (*Image, error) {
-	token := getTokenFromAnnotations(alert.Annotations)
-	if token == "" {
-		return nil, nil
-	}
-
 	ctx, cancelFunc := context.WithTimeout(ctx, ProviderTimeout)
 	defer cancelFunc()
 
-	img, err := imageProvider.GetImage(ctx, token)
+	img, err := imageProvider.GetImage(ctx, alert)
 	if errors.Is(err, ErrImageNotFound) || errors.Is(err, ErrImagesUnavailable) {
 		return nil, nil
 	} else if err != nil {
-		l.Warn("failed to get image with token", "token", token, "error", err)
+		l.Warn("failed to get image", "error", err)
 		return nil, err
 	} else {
 		return img, nil
@@ -45,12 +37,15 @@ func getImage(ctx context.Context, l logging.Logger, imageProvider Provider, ale
 
 // WithStoredImages retrieves the image for each alert and then calls forEachFunc
 // with the index of the alert and the retrieved image struct. If the alert does
-// not have an image token, or the image does not exist then forEachFunc will not be
+// not have an image then forEachFunc will not be
 // called for that alert. If forEachFunc returns an error, WithStoredImages will return
 // the error and not iterate the remaining alerts. A forEachFunc can return ErrImagesDone
 // to stop the iteration of remaining alerts if the intended image or maximum number of
 // images have been found.
 func WithStoredImages(ctx context.Context, l logging.Logger, imageProvider Provider, forEachFunc forEachImageFunc, alerts ...*types.Alert) error {
+	if imageProvider == nil {
+		return nil
+	}
 	for index, alert := range alerts {
 		logger := l.New("alert", alert.String())
 		img, err := getImage(ctx, logger, imageProvider, *alert)
@@ -67,11 +62,4 @@ func WithStoredImages(ctx context.Context, l logging.Logger, imageProvider Provi
 		}
 	}
 	return nil
-}
-
-func getTokenFromAnnotations(annotations model.LabelSet) string {
-	if value, ok := annotations[models.ImageTokenAnnotation]; ok {
-		return string(value)
-	}
-	return ""
 }

--- a/models/labels.go
+++ b/models/labels.go
@@ -13,6 +13,9 @@ const (
 	//nolint:gosec
 	ImageTokenAnnotation = "__alertImageToken__"
 
+	// ImageURLAnnotation is the annotation that will contain the URL of an alert's image.
+	ImageURLAnnotation = "__alert_image_url__"
+
 	// GrafanaReservedLabelPrefix contains the prefix for Grafana reserved labels. These differ from "__<label>__" labels
 	// in that they are not meant for internal-use only and will be passed-through to AMs and available to users in the same
 	// way as manually configured labels.

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -19,7 +19,7 @@ import (
 func TestBuildReceiverIntegrations(t *testing.T) {
 	var orgID = rand.Int63()
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
-	imageProvider := &images.FakeProvider{}
+	imageProvider := &images.URLProvider{}
 	tmpl := templates.ForTests(t)
 
 	emailFactory := func(_ receivers.Metadata) (receivers.EmailSender, error) {

--- a/receivers/discord/discord.go
+++ b/receivers/discord/discord.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"mime/multipart"
 	"strconv"
 	"strings"
@@ -81,7 +79,7 @@ type Notifier struct {
 
 type discordAttachment struct {
 	url       string
-	reader    io.ReadCloser
+	content   []byte
 	name      string
 	alertName string
 	state     model.AlertStatus
@@ -219,66 +217,49 @@ func (d Notifier) SendResolved() bool {
 
 func (d Notifier) constructAttachments(ctx context.Context, alerts []*types.Alert, embedQuota int) []discordAttachment {
 	attachments := make([]discordAttachment, 0, embedQuota)
-	embedsUsed := 0
-	for _, alert := range alerts {
-		// Check if the image limit has been reached at the start of each iteration.
-		if embedsUsed >= embedQuota {
-			d.log.Warn("Discord embed quota reached, not creating more attachments for this notification", "embedQuota", embedQuota)
-			break
-		}
-
-		attachment, err := d.getAttachment(ctx, alert)
-		if err != nil {
-			if errors.Is(err, images.ErrNoImageForAlert) {
-				// There's no image for this alert, continue.
-				continue
+	_ = images.WithStoredImages(ctx, d.log, d.images,
+		func(index int, image images.Image) error {
+			// Check if the image limit has been reached at the start of each iteration.
+			if len(attachments) >= embedQuota {
+				d.log.Warn("Discord embed quota reached, not creating more attachments for this notification", "embedQuota", embedQuota)
+				return images.ErrImagesDone
 			}
-			d.log.Error("failed to create an attachment for Discord", "alert", alert, "error", err)
-			continue
-		}
 
-		// We got an attachment, either using the image URL or bytes.
-		attachments = append(attachments, attachment)
-		embedsUsed++
-	}
+			alert := alerts[index]
+			attachment, err := d.getAttachment(ctx, alert, image)
+			if err != nil {
+				d.log.Error("failed to create an attachment for Discord", "alert", alert, "error", err)
+				return nil
+			}
+
+			// We got an attachment, either using the image URL or bytes.
+			attachments = append(attachments, *attachment)
+			return nil
+		}, alerts...)
 
 	return attachments
 }
 
 // getAttachment takes an alert and generates a Discord attachment containing an image for it.
 // If the image has no public URL, it uses the raw bytes for uploading directly to Discord.
-func (d Notifier) getAttachment(ctx context.Context, alert *types.Alert) (discordAttachment, error) {
-	attachment, err := d.getAttachmentFromURL(ctx, alert)
-	if errors.Is(err, images.ErrImagesNoURL) {
-		// There's an image but it has no public URL, use the bytes for the attachment.
-		return d.getAttachmentFromBytes(ctx, alert)
+func (d Notifier) getAttachment(ctx context.Context, alert *types.Alert, image images.Image) (*discordAttachment, error) {
+	if image.HasURL() {
+		return &discordAttachment{
+			url:       image.URL,
+			state:     alert.Status(),
+			alertName: alert.Name(),
+		}, nil
 	}
 
-	return attachment, err
-}
-
-func (d Notifier) getAttachmentFromURL(ctx context.Context, alert *types.Alert) (discordAttachment, error) {
-	url, err := d.images.GetImageURL(ctx, alert)
+	// There's an image but it has no public URL, use the bytes for the attachment.
+	r, err := image.RawData(ctx)
 	if err != nil {
-		return discordAttachment{}, err
+		return nil, err
 	}
-
-	return discordAttachment{
-		url:       url,
-		state:     alert.Status(),
-		alertName: alert.Name(),
-	}, nil
-}
-
-func (d Notifier) getAttachmentFromBytes(ctx context.Context, alert *types.Alert) (discordAttachment, error) {
-	r, name, err := d.images.GetRawImage(ctx, alert)
-	if err != nil {
-		return discordAttachment{}, err
-	}
-	return discordAttachment{
-		url:       "attachment://" + name,
-		name:      name,
-		reader:    r,
+	return &discordAttachment{
+		url:       "attachment://" + r.Name,
+		name:      r.Name,
+		content:   r.Content,
 		state:     alert.Status(),
 		alertName: alert.Name(),
 	}, nil
@@ -314,16 +295,12 @@ func (d Notifier) buildRequest(url string, body []byte, attachments []discordAtt
 	}
 
 	for _, a := range attachments {
-		if a.reader != nil { // We have an image to upload.
-			err = func() error {
-				defer func() { _ = a.reader.Close() }()
-				part, err := w.CreateFormFile("", a.name)
-				if err != nil {
-					return err
-				}
-				_, err = io.Copy(part, a.reader)
-				return err
-			}()
+		if len(a.content) > 0 { // We have an image to upload.
+			part, err := w.CreateFormFile("", a.name)
+			if err != nil {
+				return nil, err
+			}
+			_, err = part.Write(a.content)
 			if err != nil {
 				return nil, err
 			}

--- a/receivers/email/email.go
+++ b/receivers/email/email.go
@@ -56,7 +56,7 @@ func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 
 	// Extend alerts data with images, if available.
 	embeddedContents := make([]receivers.EmbeddedContent, 0)
-	_ = images.WithStoredImages(ctx, en.log, en.images,
+	err = images.WithStoredImages(ctx, en.log, en.images,
 		func(index int, image images.Image) error {
 			if image.HasURL() {
 				data.Alerts[index].ImageURL = image.URL
@@ -73,6 +73,9 @@ func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 			}
 			return nil
 		}, alerts...)
+	if err != nil {
+		en.log.Warn("failed to get all images for email", "error", err)
+	}
 
 	cmd := &receivers.SendEmailSettings{
 		Subject: subject,

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 	"time"
@@ -285,7 +284,7 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 	if isIncomingWebhook(sn.settings) {
 		// Incoming webhooks cannot upload files, instead share images via their URL
 		_ = images.WithStoredImages(ctx, sn.log, sn.images, func(_ int, image images.Image) error {
-			if image.URL != "" {
+			if image.HasURL() {
 				req.Attachments[0].ImageURL = image.URL
 				return images.ErrImagesDone
 			}
@@ -367,7 +366,7 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (slac
 // createImageMultipart returns the multipart/form-data request and headers for the url from getUploadURL
 // It returns an error if the image does not exist or there was an error preparing the
 // multipart form.
-func (sn *Notifier) createImageMultipart(image images.Image) (http.Header, []byte, error) {
+func (sn *Notifier) createImageMultipart(f images.ImageContent) (http.Header, []byte, error) {
 	buf := bytes.Buffer{}
 	w := multipart.NewWriter(&buf)
 	defer func() {
@@ -376,23 +375,13 @@ func (sn *Notifier) createImageMultipart(image images.Image) (http.Header, []byt
 		}
 	}()
 
-	f, err := os.Open(image.Path)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			sn.log.Error("Failed to close image file reader", "error", err)
-		}
-	}()
-
-	fw, err := w.CreateFormFile("filename", image.Path)
+	fw, err := w.CreateFormFile("filename", f.Name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create form file: %w", err)
 	}
 
-	if _, err := io.Copy(fw, f); err != nil {
-		return nil, nil, fmt.Errorf("failed to copy file to form: %w", err)
+	if _, err := fw.Write(f.Content); err != nil {
+		return nil, nil, fmt.Errorf("failed to write file to form: %w", err)
 	}
 
 	if err := w.Close(); err != nil {
@@ -424,25 +413,25 @@ func (sn *Notifier) sendMultipart(ctx context.Context, uploadURL string, headers
 // does not exist, or if there was an error either preparing or sending the multipart/form-data
 // request.
 func (sn *Notifier) uploadImage(ctx context.Context, image images.Image, channelID, comment, threadTs string) error {
-	sn.log.Debug("Uploading image", "image", image.Token)
-
-	imageData, err := os.Stat(image.Path)
+	sn.log.Debug("Retrieving image data")
+	f, err := image.RawData(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get image info: %w", err)
+		return err
+	}
+	sn.log.Debug("Uploading image", "image", f.Name)
+
+	headers, data, err := sn.createImageMultipart(f)
+	if err != nil {
+		return fmt.Errorf("failed to create multipart form: %w", err)
 	}
 
 	// get the upload url
-	uploadURLResponse, err := sn.getUploadURL(ctx, image.Path, imageData.Size())
+	uploadURLResponse, err := sn.getUploadURL(ctx, f.Name, len(data))
 	if err != nil {
 		return fmt.Errorf("failed to get upload URL: %w", err)
 	}
 
 	// upload the image
-	headers, data, err := sn.createImageMultipart(image)
-	if err != nil {
-		return fmt.Errorf("failed to create multipart form: %w", err)
-	}
-
 	uploadErr := sn.sendMultipart(ctx, uploadURLResponse.UploadURL, headers, bytes.NewReader(data))
 	if uploadErr != nil {
 		return fmt.Errorf("failed to upload image: %w", uploadErr)
@@ -453,7 +442,7 @@ func (sn *Notifier) uploadImage(ctx context.Context, image images.Image, channel
 }
 
 // getUploadURL returns the URL to upload the image to. It returns an error if the image cannot be uploaded.
-func (sn *Notifier) getUploadURL(ctx context.Context, filename string, imageSize int64) (*FileUploadURLResponse, error) {
+func (sn *Notifier) getUploadURL(ctx context.Context, filename string, imageSize int) (*FileUploadURLResponse, error) {
 	apiEndpoint, err := endpointURL(sn.settings, "files.getUploadURLExternal")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get URL for files.getUploadURLExternal: %w", err)

--- a/receivers/telegram/telegram_test.go
+++ b/receivers/telegram/telegram_test.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	images2 "github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
@@ -28,8 +29,8 @@ func TestNotify(t *testing.T) {
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
-	image1Name := images.GetImageFileName("test-image-1")
-	image2Name := images.GetImageFileName("test-image-2")
+	image1Name := "test-image-1.jpg"
+	image2Name := "test-image-2.jpg"
 
 	cases := []struct {
 		name        string


### PR DESCRIPTION
### Overview

This PR reworks the image `Provider` interface so that we can get screenshots in notifications working in both local and remote AMs. To this end, it:

- Simplifies the image `Provider` abstraction to hide Path and File information.
- Modifies a few integrations that use image upload to use the new `Image` struct.
- Provides two generic Provider implementations:
  - `TokenProvider`: Provider that takes tokens from `__alertImageToken__` annotation and attempts to retrieve an Image from the attached `TokenStore`. Allows fetching raw data. This is used by local AM where raw data is fetches from disk, but could eventually be used in remote AM with an appropriate image store.
  - `URLProvider`: Provider that takes urls from `__alert_image_url__` annotation and uses this as the public image url. Fetching raw data is unsupported, thus integrations that upload are not supported for screenshots. This is meant to be used by remote AM as a store is not necessary.
 
New abstraction is:

```go
type Provider interface {
	// GetImage takes an alert and returns its associated image.
	GetImage(ctx context.Context, alert types.Alert) (*Image, error)
}

type Image struct {
	// URL is the public URL of the image. This URL should not be treated as a trusted source and should not be
	// downloaded directly. RawData should be used to retrieve the image data.
	URL string
	// RawData returns the raw image data. Depending on the provider, this may be a file read, a network request, or
	// unsupported. It's the responsibility of the Provider to ensure that the data is safe to read.
	RawData func(ctx context.Context) (ImageContent, error)
}

type ImageContent struct {
	// Name is the unique identifier for the image. Usually this will be an image filename, but is not required to be.
	Name string
	// Content is the raw image data.
	Content []byte
}
```

### Other Notes

- Raw data fetching is encapsulated in the `Image` struct as `RawData(...)` so that we don't need to unnecessarily fetch from the `TokenStore` twice for those integrations that attempt both public URL and image upload/embed.
- Lots of defined errors are no longer needed with this simpler abstraction. Notably, we return `nil` when image isn't found instead of an error for conditional flow.

Split by easy to understand commit for those that prefer reviewing by commit.

### Image upload testing:

<details>
  <summary>Slack</summary>

![Screenshot from 2025-02-19 10-33-47](https://github.com/user-attachments/assets/8935c8ce-da4b-4e09-9a5d-2e3559402fa2)


</details>

<details>
  <summary>Email</summary>

![Screenshot from 2025-02-19 10-30-24](https://github.com/user-attachments/assets/769cb66f-2000-447f-b90b-8dcd5b4fc54e)


</details>

<details>
  <summary>Discord</summary>

![Screenshot from 2025-02-19 10-29-16](https://github.com/user-attachments/assets/108a1403-2745-49ed-9986-603899bc89d0)


</details>

<details>
  <summary>Telegram</summary>

![Screenshot from 2025-02-19 10-28-32](https://github.com/user-attachments/assets/0ccc2d7f-bc7c-4710-85cc-b3a3ed2cbd7b)


</details>