### PR TITLE
Support HMAC SHA256 request signing in the http client

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/benbjohnson/clock"
+
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
 )
@@ -37,7 +39,7 @@ func NewClient(log logging.Logger, cfg ClientConfiguration) *Client {
 }
 
 func (ns *Client) SendWebhook(ctx context.Context, webhook *receivers.SendWebhookSettings) error {
-	// This method is carbon copy of https://github.com/grafana/grafana/blob/71d04a326be9578e2d678f23c1efa61768e0541f/pkg/services/notifications/webhook.go#L38
+	// This method was moved from https://github.com/grafana/grafana/blob/71d04a326be9578e2d678f23c1efa61768e0541f/pkg/services/notifications/webhook.go#L38
 	if webhook.HTTPMethod == "" {
 		webhook.HTTPMethod = http.MethodPost
 	}
@@ -72,7 +74,24 @@ func (ns *Client) SendWebhook(ctx context.Context, webhook *receivers.SendWebhoo
 		request.Header.Set(k, v)
 	}
 
-	resp, err := receivers.NewTLSClient(webhook.TLSConfig).Do(request)
+	client := receivers.NewTLSClient(webhook.TLSConfig)
+
+	if webhook.HMACConfig != nil {
+		ns.log.Debug("Adding HMAC roundtripper to client")
+		client.Transport, err = NewHMACRoundTripper(
+			client.Transport,
+			clock.New(),
+			webhook.HMACConfig.Secret,
+			webhook.HMACConfig.Header,
+			webhook.HMACConfig.TimestampHeader,
+		)
+		if err != nil {
+			ns.log.Error("Failed to add HMAC roundtripper to client", "error", err)
+			return err
+		}
+	}
+
+	resp, err := client.Do(request)
 	if err != nil {
 		return redactURL(err)
 	}

--- a/http/client.go
+++ b/http/client.go
@@ -74,7 +74,7 @@ func (ns *Client) SendWebhook(ctx context.Context, webhook *receivers.SendWebhoo
 		request.Header.Set(k, v)
 	}
 
-	client := receivers.NewTLSClient(webhook.TLSConfig)
+	client := NewTLSClient(webhook.TLSConfig)
 
 	if webhook.HMACConfig != nil {
 		ns.log.Debug("Adding HMAC roundtripper to client")

--- a/http/hmac.go
+++ b/http/hmac.go
@@ -1,0 +1,92 @@
+package http
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/benbjohnson/clock"
+)
+
+const (
+	// defaultHeaderName is the default HTTP header used for the HMAC signature
+	defaultHeaderName = "X-Grafana-Alert-Signature"
+	// timestampSeparator is used to separate the timestamp from the request body in the HMAC calculation
+	timestampSeparator = ":"
+)
+
+// HMACRoundTripper is an HTTP transport that signs outgoing requests using HMAC SHA256.
+// It can optionally include a timestamp in the signature calculation (if timestampHeader is not empty)
+// and supports custom header names for both the signature and timestamp values.
+type HMACRoundTripper struct {
+	wrapped         http.RoundTripper
+	clk             clock.Clock
+	secret          string
+	header          string
+	timestampHeader string
+}
+
+// NewHMACRoundTripper creates a new HMACRoundTripper that wraps the provided RoundTripper.
+// It signs requests using the provided secret key and places the signature in the specified header.
+// If header is empty, it defaults to "X-Grafana-Alert-Signature".
+// If timestampHeader is non-empty, the current timestamp will be included in the signature
+// calculation and set in the specified header.
+func NewHMACRoundTripper(wrapped http.RoundTripper, clk clock.Clock, secret, header, timestampHeader string) (*HMACRoundTripper, error) {
+	if secret == "" {
+		return nil, errors.New("secret must be provided")
+	}
+	if header == "" {
+		header = defaultHeaderName
+	}
+	return &HMACRoundTripper{
+		wrapped:         wrapped,
+		clk:             clk,
+		secret:          secret,
+		header:          header,
+		timestampHeader: timestampHeader,
+	}, nil
+}
+
+func (rt *HMACRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := rt.sign(req); err != nil {
+		return nil, fmt.Errorf("failed to sign request: %w", err)
+	}
+	return rt.wrapped.RoundTrip(req)
+}
+
+// sign computes the HMAC SHA256 signature for the request body.
+// If a timestamp header is configured, it includes the current timestamp in the signature.
+// The computed signature is then set in the request header, and the request body is restored.
+func (rt *HMACRoundTripper) sign(req *http.Request) error {
+	if req.Body == nil {
+		return nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+	req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	hash := hmac.New(sha256.New, []byte(rt.secret))
+
+	if rt.timestampHeader != "" {
+		timestamp := strconv.FormatInt(rt.clk.Now().Unix(), 10)
+		req.Header.Set(rt.timestampHeader, timestamp)
+		hash.Write([]byte(timestamp))
+		hash.Write([]byte(timestampSeparator))
+	}
+
+	hash.Write(body)
+	signature := hex.EncodeToString(hash.Sum(nil))
+	req.Header.Set(rt.header, signature)
+
+	return nil
+}

--- a/http/hmac.go
+++ b/http/hmac.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// defaultHeaderName is the default HTTP header used for the HMAC signature
-	defaultHeaderName = "X-Grafana-Alert-Signature"
+	defaultHeaderName = "X-Grafana-Alerting-Signature"
 	// timestampSeparator is used to separate the timestamp from the request body in the HMAC calculation
 	timestampSeparator = ":"
 )

--- a/http/hmac_test.go
+++ b/http/hmac_test.go
@@ -1,0 +1,132 @@
+package http
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/require"
+)
+
+func computeHMAC(t *testing.T, secret, body string, clk clock.Clock) string {
+	t.Helper()
+
+	hash := hmac.New(sha256.New, []byte(secret))
+
+	if clk != nil {
+		ts := strconv.FormatInt(clk.Now().Unix(), 10)
+		hash.Write([]byte(ts))
+		hash.Write([]byte(":"))
+	}
+	hash.Write([]byte(body))
+
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func TestHMACRoundTripper(t *testing.T) {
+	mockClock := clock.NewMock()
+
+	testCases := []struct {
+		name            string
+		secret          string
+		header          string
+		timestampHeader string
+		body            string
+		expectErr       bool
+	}{
+		{
+			name:            "Valid signing without timestamp",
+			secret:          "secret",
+			header:          "X-Signature",
+			timestampHeader: "",
+			body:            "test message",
+		},
+		{
+			name:            "Valid signing with timestamp",
+			secret:          "secret",
+			header:          "X-Signature",
+			timestampHeader: "X-Timestamp",
+			body:            "test message",
+		},
+		{
+			name:            "Empty secret",
+			secret:          "",
+			header:          "X-Signature",
+			timestampHeader: "",
+			body:            "test message",
+			expectErr:       true,
+		},
+		{
+			name:            "Empty header uses default",
+			secret:          "secret",
+			header:          "",
+			timestampHeader: "",
+			body:            "test message",
+		},
+		{
+			name:            "Empty body without timestamp",
+			secret:          "secret",
+			header:          "X-Signature",
+			timestampHeader: "",
+			body:            "",
+		},
+		{
+			name:            "Empty body with timestamp",
+			secret:          "secret",
+			header:          "X-Signature",
+			timestampHeader: "X-Timestamp",
+			body:            "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt, err := NewHMACRoundTripper(http.DefaultTransport, mockClock, tc.secret, tc.header, tc.timestampHeader)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Create request with body
+			body := bytes.NewReader([]byte(tc.body))
+			req, err := http.NewRequest(http.MethodPost, "http://example.com", body)
+			require.NoError(t, err)
+
+			err = rt.sign(req)
+			require.NoError(t, err)
+
+			// Verify the signature and the timestamp
+			headerName := tc.header
+			if headerName == "" {
+				headerName = defaultHeaderName
+			}
+
+			var clkForSigning clock.Clock
+			if tc.timestampHeader != "" {
+				clkForSigning = mockClock
+			}
+			expectedHash := computeHMAC(t, tc.secret, tc.body, clkForSigning)
+			require.Equal(t, expectedHash, req.Header.Get(headerName))
+
+			if tc.timestampHeader != "" {
+				ts := strconv.FormatInt(mockClock.Now().Unix(), 10)
+				require.Equal(t, ts, req.Header.Get(tc.timestampHeader))
+			}
+
+			// Verify that the body can still be read
+			if req.Body != nil {
+				bodyBytes, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.Equal(t, tc.body, string(bodyBytes))
+			}
+		})
+	}
+}

