### PR TITLE
Use correct template function in sns receiver

### DIFF
--- a/receivers/sns/sns.go
+++ b/receivers/sns/sns.go
@@ -41,11 +41,9 @@ func New(cfg Config, meta receivers.Metadata, template *templates.Template, logg
 
 // Notify sends the alert notification to sns.
 func (s *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
-	var (
-		tmplErr error
-		data    = notify.GetTemplateData(ctx, s.tmpl, as, s.log)
-		tmpl    = notify.TmplText(s.tmpl, data, &tmplErr)
-	)
+	var tmplErr error
+	tmpl, _ := templates.TmplText(ctx, s.tmpl, as, s.log, &tmplErr)
+
 	s.log.Info("Sending notification")
 
 	publishInput, err := s.createPublishInput(ctx, tmpl)

--- a/receivers/sns/sns_test.go
+++ b/receivers/sns/sns_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -50,8 +49,7 @@ func TestCreatePublishInput(t *testing.T) {
 			},
 		}
 		var tmplErr error
-		data := notify.GetTemplateData(context.Background(), tmpl, alerts, snsNotifier.log)
-		tmplFn := notify.TmplText(tmpl, data, &tmplErr)
+		tmplFn, _ := templates.TmplText(context.Background(), tmpl, alerts, snsNotifier.log, &tmplErr)
 
 		snsInput, err := snsNotifier.createPublishInput(context.Background(), tmplFn)
 		require.NoError(t, err)
@@ -90,8 +88,7 @@ func TestCreatePublishInput(t *testing.T) {
 		}
 
 		var tmplErr error
-		data := notify.GetTemplateData(context.Background(), tmpl, alerts, snsNotifier.log)
-		tmplFn := notify.TmplText(tmpl, data, &tmplErr)
+		tmplFn, _ := templates.TmplText(context.Background(), tmpl, alerts, snsNotifier.log, &tmplErr)
 
 		snsInput, err := snsNotifier.createPublishInput(context.Background(), tmplFn)
 		require.NoError(t, err)
@@ -131,8 +128,7 @@ func TestCreatePublishInput(t *testing.T) {
 		}
 
 		var tmplErr error
-		data := notify.GetTemplateData(context.Background(), tmpl, alerts, snsNotifier.log)
-		tmplFn := notify.TmplText(tmpl, data, &tmplErr)
+		tmplFn, _ := templates.TmplText(context.Background(), tmpl, alerts, snsNotifier.log, &tmplErr)
 
 		snsInput, err := snsNotifier.createPublishInput(context.Background(), tmplFn)
 		require.NoError(t, err)


### PR DESCRIPTION
The current SNS receiver uses the upstream template logic, which doesn't make use of the extended alert data included in our own logic. This PR corrects that to use the same function the rest of our receivers use.

Resolves https://github.com/grafana/grafana/issues/91943