### PR TITLE
Copy http client from Grafana

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -1,0 +1,118 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/alerting/logging"
+	"github.com/grafana/alerting/receivers"
+)
+
+// This is carbon copy of https://github.com/grafana/grafana/blob/71d04a326be9578e2d678f23c1efa61768e0541f/pkg/services/notifications/webhook.go#L38
+
+type Webhook struct {
+	Url         string
+	User        string
+	Password    string
+	Body        string
+	HttpMethod  string
+	HttpHeader  map[string]string
+	ContentType string
+	TLSConfig   *tls.Config
+
+	// Validation is a function that will validate the response body and statusCode of the webhook. Any returned error will cause the webhook request to be considered failed.
+	// This can be useful when a webhook service communicates failures in creative ways, such as using the response body instead of the status code.
+	Validation func(body []byte, statusCode int) error
+}
+
+type NotificationService struct {
+	log logging.Logger
+}
+
+func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *Webhook) error {
+	if webhook.HttpMethod == "" {
+		webhook.HttpMethod = http.MethodPost
+	}
+	ns.log.Debug("Sending webhook", "url", webhook.Url, "http method", webhook.HttpMethod)
+
+	if webhook.HttpMethod != http.MethodPost && webhook.HttpMethod != http.MethodPut {
+		return fmt.Errorf("webhook only supports HTTP methods PUT or POST")
+	}
+
+	request, err := http.NewRequestWithContext(ctx, webhook.HttpMethod, webhook.Url, bytes.NewReader([]byte(webhook.Body)))
+	if err != nil {
+		return err
+	}
+	url, err := url.Parse(webhook.Url)
+	if err != nil {
+		// Should not be possible - NewRequestWithContext should also err if the URL is bad.
+		return err
+	}
+
+	if webhook.ContentType == "" {
+		webhook.ContentType = "application/json"
+	}
+
+	request.Header.Set("Content-Type", webhook.ContentType)
+	request.Header.Set("User-Agent", "Grafana")
+
+	if webhook.User != "" && webhook.Password != "" {
+		request.Header.Set("Authorization", GetBasicAuthHeader(webhook.User, webhook.Password))
+	}
+
+	for k, v := range webhook.HttpHeader {
+		request.Header.Set(k, v)
+	}
+
+	resp, err := receivers.NewTLSClient(webhook.TLSConfig).Do(request)
+	if err != nil {
+		return redactURL(err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			ns.log.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if webhook.Validation != nil {
+		err := webhook.Validation(body, resp.StatusCode)
+		if err != nil {
+			ns.log.Debug("Webhook failed validation", "url", url.Redacted(), "statuscode", resp.Status, "body", string(body), "error", err)
+			return fmt.Errorf("webhook failed validation: %w", err)
+		}
+	}
+
+	if resp.StatusCode/100 == 2 {
+		ns.log.Debug("Webhook succeeded", "url", url.Redacted(), "statuscode", resp.Status)
+		return nil
+	}
+
+	ns.log.Debug("Webhook failed", "url", url.Redacted(), "statuscode", resp.Status, "body", string(body))
+	return fmt.Errorf("webhook response status %v", resp.Status)
+}
+
+func redactURL(err error) error {
+	var e *url.Error
+	if !errors.As(err, &e) {
+		return err
+	}
+	e.URL = "<redacted>"
+	return e
+}
+
+func GetBasicAuthHeader(user string, password string) string {
+	var userAndPass = user + ":" + password
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(userAndPass))
+}

--- a/http/client.go
+++ b/http/client.go
@@ -14,13 +14,12 @@ import (
 	"github.com/grafana/alerting/receivers"
 )
 
-// This is carbon copy of https://github.com/grafana/grafana/blob/71d04a326be9578e2d678f23c1efa61768e0541f/pkg/services/notifications/webhook.go#L38
-
 type NotificationService struct {
 	log logging.Logger
 }
 
 func (ns *NotificationService) SendWebhook(ctx context.Context, webhook *receivers.SendWebhookSettings) error {
+	// This method is carbon copy of https://github.com/grafana/grafana/blob/71d04a326be9578e2d678f23c1efa61768e0541f/pkg/services/notifications/webhook.go#L38
 	if webhook.HTTPMethod == "" {
 		webhook.HTTPMethod = http.MethodPost
 	}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -1,0 +1,91 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/logging"
+	"github.com/grafana/alerting/receivers"
+)
+
+func TestSendWebhook(t *testing.T) {
+	var got *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/error" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		got = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	s := NewClient(logging.FakeLogger{}, ClientConfiguration{UserAgent: "TEST"})
+
+	// The method should be either POST or PUT.
+	cmd := receivers.SendWebhookSettings{
+		HTTPMethod: http.MethodGet,
+		URL:        server.URL,
+	}
+	require.ErrorIs(t, s.SendWebhook(context.Background(), &cmd), ErrInvalidMethod)
+
+	// If the method is not specified, it should default to POST.
+	// Content type should default to application/json.
+	testHeaders := map[string]string{
+		"test-header-1": "test-1",
+		"test-header-2": "test-2",
+		"test-header-3": "test-3",
+	}
+	cmd = receivers.SendWebhookSettings{
+		URL:        server.URL,
+		HTTPHeader: testHeaders,
+	}
+	require.NoError(t, s.SendWebhook(context.Background(), &cmd))
+	require.Equal(t, http.MethodPost, got.Method)
+	require.Equal(t, "application/json", got.Header.Get("Content-Type"))
+
+	// User agent should be correctly set.
+	require.Equal(t, "TEST", got.Header.Get("User-Agent"))
+
+	// No basic auth should be set if user and password are not provided.
+	_, _, ok := got.BasicAuth()
+	require.False(t, ok)
+
+	// Request heders should be set.
+	for k, v := range testHeaders {
+		require.Equal(t, v, got.Header.Get(k))
+	}
+
+	// Basic auth should be correctly set.
+	testUser := "test-user"
+	testPassword := "test-password"
+	cmd = receivers.SendWebhookSettings{
+		URL:      server.URL,
+		User:     testUser,
+		Password: testPassword,
+	}
+
+	require.NoError(t, s.SendWebhook(context.Background(), &cmd))
+	user, password, ok := got.BasicAuth()
+	require.True(t, ok)
+	require.Equal(t, testUser, user)
+	require.Equal(t, testPassword, password)
+
+	// Validation errors should be returned.
+	testErr := errors.New("test")
+	cmd = receivers.SendWebhookSettings{
+		URL:        server.URL,
+		Validation: func([]byte, int) error { return testErr },
+	}
+
+	require.ErrorIs(t, s.SendWebhook(context.Background(), &cmd), testErr)
+
+	// A non-200 status code should cause an error.
+	cmd = receivers.SendWebhookSettings{
+		URL: server.URL + "/error",
+	}
+	require.Error(t, s.SendWebhook(context.Background(), &cmd))
+}

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -42,7 +42,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	t.Run("should build all supported notifiers", func(t *testing.T) {
 		fullCfg, qty := getFullConfig(t)
 
-		logger := func(name string, _ ...interface{}) logging.Logger {
+		logger := func(_ string, _ ...interface{}) logging.Logger {
 			return &logging.FakeLogger{}
 		}
 

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -42,13 +42,9 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	t.Run("should build all supported notifiers", func(t *testing.T) {
 		fullCfg, qty := getFullConfig(t)
 
-		loggerNames := make(map[string]struct{}, qty)
 		logger := func(name string, _ ...interface{}) logging.Logger {
-			loggerNames[name] = struct{}{}
 			return &logging.FakeLogger{}
 		}
-
-		webhooks := make(map[receivers.Metadata]struct{}, qty)
 
 		emails := make(map[receivers.Metadata]struct{}, qty)
 		em := func(n receivers.Metadata) (receivers.EmailSender, error) {
@@ -61,12 +57,6 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, integrations, qty)
 
-		t.Run("should call logger factory for each config", func(t *testing.T) {
-			require.Len(t, loggerNames, qty)
-		})
-		t.Run("should call webhook factory for each config that needs it", func(t *testing.T) {
-			require.Len(t, webhooks, 17) // we have 17 notifiers that support webhook
-		})
 		t.Run("should call email factory for each config that needs it", func(t *testing.T) {
 			require.Len(t, emails, 1) // we have only email notifier that needs sender
 		})

--- a/receivers/webhook.go
+++ b/receivers/webhook.go
@@ -13,8 +13,11 @@ type SendWebhookSettings struct {
 	HTTPMethod  string
 	HTTPHeader  map[string]string
 	ContentType string
-	Validation  func(body []byte, statusCode int) error
-	TLSConfig   *tls.Config
+
+	// Validation is a function that will validate the response body and statusCode of the webhook. Any returned error will cause the webhook request to be considered failed.
+	// This can be useful when a webhook service communicates failures in creative ways, such as using the response body instead of the status code.
+	Validation func(body []byte, statusCode int) error
+	TLSConfig  *tls.Config
 }
 
 type WebhookSender interface {


### PR DESCRIPTION
Currently, we use Grafana's webhook client, and there is an almost carbon copy of it in [Mimir](https://github.com/grafana/mimir/blob/main/pkg/alertmanager/sender.go). This PR allows to consolidate those clients in one place 

I will allow us refactor receivers to use an http client compatible with upstream and potentially ability to configure upstream integrations.