--- a/http/tls.go
+++ b/http/tls.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// NewTLSClient creates a new HTTP client with the provided TLS configuration or with default settings.
+func NewTLSClient(tlsConfig *tls.Config) *http.Client {
+	nc := func(tlsConfig *tls.Config) *http.Client {
+		return &http.Client{
+			Timeout: time.Second * 30,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+				Proxy:           http.ProxyFromEnvironment,
+				Dial: (&net.Dialer{
+					Timeout: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout: 5 * time.Second,
+			},
+		}
+	}
+
+	if tlsConfig == nil {
+		return nc(&tls.Config{Renegotiation: tls.RenegotiateFreelyAsClient})
+	}
+
+	return nc(tlsConfig)
+}

--- a/http/tls_test.go
+++ b/http/tls_test.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewTLSClient(t *testing.T) {
+	tc := []struct {
+		name   string
+		cfg    *tls.Config
+		expCfg *tls.Config
+	}{
+		{
+			name:   "empty TLSConfig",
+			expCfg: &tls.Config{Renegotiation: tls.RenegotiateFreelyAsClient},
+		},
+		{
+			name:   "valid TLSConfig",
+			cfg:    &tls.Config{InsecureSkipVerify: true},
+			expCfg: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewTLSClient(tt.cfg)
+			require.Equal(t, tt.expCfg, c.Transport.(*http.Transport).TLSClientConfig)
+		})
+	}
+}

