### PR TITLE
Add more context to log in PipelineAndStateTimestampCoordinationStage

### DIFF
--- a/notify/stages/coordination_stage.go
+++ b/notify/stages/coordination_stage.go
@@ -72,7 +72,7 @@ func (n *PipelineAndStateTimestampCoordinationStage) Exec(ctx context.Context, l
 	if ok && entry.Timestamp.After(timeNow) {
 		diff := entry.Timestamp.Sub(timeNow)
 		// this usually means that the WaitStage took longer than the group_wait, and the subsequent node in the cluster sees the event from the first node
-		_ = level.Warn(l).Log("msg", "timestamp of notification log entry is after the current pipeline timestamp.", "entry_time", entry.Timestamp, "pipeline_time", timeNow, "diff", diff, "dropped", n.stopPipeline)
+		_ = level.Warn(l).Log("msg", "timestamp of notification log entry is after the current pipeline timestamp.", "entry_time", entry.Timestamp, "pipeline_time", timeNow, "diff", diff, "dropped", n.stopPipeline, "aggrGroup", gkey, "alerts", fmt.Sprintf("%v", alerts))
 		if n.stopPipeline {
 			return ctx, nil, nil
 		}

--- a/notify/stages/coordination_stage.go
+++ b/notify/stages/coordination_stage.go
@@ -72,7 +72,7 @@ func (n *PipelineAndStateTimestampCoordinationStage) Exec(ctx context.Context, l
 	if ok && entry.Timestamp.After(timeNow) {
 		diff := entry.Timestamp.Sub(timeNow)
 		// this usually means that the WaitStage took longer than the group_wait, and the subsequent node in the cluster sees the event from the first node
-		_ = level.Warn(l).Log("msg", "timestamp of notification log entry is after the current pipeline timestamp.", "entry_time", entry.Timestamp, "pipeline_time", timeNow, "diff", diff, "dropped", n.stopPipeline, "aggrGroup", gkey, "alerts", fmt.Sprintf("%v", alerts))
+		_ = level.Warn(l).Log("msg", "timestamp of notification log entry is after the current pipeline timestamp.", "entry_time", entry.Timestamp, "pipeline_time", timeNow, "diff", diff, "dropped", n.stopPipeline, "aggrGroup", gkey, "alerts", fmt.Sprintf("%v", alerts), "receiver", n.recv.GroupName, "integration", n.recv.Integration)
 		if n.stopPipeline {
 			return ctx, nil, nil
 		}

--- a/notify/stages/coordination_stage.go
+++ b/notify/stages/coordination_stage.go
@@ -72,7 +72,7 @@ func (n *PipelineAndStateTimestampCoordinationStage) Exec(ctx context.Context, l
 	if ok && entry.Timestamp.After(timeNow) {
 		diff := entry.Timestamp.Sub(timeNow)
 		// this usually means that the WaitStage took longer than the group_wait, and the subsequent node in the cluster sees the event from the first node
-		_ = level.Warn(l).Log("msg", "timestamp of notification log entry is after the current pipeline timestamp.", "entry_time", entry.Timestamp, "pipeline_time", timeNow, "diff", diff, "dropped", n.stopPipeline, "aggrGroup", gkey, "alerts", fmt.Sprintf("%v", alerts), "receiver", n.recv.GroupName, "integration", n.recv.Integration)
+		_ = level.Warn(l).Log("msg", "timestamp of notification log entry is after the current pipeline timestamp.", "entry_time", entry.Timestamp, "pipeline_time", timeNow, "diff", diff, "dropped", n.stopPipeline, "aggrGroup", gkey, "alerts", fmt.Sprintf("%+v", alerts), "receiver", n.recv.GroupName, "integration", n.recv.Integration)
 		if n.stopPipeline {
 			return ctx, nil, nil
 		}

--- a/notify/stages/coordination_stage_test.go
+++ b/notify/stages/coordination_stage_test.go
@@ -79,6 +79,10 @@ func TestPipelineAndStateTimestampCoordinationStage(t *testing.T) {
 			stage := PipelineAndStateTimestampCoordinationStage{
 				nflog:        n,
 				stopPipeline: tc.stopPipeline,
+				recv: &nflogpb.Receiver{
+					GroupName:   "test-receiver",
+					Integration: "test-integration",
+				},
 			}
 			alerts := []*types.Alert{{}, {}, {}}
 			rCtx, rAlerts, err := stage.Exec(ctx, log.NewNopLogger(), alerts...)


### PR DESCRIPTION
This PR adds additional context to the log message. The context labels are the same as in the other places.