### PR TITLE
Try additional scopes when testing templates with root scope fails

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -1,7 +1,6 @@
 package notify
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -596,8 +595,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 	// Iterate over each definition in the template and evaluate it.
 	var results TestTemplatesResults
 	for _, def := range definitions {
-		var buf bytes.Buffer
-		err := newTextTmpl.ExecuteTemplate(&buf, def, data)
+		res, scope, err := testTemplateScopes(newTextTmpl, def, data)
 		if err != nil {
 			results.Errors = append(results.Errors, TestTemplatesErrorResult{
 				Name:  def,
@@ -606,8 +604,9 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 			})
 		} else {
 			results.Results = append(results.Results, TestTemplatesResult{
-				Name: def,
-				Text: buf.String(),
+				Name:  def,
+				Text:  res,
+				Scope: scope,
 			})
 		}
 	}

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/grafana/alerting/templates"
 
 	"github.com/go-openapi/strfmt"
-	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 )
 
 var (
@@ -39,8 +40,9 @@ func TestTemplateSimple(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "Template Contents",
+				Name:  "slack.title",
+				Text:  "Template Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -53,8 +55,9 @@ func TestTemplateSimple(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "17",
+				Name:  "slack.title",
+				Text:  "17",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -67,8 +70,9 @@ func TestTemplateSimple(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "TEMPLATE CONTENTS",
+				Name:  "slack.title",
+				Text:  "TEMPLATE CONTENTS",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -110,8 +114,9 @@ func TestTemplateSimple(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "Other Contents",
+				Name:  "slack.title",
+				Text:  "Other Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -124,11 +129,13 @@ func TestTemplateSimple(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "discord.title",
-				Text: "Discord Title",
+				Name:  "discord.title",
+				Text:  "Discord Title",
+				Scope: rootScope,
 			}, {
-				Name: "slack.title",
-				Text: "Other Contents",
+				Name:  "slack.title",
+				Text:  "Other Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -141,8 +148,9 @@ func TestTemplateSimple(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "discord.title",
-				Text: "Discord Title",
+				Name:  "discord.title",
+				Text:  "Discord Title",
+				Scope: rootScope,
 			}},
 			Errors: []TestTemplatesErrorResult{{
 				Name:  "slack.title",
@@ -178,8 +186,9 @@ func TestTemplateSpecialCases(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "Template Contents",
+				Name:  "slack.title",
+				Text:  "Template Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -203,8 +212,9 @@ func TestTemplateSpecialCases(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "discord.title",
-				Text: "Template Contents",
+				Name:  "discord.title",
+				Text:  "Template Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -231,8 +241,9 @@ func TestTemplateSpecialCases(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "",
-				Text: "Template Contents",
+				Name:  "",
+				Text:  "Template Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -245,11 +256,13 @@ func TestTemplateSpecialCases(t *testing.T) {
 		},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "",
-				Text: "abcdef",
+				Name:  "",
+				Text:  "abcdef",
+				Scope: rootScope,
 			}, {
-				Name: "slack.title",
-				Text: "Template Contents",
+				Name:  "slack.title",
+				Text:  "Template Contents",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -283,8 +296,9 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		existingTemplates: nil,
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "[FIRING:1] group_label_value (alert1 val1)",
+				Name:  "slack.title",
+				Text:  "[FIRING:1] group_label_value (alert1 val1)",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -301,8 +315,9 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "Some existing template",
+				Name:  "slack.title",
+				Text:  "Some existing template",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -319,8 +334,9 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "New template",
+				Name:  "slack.title",
+				Text:  "New template",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -356,8 +372,9 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "Some new alternate template",
+				Name:  "slack.title",
+				Text:  "Some new alternate template",
+				Scope: rootScope,
 			}},
 			Errors: nil,
 		},
@@ -384,12 +401,13 @@ func TestTemplateAlertData(t *testing.T) {
 		name     string
 		input    TestTemplatesConfigBodyParams
 		expected TestTemplatesResults
-	}{{
-		name: "check various extended data",
-		input: TestTemplatesConfigBodyParams{
-			Alerts: []*amv2.PostableAlert{&simpleAlert},
-			Name:   "slack.title",
-			Template: `{{ define "slack.title" }}
+	}{
+		{
+			name: "check various extended data",
+			input: TestTemplatesConfigBodyParams{
+				Alerts: []*amv2.PostableAlert{&simpleAlert},
+				Name:   "slack.title",
+				Template: `{{ define "slack.title" }}
 Receiver: {{ .Receiver }}
 Status: {{ .Status }}
 ExternalURL: {{ .ExternalURL }}
@@ -400,15 +418,82 @@ GroupLabels: {{ range .GroupLabels.SortedPairs }}{{ .Name }}={{ .Value }}{{ end 
 CommonLabels: {{ range .CommonLabels.SortedPairs }}{{ .Name }}={{ .Value }}{{ end }}
 CommonAnnotations: {{ range .CommonAnnotations.SortedPairs }}{{ .Name }}={{ .Value }}{{ end }}
 {{ end }}`,
+			},
+			expected: TestTemplatesResults{
+				Results: []TestTemplatesResult{{
+					Name:  "slack.title",
+					Text:  "\nReceiver: TestReceiver\nStatus: firing\nExternalURL: http://localhost:9093\nAlerts: 1\nFiring Alerts: 1\nResolved Alerts: 0\nGroupLabels: group_label=group_label_value\nCommonLabels: alertname=alert1lbl1=val1\nCommonAnnotations: ann1=annv1\n",
+					Scope: rootScope,
+				}},
+				Errors: nil,
+			},
 		},
-		expected: TestTemplatesResults{
-			Results: []TestTemplatesResult{{
-				Name: "slack.title",
-				Text: "\nReceiver: TestReceiver\nStatus: firing\nExternalURL: http://localhost:9093\nAlerts: 1\nFiring Alerts: 1\nResolved Alerts: 0\nGroupLabels: group_label=group_label_value\nCommonLabels: alertname=alert1lbl1=val1\nCommonAnnotations: ann1=annv1\n",
-			}},
-			Errors: nil,
+		{
+			name: "template scoped to .Alerts",
+			input: TestTemplatesConfigBodyParams{
+				Alerts: []*amv2.PostableAlert{&simpleAlert},
+				Name:   "alerts.custom",
+				Template: `{{ define "alerts.custom" }}{{ range . }}
+Labels:
+{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Annotations:
+{{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}{{ if gt (len .GeneratorURL) 0 }}Source: {{ .GeneratorURL }}
+{{ end }}{{ if gt (len .SilenceURL) 0 }}Silence: {{ .SilenceURL }}
+{{ end }}{{ if gt (len .DashboardURL) 0 }}Dashboard: {{ .DashboardURL }}
+{{ end }}{{ if gt (len .PanelURL) 0 }}Panel: {{ .PanelURL }}
+{{ end }}{{ end }}{{ end }}`,
+			},
+			expected: TestTemplatesResults{
+				Results: []TestTemplatesResult{{
+					Name:  "alerts.custom",
+					Text:  "\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost:9093/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Drule+uid&matcher=lbl1%3Dval1\nDashboard: http://localhost:9093/d/abcd\nPanel: http://localhost:9093/d/abcd?viewPanel=efgh\n",
+					Scope: alertsScope,
+				}},
+				Errors: nil,
+			},
 		},
-	},
+		{
+			name: "template scoped to .Alert",
+			input: TestTemplatesConfigBodyParams{
+				Alerts: []*amv2.PostableAlert{&simpleAlert},
+				Name:   "alerts.custom.single",
+				Template: `{{ define "alerts.custom.single" }}
+Labels:
+{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Annotations:
+{{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}{{ if gt (len .GeneratorURL) 0 }}Source: {{ .GeneratorURL }}
+{{ end }}{{ if gt (len .SilenceURL) 0 }}Silence: {{ .SilenceURL }}
+{{ end }}{{ if gt (len .DashboardURL) 0 }}Dashboard: {{ .DashboardURL }}
+{{ end }}{{ if gt (len .PanelURL) 0 }}Panel: {{ .PanelURL }}
+{{ end }}{{ end }}`,
+			},
+			expected: TestTemplatesResults{
+				Results: []TestTemplatesResult{{
+					Name:  "alerts.custom.single",
+					Text:  "\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost:9093/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Drule+uid&matcher=lbl1%3Dval1\nDashboard: http://localhost:9093/d/abcd\nPanel: http://localhost:9093/d/abcd?viewPanel=efgh\n",
+					Scope: alertScope,
+				}},
+				Errors: nil,
+			},
+		},
+		{
+			name: "failing scope",
+			input: TestTemplatesConfigBodyParams{
+				Alerts:   []*amv2.PostableAlert{&simpleAlert},
+				Name:     "alerts.custom.failing",
+				Template: `{{ define "alerts.custom.failing" }}{{ .DOESNOTEXIST }} {{ end }}`,
+			},
+			expected: TestTemplatesResults{
+				Results: nil,
+				Errors: []TestTemplatesErrorResult{{
+					Name:  "alerts.custom.failing",
+					Kind:  ExecutionError,
+					Error: `template: :1:39: executing "alerts.custom.failing" at <.DOESNOTEXIST>: can't evaluate field DOESNOTEXIST in type *templates.ExtendedData`,
+				}},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Template testing currently tests all definitions using the `ExtendedData` as the scope (`.`). However, some template definitions may be intended to be used with other scopes, such as `.Alerts` or a single `ExtendedAlert`. 

This limitation is somewhat mitigated by the fact that we restrict which definitions within a template are returned as results during testing. We only return "top-level" definitions, i.e. definitions that aren't reference by other definitions in the template, and definitions meant for non-root scopes are *usually* not top-level.

One clear counter-example is the `pagerduty.default.instances` default definition. Which is both top-level and meant to be used with the `.Alerts` scope. This causes a persistent error to display when preview the default definitions:

![image](https://github.com/user-attachments/assets/26ff90b7-c7d6-4f3c-bf9c-eee7d81e30f6)

This leaves us with a few options:

1. Ask for intended scope when testing templates.
2. Analyze the definition to attempt to determine which scope it's intended for.
3. Attempt a pre-determined set of more specific scope if the root scope fails.

Thoughts:

1. Is tempting but is a larger change that has rippling effects on the Template model and UI/UX. In the future though, if we end up separating the `Template` model to be more granular in k8s API, this could become an good option.
2. This is likely a rabbit-hole of brittleness.
3. Fairly safe incremental improvement that, while not covering all possible scopes, is extensible and simple. Performance will be slower but the endpoint is not high volume and the performance impact only effects failing templates.

This PR implements 3.

Additional Scopes:
- `.Alerts`
- `.Alert` (aka .Alerts[0])