--- a/http/webhook.go
+++ b/http/webhook.go
@@ -43,7 +43,7 @@ func (f ForkedSender) SendWebhook(ctx context.Context, cmd *receivers.SendWebhoo
 		request.Header.Set(k, v)
 	}
 
-	resp, err := receivers.NewTLSClient(cmd.TLSConfig).Do(request)
+	resp, err := NewTLSClient(cmd.TLSConfig).Do(request)
 	if err != nil {
 		return redactURL(err)
 	}

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -87,29 +87,6 @@ func (cfg *TLSConfig) ToCryptoTLSConfig() (*tls.Config, error) {
 	return tlsCfg, nil
 }
 
-// NewTLSClient creates a new HTTP client with the provided TLS configuration or with default settings.
-func NewTLSClient(tlsConfig *tls.Config) *http.Client {
-	nc := func(tlsConfig *tls.Config) *http.Client {
-		return &http.Client{
-			Timeout: time.Second * 30,
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-				Proxy:           http.ProxyFromEnvironment,
-				Dial: (&net.Dialer{
-					Timeout: 30 * time.Second,
-				}).Dial,
-				TLSHandshakeTimeout: 5 * time.Second,
-			},
-		}
-	}
-
-	if tlsConfig == nil {
-		return nc(&tls.Config{Renegotiation: tls.RenegotiateFreelyAsClient})
-	}
-
-	return nc(tlsConfig)
-}
-
 // SendHTTPRequest sends an HTTP request.
 // Stubbable by tests.
 //

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -43,6 +43,17 @@ type HTTPCfg struct {
 	Password string
 }
 
+// HMACConfig contains configuration for HMAC signing of HTTP requests
+type HMACConfig struct {
+	// Secret to use for HMAC signing.
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+	// Header is the name of the header containing the HMAC signature.
+	Header string `json:"header,omitempty" yaml:"header,omitempty"`
+	// TimestampHeader is the name of the header containing the timestamp
+	// used to generate the HMAC signature. If empty, timestamp is not included.
+	TimestampHeader string `yaml:"timestampHeader,omitempty" json:"timestampHeader,omitempty"`
+}
+
 type TLSConfig struct {
 	CACertificate      string `json:"caCertificate,omitempty" yaml:"caCertificate,omitempty"`
 	ClientCertificate  string `json:"clientCertificate,omitempty" yaml:"clientCertificate,omitempty"`

--- a/receivers/util_test.go
+++ b/receivers/util_test.go
@@ -1,8 +1,6 @@
 package receivers
 
 import (
-	"crypto/tls"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,31 +103,6 @@ func TestNewTLSConfig(t *testing.T) {
 					require.NotEmpty(t, tlsCfg.Certificates, "expected Certificates to be set, but it was empty")
 				}
 			}
-		})
-	}
-}
-
-func Test_NewTLSClient(t *testing.T) {
-	tc := []struct {
-		name   string
-		cfg    *tls.Config
-		expCfg *tls.Config
-	}{
-		{
-			name:   "empty TLSConfig",
-			expCfg: &tls.Config{Renegotiation: tls.RenegotiateFreelyAsClient},
-		},
-		{
-			name:   "valid TLSConfig",
-			cfg:    &tls.Config{InsecureSkipVerify: true},
-			expCfg: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			c := NewTLSClient(tt.cfg)
-			require.Equal(t, tt.expCfg, c.Transport.(*http.Transport).TLSClientConfig)
 		})
 	}
 }

--- a/receivers/webhook.go
+++ b/receivers/webhook.go
@@ -18,6 +18,7 @@ type SendWebhookSettings struct {
 	// This can be useful when a webhook service communicates failures in creative ways, such as using the response body instead of the status code.
 	Validation func(body []byte, statusCode int) error
 	TLSConfig  *tls.Config
+	HMACConfig *HMACConfig
 }
 
 type WebhookSender interface {

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -22,9 +22,10 @@ type Config struct {
 	User     string
 	Password string
 
-	Title     string
-	Message   string
-	TLSConfig *receivers.TLSConfig
+	Title      string
+	Message    string
+	TLSConfig  *receivers.TLSConfig
+	HMACConfig *receivers.HMACConfig
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
@@ -40,6 +41,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		Title                    string                   `json:"title,omitempty" yaml:"title,omitempty"`
 		Message                  string                   `json:"message,omitempty" yaml:"message,omitempty"`
 		TLSConfig                *receivers.TLSConfig     `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty"`
+		HMACConfig               *receivers.HMACConfig    `json:"hmacConfig,omitempty" yaml:"hmacConfig,omitempty"`
 	}{}
 
 	err := json.Unmarshal(jsonData, &rawSettings)
@@ -86,6 +88,14 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 			CACertificate:      decryptFn("tlsConfig.caCertificate", tlsConfig.CACertificate),
 			ClientCertificate:  decryptFn("tlsConfig.clientCertificate", tlsConfig.ClientCertificate),
 			ClientKey:          decryptFn("tlsConfig.clientKey", tlsConfig.ClientKey),
+		}
+	}
+
+	if hmacConfig := rawSettings.HMACConfig; hmacConfig != nil {
+		settings.HMACConfig = &receivers.HMACConfig{
+			Secret:          decryptFn("hmacConfig.secret", hmacConfig.Secret),
+			Header:          hmacConfig.Header,
+			TimestampHeader: hmacConfig.TimestampHeader,
 		}
 	}
 

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -89,6 +89,11 @@ func TestNewConfig(t *testing.T) {
 					ClientKey:          "test-client-key",
 					CACertificate:      "test-ca-certificate",
 				},
+				HMACConfig: &receivers.HMACConfig{
+					Secret:          "test-hmac-secret",
+					Header:          "X-Grafana-Alerting-Signature",
+					TimestampHeader: "X-Grafana-Alerting-Timestamp",
+				},
 			},
 		},
 		{
@@ -107,9 +112,14 @@ func TestNewConfig(t *testing.T) {
 				Message:                  "test-message",
 				TLSConfig: &receivers.TLSConfig{
 					InsecureSkipVerify: false,
-					ClientCertificate:  "test-client-certificate",
-					ClientKey:          "test-client-key",
-					CACertificate:      "test-ca-certificate",
+					ClientCertificate:  "test-override-client-certificate",
+					ClientKey:          "test-override-client-key",
+					CACertificate:      "test-override-ca-certificate",
+				},
+				HMACConfig: &receivers.HMACConfig{
+					Secret:          "test-override-hmac-secret",
+					Header:          "X-Grafana-Alerting-Signature",
+					TimestampHeader: "X-Grafana-Alerting-Timestamp",
 				},
 			},
 		},
@@ -248,6 +258,31 @@ func TestNewConfig(t *testing.T) {
 				Password:                 "",
 				Title:                    templates.DefaultMessageTitleEmbed,
 				Message:                  templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name: "with HMAC config",
+			settings: `{
+				"url": "http://localhost/test1",
+				"hmacConfig": {
+					"header": "X-Test-Hash",
+					"timestampHeader": "X-Test-Timestamp"
+				}
+			}`,
+			secretSettings: map[string][]byte{
+				"hmacConfig.secret": []byte("test-secret-from-secrets"),
+			},
+			expectedConfig: Config{
+				URL:        "http://localhost/test1",
+				HTTPMethod: http.MethodPost,
+				MaxAlerts:  0,
+				Title:      templates.DefaultMessageTitleEmbed,
+				Message:    templates.DefaultMessageEmbed,
+				HMACConfig: &receivers.HMACConfig{
+					Secret:          "test-secret-from-secrets",
+					Header:          "X-Test-Hash",
+					TimestampHeader: "X-Test-Timestamp",
+				},
 			},
 		},
 		{

--- a/receivers/webhook/testing.go
+++ b/receivers/webhook/testing.go
@@ -16,6 +16,11 @@ const FullValidConfigForTesting = `{
 		"clientCertificate": "test-client-certificate",
 		"clientKey": "test-client-key",
 		"caCertificate": "test-ca-certificate"
+	},
+	"hmacConfig": {
+		"secret": "test-hmac-secret",
+		"header": "X-Grafana-Alerting-Signature",
+		"timestampHeader": "X-Grafana-Alerting-Timestamp"
 	}
 }`
 
@@ -23,7 +28,8 @@ const FullValidConfigForTesting = `{
 const FullValidSecretsForTesting = `{
 	"username": "test-secret-user",
 	"password": "test-secret-pass",
-	"clientCertificate": "test-client-certificate",
-	"clientKey": "test-client-key",
-	"caCertificate": "test-ca-certificate"
+	"tlsConfig.clientCertificate": "test-override-client-certificate",
+	"tlsConfig.clientKey": "test-override-client-key",
+	"tlsConfig.caCertificate": "test-override-ca-certificate",
+	"hmacConfig.secret": "test-override-hmac-secret"
 }`

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -127,6 +127,7 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		HTTPMethod: wn.settings.HTTPMethod,
 		HTTPHeader: headers,
 		TLSConfig:  tlsConfig,
+		HMACConfig: wn.settings.HMACConfig,
 	}
 
 	if err := wn.ns.SendWebhook(ctx, cmd); err != nil {


### PR DESCRIPTION
Adds optional HMAC SHA256 signing to the HTTP client.

A new HMACRoundTripper (in http/hmac.go) computes and adds a signature for outgoing webhooks. The signature is computed from the request body.

Optionally, a timestamp header name can be specified, and if it's set, the signature is computed from `{timestamp}:{body}`, and the timestamp is added to the headers for the client to verify.

Other implementation examples:
- [Slack](https://api.slack.com/authentication/verifying-requests-from-slack) (also adds a timestamp)
- [Docusign](https://developers.docusign.com/platform/webhooks/connect/setting-up-hmac/)

Draft PR to Grafana: https://github.com/grafana/grafana/pull/100960 if you want to test it locally.

Part of https://github.com/grafana/alerting-squad/issues/1040