### PR TITLE
Alerting: Update slack image upload to use new API

### DIFF
--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,7 +57,7 @@ var (
 	}
 )
 
-type sendMessageFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (string, error)
+type sendMessageFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (slackMessageResponse, error)
 
 type initFileUploadFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (*FileUploadURLResponse, error)
 
@@ -180,7 +181,7 @@ func (sn *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 		return false, fmt.Errorf("failed to create Slack message: %w", err)
 	}
 
-	threadTs, err := sn.sendSlackMessage(ctx, m)
+	slackResp, err := sn.sendSlackMessage(ctx, m)
 	if err != nil {
 		sn.log.Error("Failed to send Slack message", "err", err)
 		return false, fmt.Errorf("failed to send Slack message: %w", err)
@@ -195,14 +196,21 @@ func (sn *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 				if _, err := sn.sendSlackMessage(ctx, &slackMessage{
 					Channel:  sn.settings.Recipient,
 					Text:     maxImagesPerThreadTsMessage,
-					ThreadTs: threadTs,
+					ThreadTs: slackResp.Ts,
 				}); err != nil {
 					sn.log.Error("Failed to send Slack message", "err", err)
 				}
 				return images.ErrImagesDone
 			}
 			comment := initialCommentForImage(alerts[index])
-			return sn.uploadImage(ctx, image, sn.settings.Recipient, comment, threadTs)
+			// settings.Recipient can be either a channel name or ID. However, file upload v2 requires channel ID only.
+			// chat.postMessage API returns channel ID in slackResp.Channel, so we use it when it exists as a more
+			// reliable source of the channel ID.
+			channelID := sn.settings.Recipient
+			if slackResp.Channel != "" {
+				channelID = slackResp.Channel
+			}
+			return sn.uploadImage(ctx, image, channelID, comment, slackResp.Ts)
 		}, alerts...); err != nil {
 			// Do not return an error here as we might have exceeded the rate limit for uploading files
 			sn.log.Error("Failed to upload image", "err", err)
@@ -317,16 +325,16 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 	return req, nil
 }
 
-func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (string, error) {
+func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (slackMessageResponse, error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal Slack message: %w", err)
+		return slackMessageResponse{}, fmt.Errorf("failed to marshal Slack message: %w", err)
 	}
 
 	sn.log.Debug("sending Slack API request", "url", sn.settings.URL, "data", string(b))
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, sn.settings.URL, bytes.NewReader(b))
 	if err != nil {
-		return "", fmt.Errorf("failed to create HTTP request: %w", err)
+		return slackMessageResponse{}, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
 	request.Header.Set("Content-Type", "application/json")
@@ -341,12 +349,12 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (stri
 		request.Header.Set("Authorization", "Bearer "+sn.settings.Token)
 	}
 
-	threadTs, err := sn.sendMessageFn(ctx, request, sn.log)
+	slackResp, err := sn.sendMessageFn(ctx, request, sn.log)
 	if err != nil {
-		return "", err
+		return slackMessageResponse{}, err
 	}
 
-	return threadTs, nil
+	return slackResp, nil
 }
 
 // createImageMultipart returns the multipart/form-data request and headers for the url from getUploadURL
@@ -408,7 +416,7 @@ func (sn *Notifier) sendMultipart(ctx context.Context, uploadURL string, headers
 // uploadImage shares the image to the channel names or IDs. It returns an error if the file
 // does not exist, or if there was an error either preparing or sending the multipart/form-data
 // request.
-func (sn *Notifier) uploadImage(ctx context.Context, image images.Image, channel, comment, threadTs string) error {
+func (sn *Notifier) uploadImage(ctx context.Context, image images.Image, channelID, comment, threadTs string) error {
 	sn.log.Debug("Uploading image", "image", image.Token)
 
 	imageData, err := os.Stat(image.Path)
@@ -434,7 +442,7 @@ func (sn *Notifier) uploadImage(ctx context.Context, image images.Image, channel
 	}
 	// complete file upload to upload the image to the channel/thread with the comment
 	// need to use uploadURLResponse.FileID to complete the upload
-	return sn.finalizeUpload(ctx, uploadURLResponse.FileID, channel, threadTs, comment)
+	return sn.finalizeUpload(ctx, uploadURLResponse.FileID, channelID, threadTs, comment)
 }
 
 // getUploadURL returns the URL to upload the image to. It returns an error if the image cannot be uploaded.
@@ -459,7 +467,7 @@ func (sn *Notifier) getUploadURL(ctx context.Context, filename string, imageSize
 	return sn.initFileUploadFn(ctx, req, sn.log)
 }
 
-func (sn *Notifier) finalizeUpload(ctx context.Context, fileID, channel, threadTs, comment string) error {
+func (sn *Notifier) finalizeUpload(ctx context.Context, fileID, channelID, threadTs, comment string) error {
 	completeUploadEndpoint, err := endpointURL(sn.settings, "files.completeUploadExternal")
 	if err != nil {
 		return fmt.Errorf("failed to get URL for files.completeUploadExternal: %w", err)
@@ -471,7 +479,7 @@ func (sn *Notifier) finalizeUpload(ctx context.Context, fileID, channel, threadT
 		}{
 			{ID: fileID},
 		},
-		ChannelID:      channel,
+		ChannelID:      channelID,
 		ThreadTs:       threadTs,
 		InitialComment: comment,
 	}
@@ -513,16 +521,15 @@ func initialCommentForImage(alert *types.Alert) string {
 	sb.WriteString(", ")
 
 	sb.WriteString("*Labels*: ")
-
-	var n int
-	for k, v := range alert.Labels {
-		sb.WriteString(string(k))
-		sb.WriteString(" = ")
-		sb.WriteString(string(v))
-		if n < len(alert.Labels)-1 {
-			sb.WriteString(", ")
-			n++
+	if len(alert.Labels) == 0 {
+		sb.WriteString("None")
+	} else {
+		lstrs := make([]string, 0, len(alert.Labels))
+		for l, v := range alert.Labels {
+			lstrs = append(lstrs, fmt.Sprintf("%s=%s", l, v))
 		}
+		sort.Strings(lstrs)
+		sb.WriteString(strings.Join(lstrs, ", "))
 	}
 
 	return sb.String()
@@ -544,10 +551,10 @@ func errorForStatusCode(logger logging.Logger, statusCode int) error {
 
 // sendSlackMessage sends a request to the Slack API.
 // Stubbable by tests.
-func sendSlackMessage(_ context.Context, req *http.Request, logger logging.Logger) (string, error) {
+func sendSlackMessage(_ context.Context, req *http.Request, logger logging.Logger) (slackMessageResponse, error) {
 	resp, err := slackClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to send request: %w", err)
+		return slackMessageResponse{}, fmt.Errorf("failed to send request: %w", err)
 	}
 
 	defer func() {
@@ -557,7 +564,7 @@ func sendSlackMessage(_ context.Context, req *http.Request, logger logging.Logge
 	}()
 
 	if err := errorForStatusCode(logger, resp.StatusCode); err != nil {
-		return "", err
+		return slackMessageResponse{}, err
 	}
 
 	content := resp.Header.Get("Content-Type")
@@ -565,19 +572,19 @@ func sendSlackMessage(_ context.Context, req *http.Request, logger logging.Logge
 		return handleSlackMessageJSONResponse(resp, logger)
 	}
 	// If the response is not JSON it could be the response to an incoming webhook
-	return handleSlackIncomingWebhookResponse(resp, logger)
+	return slackMessageResponse{}, handleSlackIncomingWebhookResponse(resp, logger)
 }
 
-func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logger) (string, error) {
+func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logger) error {
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return fmt.Errorf("failed to read response: %w", err)
 	}
 
 	// Incoming webhooks return the string "ok" on success
 	if bytes.Equal(b, []byte("ok")) {
 		logger.Debug("The incoming webhook was successful")
-		return "", nil
+		return nil
 	}
 
 	logger.Debug("Incoming webhook was unsuccessful", "status", resp.StatusCode, "body", string(b))
@@ -586,41 +593,41 @@ func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logg
 	// errors can be found at https://api.slack.com/messaging/webhooks#handling_errors and
 	// https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks
 	if bytes.Equal(b, []byte("user_not_found")) {
-		return "", errors.New("the user does not exist or is invalid")
+		return errors.New("the user does not exist or is invalid")
 	}
 
 	if bytes.Equal(b, []byte("channel_not_found")) {
-		return "", errors.New("the channel does not exist or is invalid")
+		return errors.New("the channel does not exist or is invalid")
 	}
 
 	if bytes.Equal(b, []byte("channel_is_archived")) {
-		return "", errors.New("cannot send an incoming webhook for an archived channel")
+		return errors.New("cannot send an incoming webhook for an archived channel")
 	}
 
 	if bytes.Equal(b, []byte("posting_to_general_channel_denied")) {
-		return "", errors.New("cannot send an incoming webhook to the #general channel")
+		return errors.New("cannot send an incoming webhook to the #general channel")
 	}
 
 	if bytes.Equal(b, []byte("no_service")) {
-		return "", errors.New("the incoming webhook is either disabled, removed, or invalid")
+		return errors.New("the incoming webhook is either disabled, removed, or invalid")
 	}
 
 	if bytes.Equal(b, []byte("no_text")) {
-		return "", errors.New("cannot send an incoming webhook without a message")
+		return errors.New("cannot send an incoming webhook without a message")
 	}
 
-	return "", fmt.Errorf("failed incoming webhook: %s", string(b))
+	return fmt.Errorf("failed incoming webhook: %s", string(b))
 }
 
-func handleSlackMessageJSONResponse(resp *http.Response, logger logging.Logger) (string, error) {
+func handleSlackMessageJSONResponse(resp *http.Response, logger logging.Logger) (slackMessageResponse, error) {
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return slackMessageResponse{}, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	if len(b) == 0 {
 		logger.Error("Expected JSON but got empty response")
-		return "", errors.New("unexpected empty response")
+		return slackMessageResponse{}, errors.New("unexpected empty response")
 	}
 
 	// Slack responds to some requests with a JSON document, that might contain an error.
@@ -631,16 +638,16 @@ func handleSlackMessageJSONResponse(resp *http.Response, logger logging.Logger) 
 
 	if err := json.Unmarshal(b, &result); err != nil {
 		logger.Error("Failed to unmarshal response", "body", string(b), "err", err)
-		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+		return slackMessageResponse{}, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
 	if !result.OK {
 		logger.Error("The request was unsuccessful", "body", string(b), "err", result.Error)
-		return "", fmt.Errorf("failed to send request: %s", result.Error)
+		return slackMessageResponse{}, fmt.Errorf("failed to send request: %s", result.Error)
 	}
 
 	logger.Debug("The request was successful")
-	return result.Ts, nil
+	return result.slackMessageResponse, nil
 }
 
 func initFileUpload(_ context.Context, req *http.Request, logger logging.Logger) (*FileUploadURLResponse, error) {

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -31,7 +31,7 @@ import (
 const (
 	// maxImagesPerThreadTs is the maximum number of images that can be posted as
 	// replies to the same thread_ts. It should prevent tokens from exceeding the
-	// rate limits for files.upload https://api.slack.com/docs/rate-limits#tier_t2
+	// rate limits for uploads https://api.slack.com/docs/rate-limits#tier_t2
 	maxImagesPerThreadTs        = 5
 	maxImagesPerThreadTsMessage = "There are more images than can be shown here. To see the panels for all firing and resolved alerts please check Grafana"
 	footerIconURL               = "https://grafana.com/static/assets/img/fav32.png"
@@ -56,7 +56,13 @@ var (
 	}
 )
 
-type sendFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (string, error)
+type sendMessageFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (string, error)
+
+type initFileUploadFunc func(ctx context.Context, req *http.Request, logger logging.Logger) (*FileUploadURLResponse, error)
+
+type uploadFileFunc func(ctx context.Context, req *http.Request, logger logging.Logger) error
+
+type completeFileUploadFunc func(ctx context.Context, req *http.Request, logger logging.Logger) error
 
 // https://api.slack.com/reference/messaging/attachments#legacy_fields - 1024, no units given, assuming runes or characters.
 const slackMaxTitleLenRunes = 1024
@@ -65,13 +71,16 @@ const slackMaxTitleLenRunes = 1024
 // alert notification to Slack.
 type Notifier struct {
 	*receivers.Base
-	log           logging.Logger
-	tmpl          *templates.Template
-	images        images.Provider
-	webhookSender receivers.WebhookSender
-	sendFn        sendFunc
-	settings      Config
-	appVersion    string
+	log                  logging.Logger
+	tmpl                 *templates.Template
+	images               images.Provider
+	webhookSender        receivers.WebhookSender
+	sendMessageFn        sendMessageFunc
+	initFileUploadFn     initFileUploadFunc
+	uploadFileFn         uploadFileFunc
+	completeFileUploadFn completeFileUploadFunc
+	settings             Config
+	appVersion           string
 }
 
 // isIncomingWebhook returns true if the settings are for an incoming webhook.
@@ -79,28 +88,30 @@ func isIncomingWebhook(s Config) bool {
 	return s.Token == ""
 }
 
-// uploadURL returns the upload URL for Slack.
-func uploadURL(s Config) (string, error) {
+// endpointURL returns the combined URL for the endpoint based on the config and apiMethod
+func endpointURL(s Config, apiMethod string) (string, error) {
 	u, err := url.Parse(s.URL)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse URL: %w", err)
 	}
 	dir, _ := path.Split(u.Path)
-	u.Path = path.Join(dir, "files.upload")
+	u.Path = path.Join(dir, apiMethod)
 	return u.String(), nil
 }
 
 func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, images images.Provider, logger logging.Logger, appVersion string) *Notifier {
 	return &Notifier{
-		Base:     receivers.NewBase(meta),
-		settings: cfg,
-
-		images:        images,
-		webhookSender: sender,
-		sendFn:        sendSlackRequest,
-		log:           logger,
-		tmpl:          template,
-		appVersion:    appVersion,
+		Base:                 receivers.NewBase(meta),
+		settings:             cfg,
+		images:               images,
+		webhookSender:        sender,
+		sendMessageFn:        sendSlackMessage,
+		initFileUploadFn:     initFileUpload,
+		uploadFileFn:         uploadFile,
+		completeFileUploadFn: completeFileUpload,
+		log:                  logger,
+		tmpl:                 template,
+		appVersion:           appVersion,
 	}
 }
 
@@ -130,6 +141,33 @@ type attachment struct {
 	Ts         int64                 `json:"ts,omitempty"`
 	Pretext    string                `json:"pretext,omitempty"`
 	MrkdwnIn   []string              `json:"mrkdwn_in,omitempty"`
+}
+
+// generic api response from slack
+type CommonAPIResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// the response from the slack API when sending a message (i.e. chat.postMessage)
+type slackMessageResponse struct {
+	Ts      string `json:"ts"`
+	Channel string `json:"channel"`
+}
+
+// the response to get the URL to upload a file to (files.getUploadURLExternal)
+type FileUploadURLResponse struct {
+	UploadURL string `json:"upload_url"`
+	FileID    string `json:"file_id"`
+}
+
+type CompleteFileUploadRequest struct {
+	Files []struct {
+		ID string `json:"id"`
+	} `json:"files"`
+	ChannelID      string `json:"channel_id"`
+	ThreadTs       string `json:"thread_ts"`
+	InitialComment string `json:"initial_comment"`
 }
 
 // Notify sends an alert notification to Slack.
@@ -172,115 +210,6 @@ func (sn *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 	}
 
 	return true, nil
-}
-
-// sendSlackRequest sends a request to the Slack API.
-// Stubbable by tests.
-var sendSlackRequest = func(ctx context.Context, req *http.Request, logger logging.Logger) (string, error) {
-	resp, err := slackClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to send request: %w", err)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Warn("Failed to close response body", "err", err)
-		}
-	}()
-
-	if resp.StatusCode < http.StatusOK {
-		logger.Error("Unexpected 1xx response", "status", resp.StatusCode)
-		return "", fmt.Errorf("unexpected 1xx status code: %d", resp.StatusCode)
-	} else if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-		logger.Error("Unexpected 3xx response", "status", resp.StatusCode)
-		return "", fmt.Errorf("unexpected 3xx status code: %d", resp.StatusCode)
-	} else if resp.StatusCode >= http.StatusInternalServerError {
-		logger.Error("Unexpected 5xx response", "status", resp.StatusCode)
-		return "", fmt.Errorf("unexpected 5xx status code: %d", resp.StatusCode)
-	}
-
-	content := resp.Header.Get("Content-Type")
-	if strings.HasPrefix(content, "application/json") {
-		return handleSlackJSONResponse(resp, logger)
-	}
-	// If the response is not JSON it could be the response to an incoming webhook
-	return handleSlackIncomingWebhookResponse(resp, logger)
-}
-
-func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logger) (string, error) {
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Incoming webhooks return the string "ok" on success
-	if bytes.Equal(b, []byte("ok")) {
-		logger.Debug("The incoming webhook was successful")
-		return "", nil
-	}
-
-	logger.Debug("Incoming webhook was unsuccessful", "status", resp.StatusCode, "body", string(b))
-
-	// There are a number of known errors that we can check. The documentation incoming webhooks
-	// errors can be found at https://api.slack.com/messaging/webhooks#handling_errors and
-	// https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks
-	if bytes.Equal(b, []byte("user_not_found")) {
-		return "", errors.New("the user does not exist or is invalid")
-	}
-
-	if bytes.Equal(b, []byte("channel_not_found")) {
-		return "", errors.New("the channel does not exist or is invalid")
-	}
-
-	if bytes.Equal(b, []byte("channel_is_archived")) {
-		return "", errors.New("cannot send an incoming webhook for an archived channel")
-	}
-
-	if bytes.Equal(b, []byte("posting_to_general_channel_denied")) {
-		return "", errors.New("cannot send an incoming webhook to the #general channel")
-	}
-
-	if bytes.Equal(b, []byte("no_service")) {
-		return "", errors.New("the incoming webhook is either disabled, removed, or invalid")
-	}
-
-	if bytes.Equal(b, []byte("no_text")) {
-		return "", errors.New("cannot send an incoming webhook without a message")
-	}
-
-	return "", fmt.Errorf("failed incoming webhook: %s", string(b))
-}
-
-func handleSlackJSONResponse(resp *http.Response, logger logging.Logger) (string, error) {
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if len(b) == 0 {
-		logger.Error("Expected JSON but got empty response")
-		return "", errors.New("unexpected empty response")
-	}
-
-	// Slack responds to some requests with a JSON document, that might contain an error.
-	result := struct {
-		OK  bool   `json:"ok"`
-		Ts  string `json:"ts"`
-		Err string `json:"error"`
-	}{}
-
-	if err := json.Unmarshal(b, &result); err != nil {
-		logger.Error("Failed to unmarshal response", "body", string(b), "err", err)
-		return "", fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	if !result.OK {
-		logger.Error("The request was unsuccessful", "body", string(b), "err", result.Err)
-		return "", fmt.Errorf("failed to send request: %s", result.Err)
-	}
-
-	logger.Debug("The request was successful")
-	return result.Ts, nil
 }
 
 func (sn *Notifier) commonAlertGeneratorURL(_ context.Context, alerts []*types.Alert) bool {
@@ -412,7 +341,7 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (stri
 		request.Header.Set("Authorization", "Bearer "+sn.settings.Token)
 	}
 
-	threadTs, err := sn.sendFn(ctx, request, sn.log)
+	threadTs, err := sn.sendMessageFn(ctx, request, sn.log)
 	if err != nil {
 		return "", err
 	}
@@ -420,10 +349,10 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (stri
 	return threadTs, nil
 }
 
-// createImageMultipart returns the mutlipart/form-data request and headers for files.upload.
+// createImageMultipart returns the multipart/form-data request and headers for the url from getUploadURL
 // It returns an error if the image does not exist or there was an error preparing the
 // multipart form.
-func (sn *Notifier) createImageMultipart(image images.Image, channel, comment, threadTs string) (http.Header, []byte, error) {
+func (sn *Notifier) createImageMultipart(image images.Image) (http.Header, []byte, error) {
 	buf := bytes.Buffer{}
 	w := multipart.NewWriter(&buf)
 	defer func() {
@@ -442,25 +371,13 @@ func (sn *Notifier) createImageMultipart(image images.Image, channel, comment, t
 		}
 	}()
 
-	fw, err := w.CreateFormFile("file", image.Path)
+	fw, err := w.CreateFormFile("filename", image.Path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create form file: %w", err)
 	}
 
 	if _, err := io.Copy(fw, f); err != nil {
 		return nil, nil, fmt.Errorf("failed to copy file to form: %w", err)
-	}
-
-	if err := w.WriteField("channels", channel); err != nil {
-		return nil, nil, fmt.Errorf("failed to write channels to form: %w", err)
-	}
-
-	if err := w.WriteField("initial_comment", comment); err != nil {
-		return nil, nil, fmt.Errorf("failed to write initial_comment to form: %w", err)
-	}
-
-	if err := w.WriteField("thread_ts", threadTs); err != nil {
-		return nil, nil, fmt.Errorf("failed to write thread_ts to form: %w", err)
 	}
 
 	if err := w.Close(); err != nil {
@@ -473,15 +390,10 @@ func (sn *Notifier) createImageMultipart(image images.Image, channel, comment, t
 	return headers, b, nil
 }
 
-func (sn *Notifier) sendMultipart(ctx context.Context, headers http.Header, data io.Reader) error {
-	sn.log.Debug("Sending multipart request to files.upload")
+func (sn *Notifier) sendMultipart(ctx context.Context, uploadURL string, headers http.Header, data io.Reader) error {
+	sn.log.Debug("Sending multipart request", "url", uploadURL)
 
-	u, err := uploadURL(sn.settings)
-	if err != nil {
-		return fmt.Errorf("failed to get URL for files.upload: %w", err)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, u, data)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, data)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -490,24 +402,90 @@ func (sn *Notifier) sendMultipart(ctx context.Context, headers http.Header, data
 	}
 	req.Header.Set("Authorization", "Bearer "+sn.settings.Token)
 
-	if _, err := sn.sendFn(ctx, req, sn.log); err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-
-	return nil
+	return sn.uploadFileFn(ctx, req, sn.log)
 }
 
 // uploadImage shares the image to the channel names or IDs. It returns an error if the file
 // does not exist, or if there was an error either preparing or sending the multipart/form-data
 // request.
 func (sn *Notifier) uploadImage(ctx context.Context, image images.Image, channel, comment, threadTs string) error {
-	sn.log.Debug("Uploadimg image", "image", image.Token)
-	headers, data, err := sn.createImageMultipart(image, channel, comment, threadTs)
+	sn.log.Debug("Uploading image", "image", image.Token)
+
+	imageData, err := os.Stat(image.Path)
+	if err != nil {
+		return fmt.Errorf("failed to get image info: %w", err)
+	}
+
+	// get the upload url
+	uploadURLResponse, err := sn.getUploadURL(ctx, image.Path, imageData.Size())
+	if err != nil {
+		return fmt.Errorf("failed to get upload URL: %w", err)
+	}
+
+	// upload the image
+	headers, data, err := sn.createImageMultipart(image)
 	if err != nil {
 		return fmt.Errorf("failed to create multipart form: %w", err)
 	}
 
-	return sn.sendMultipart(ctx, headers, bytes.NewReader(data))
+	uploadErr := sn.sendMultipart(ctx, uploadURLResponse.UploadURL, headers, bytes.NewReader(data))
+	if uploadErr != nil {
+		return fmt.Errorf("failed to upload image: %w", uploadErr)
+	}
+	// complete file upload to upload the image to the channel/thread with the comment
+	// need to use uploadURLResponse.FileID to complete the upload
+	return sn.finalizeUpload(ctx, uploadURLResponse.FileID, channel, threadTs, comment)
+}
+
+// getUploadURL returns the URL to upload the image to. It returns an error if the image cannot be uploaded.
+func (sn *Notifier) getUploadURL(ctx context.Context, filename string, imageSize int64) (*FileUploadURLResponse, error) {
+	apiEndpoint, err := endpointURL(sn.settings, "files.getUploadURLExternal")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get URL for files.getUploadURLExternal: %w", err)
+	}
+
+	data := url.Values{}
+	data.Set("filename", filename)
+	data.Set("length", fmt.Sprintf("%d", imageSize))
+
+	url := fmt.Sprintf("%s?%s", apiEndpoint, data.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+sn.settings.Token)
+	return sn.initFileUploadFn(ctx, req, sn.log)
+}
+
+func (sn *Notifier) finalizeUpload(ctx context.Context, fileID, channel, threadTs, comment string) error {
+	completeUploadEndpoint, err := endpointURL(sn.settings, "files.completeUploadExternal")
+	if err != nil {
+		return fmt.Errorf("failed to get URL for files.completeUploadExternal: %w", err)
+	}
+	// make json request to complete the upload
+	body := CompleteFileUploadRequest{
+		Files: []struct {
+			ID string `json:"id"`
+		}{
+			{ID: fileID},
+		},
+		ChannelID:      channel,
+		ThreadTs:       threadTs,
+		InitialComment: comment,
+	}
+	completeUploadData, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal complete upload request: %w", err)
+	}
+	completeUploadReq, err := http.NewRequestWithContext(ctx, http.MethodPost, completeUploadEndpoint, bytes.NewReader(completeUploadData))
+	if err != nil {
+		return fmt.Errorf("failed to create complete upload request: %w", err)
+	}
+	completeUploadReq.Header.Set("Content-Type", "application/json; charset=utf-8")
+	completeUploadReq.Header.Set("Authorization", "Bearer "+sn.settings.Token)
+	return sn.completeFileUploadFn(ctx, completeUploadReq, sn.log)
 }
 
 func (sn *Notifier) SendResolved() bool {
@@ -548,4 +526,226 @@ func initialCommentForImage(alert *types.Alert) string {
 	}
 
 	return sb.String()
+}
+
+func errorForStatusCode(logger logging.Logger, statusCode int) error {
+	if statusCode < http.StatusOK {
+		logger.Error("Unexpected 1xx response", "status", statusCode)
+		return fmt.Errorf("unexpected 1xx status code: %d", statusCode)
+	} else if statusCode >= 300 && statusCode < 400 {
+		logger.Error("Unexpected 3xx response", "status", statusCode)
+		return fmt.Errorf("unexpected 3xx status code: %d", statusCode)
+	} else if statusCode >= http.StatusInternalServerError {
+		logger.Error("Unexpected 5xx response", "status", statusCode)
+		return fmt.Errorf("unexpected 5xx status code: %d", statusCode)
+	}
+	return nil
+}
+
+// sendSlackMessage sends a request to the Slack API.
+// Stubbable by tests.
+func sendSlackMessage(_ context.Context, req *http.Request, logger logging.Logger) (string, error) {
+	resp, err := slackClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
+	if err := errorForStatusCode(logger, resp.StatusCode); err != nil {
+		return "", err
+	}
+
+	content := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(content, "application/json") {
+		return handleSlackMessageJSONResponse(resp, logger)
+	}
+	// If the response is not JSON it could be the response to an incoming webhook
+	return handleSlackIncomingWebhookResponse(resp, logger)
+}
+
+func handleSlackIncomingWebhookResponse(resp *http.Response, logger logging.Logger) (string, error) {
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Incoming webhooks return the string "ok" on success
+	if bytes.Equal(b, []byte("ok")) {
+		logger.Debug("The incoming webhook was successful")
+		return "", nil
+	}
+
+	logger.Debug("Incoming webhook was unsuccessful", "status", resp.StatusCode, "body", string(b))
+
+	// There are a number of known errors that we can check. The documentation incoming webhooks
+	// errors can be found at https://api.slack.com/messaging/webhooks#handling_errors and
+	// https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks
+	if bytes.Equal(b, []byte("user_not_found")) {
+		return "", errors.New("the user does not exist or is invalid")
+	}
+
+	if bytes.Equal(b, []byte("channel_not_found")) {
+		return "", errors.New("the channel does not exist or is invalid")
+	}
+
+	if bytes.Equal(b, []byte("channel_is_archived")) {
+		return "", errors.New("cannot send an incoming webhook for an archived channel")
+	}
+
+	if bytes.Equal(b, []byte("posting_to_general_channel_denied")) {
+		return "", errors.New("cannot send an incoming webhook to the #general channel")
+	}
+
+	if bytes.Equal(b, []byte("no_service")) {
+		return "", errors.New("the incoming webhook is either disabled, removed, or invalid")
+	}
+
+	if bytes.Equal(b, []byte("no_text")) {
+		return "", errors.New("cannot send an incoming webhook without a message")
+	}
+
+	return "", fmt.Errorf("failed incoming webhook: %s", string(b))
+}
+
+func handleSlackMessageJSONResponse(resp *http.Response, logger logging.Logger) (string, error) {
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if len(b) == 0 {
+		logger.Error("Expected JSON but got empty response")
+		return "", errors.New("unexpected empty response")
+	}
+
+	// Slack responds to some requests with a JSON document, that might contain an error.
+	result := struct {
+		CommonAPIResponse
+		slackMessageResponse
+	}{}
+
+	if err := json.Unmarshal(b, &result); err != nil {
+		logger.Error("Failed to unmarshal response", "body", string(b), "err", err)
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if !result.OK {
+		logger.Error("The request was unsuccessful", "body", string(b), "err", result.Error)
+		return "", fmt.Errorf("failed to send request: %s", result.Error)
+	}
+
+	logger.Debug("The request was successful")
+	return result.Ts, nil
+}
+
+func initFileUpload(_ context.Context, req *http.Request, logger logging.Logger) (*FileUploadURLResponse, error) {
+	resp, err := slackClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
+	if err := errorForStatusCode(logger, resp.StatusCode); err != nil {
+		return nil, err
+	}
+
+	content := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(content, "application/json") {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		if len(b) == 0 {
+			logger.Error("Expected JSON but got empty response")
+			return nil, errors.New("unexpected empty response")
+		}
+
+		// Slack responds to some requests with a JSON document, that might contain an error.
+		result := struct {
+			CommonAPIResponse
+			FileUploadURLResponse
+		}{}
+
+		if err := json.Unmarshal(b, &result); err != nil {
+			logger.Error("Failed to unmarshal response", "body", string(b), "err", err)
+			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+
+		if !result.OK {
+			logger.Error("The request was unsuccessful", "body", string(b), "err", result.Error)
+			return nil, fmt.Errorf("failed to send request: %s", result.Error)
+		}
+
+		logger.Debug("The request was successful")
+		return &result.FileUploadURLResponse, nil
+	}
+
+	return nil, fmt.Errorf("unexpected content type: %s", content)
+}
+
+func uploadFile(_ context.Context, req *http.Request, logger logging.Logger) error {
+	resp, err := slackClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	// no need to check body, just check the status code
+	return errorForStatusCode(logger, resp.StatusCode)
+}
+
+func completeFileUpload(_ context.Context, req *http.Request, logger logging.Logger) error {
+	resp, err := slackClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
+	if err := errorForStatusCode(logger, resp.StatusCode); err != nil {
+		return err
+	}
+	content := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(content, "application/json") {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+
+		if len(b) == 0 {
+			logger.Error("Expected JSON but got empty response")
+			return errors.New("unexpected empty response")
+		}
+
+		// Slack responds to some requests with a JSON document, that might contain an error.
+		result := CommonAPIResponse{}
+
+		if err := json.Unmarshal(b, &result); err != nil {
+			logger.Error("Failed to unmarshal response", "body", string(b), "err", err)
+			return fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+
+		if !result.OK {
+			logger.Error("The request was unsuccessful", "body", string(b), "err", result.Error)
+			return fmt.Errorf("failed to send request: %s", result.Error)
+		}
+
+		logger.Debug("The request was successful")
+		return nil
+	}
+
+	return fmt.Errorf("unexpected content type: %s", content)
 }

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -252,6 +252,10 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 		}
 		sn.log.Warn("Truncated title", "key", key, "max_runes", slackMaxTitleLenRunes)
 	}
+	if tmplErr != nil {
+		sn.log.Warn("failed to template Slack title", "error", tmplErr.Error())
+		tmplErr = nil
+	}
 
 	req := &slackMessage{
 		Channel:   tmpl(sn.settings.Recipient),
@@ -337,7 +341,7 @@ func (sn *Notifier) sendSlackMessage(ctx context.Context, m *slackMessage) (slac
 		return slackMessageResponse{}, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Type", "application/json; charset=utf-8")
 	request.Header.Set("User-Agent", "Grafana")
 	if sn.settings.Token == "" {
 		if sn.settings.URL == APIURL {

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -13,11 +13,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
@@ -174,10 +175,10 @@ func TestNotify_IncomingWebhook(t *testing.T) {
 				// When sending a notification to an Incoming Webhook there should a single request.
 				// This is different from PostMessage where some content, such as images, are sent
 				// as replies to the original message
-				require.Len(t, recorder.requests, 1)
+				require.Equal(t, recorder.requestCount, 1)
 
 				// Get the request and check that it's sending to the URL of the Incoming Webhook
-				r := recorder.requests[0]
+				r := recorder.messageRequest
 				assert.Equal(t, notifier.settings.URL, r.URL.String())
 
 				// Check that the request contains the expected message
@@ -515,10 +516,10 @@ func TestNotify_PostMessage(t *testing.T) {
 				assert.NoError(t, err)
 				assert.True(t, ok)
 
-				require.Len(t, recorder.requests, 1)
+				require.Equal(t, recorder.requestCount, 1)
 
 				// Get the request and check that it's sending to the URL
-				r := recorder.requests[0]
+				r := recorder.messageRequest
 				assert.Equal(t, notifier.settings.URL, r.URL.String())
 
 				// Check that the request contains the expected message
@@ -542,7 +543,7 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 		name                 string
 		alerts               []*types.Alert
 		expectedMessage      *slackMessage
-		expectedImageUploads int
+		expectedImageUploads []CompleteFileUploadRequest
 		expectedError        string
 		settings             Config
 	}{
@@ -585,7 +586,18 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 					},
 				},
 			},
-			expectedImageUploads: 1,
+			expectedImageUploads: []CompleteFileUploadRequest{
+				{
+					Files: []struct {
+						ID string `json:"id"`
+					}{
+						{ID: "file-id"},
+					},
+					ChannelID:      "C123ABC456",
+					ThreadTs:       "1503435956.000247",
+					InitialComment: "*Firing*: alert1, *Labels*: alertname=alert1, lbl1=val1",
+				},
+			},
 		},
 	}
 
@@ -608,11 +620,11 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 
 				// When sending a notification via PostMessage some content, such as images,
 				// are sent as replies to the original message
-				imageUploadRequestCount := test.expectedImageUploads * 3
-				require.Len(t, recorder.requests, 1+imageUploadRequestCount)
+				imageUploadRequestCount := len(test.expectedImageUploads) * 3
+				require.Equal(t, recorder.requestCount, 1+imageUploadRequestCount)
 
 				// Get the request and check that it's sending to the URL
-				r := recorder.requests[0]
+				r := recorder.messageRequest
 				assert.Equal(t, notifier.settings.URL, r.URL.String())
 
 				// Check that the request contains the expected message
@@ -629,9 +641,15 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 
 				tokenHeader := fmt.Sprintf("Bearer %s", test.settings.Token)
 
-				for i := 0; i < test.expectedImageUploads; i++ {
+				readBody := func(r *http.Request) []byte {
+					b, err := io.ReadAll(r.Body)
+					assert.NoError(t, err)
+					return b
+				}
+
+				for i := 0; i < len(test.expectedImageUploads); i++ {
 					// check first request is to get the upload URL
-					initRequest := recorder.requests[i*3+1]
+					initRequest := recorder.initFileUploadRequests[i]
 					assert.Equal(t, "GET", initRequest.Method)
 					pathParts := strings.Split(initRequest.URL.EscapedPath(), "/")
 					assert.Equal(t, "files.getUploadURLExternal", pathParts[len(pathParts)-1])
@@ -640,19 +658,22 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 					assert.Contains(t, initRequest.URL.Query(), "length")
 					assert.Equal(t, tokenHeader, initRequest.Header.Get("Authorization"))
 					// check second request is to upload the image
-					uploadRequest := recorder.requests[i*3+2]
+					uploadRequest := recorder.fileUploadRequests[i]
 					assert.Equal(t, "POST", uploadRequest.Method)
 					assert.NoError(t, uploadRequest.ParseMultipartForm(32<<20))
 					assert.Equal(t, "test.png", uploadRequest.MultipartForm.File["filename"][0].Filename)
 					assert.Contains(t, strings.Split(uploadRequest.Header.Get("Content-Type"), ";"), "multipart/form-data")
 					assert.Equal(t, tokenHeader, uploadRequest.Header.Get("Authorization"))
 					// check third request is to finalize the upload
-					finalizeRequest := recorder.requests[i*3+3]
+					finalizeRequest := recorder.completeFileUploads[i]
 					assert.Equal(t, "POST", finalizeRequest.Method)
 					pathParts = strings.Split(finalizeRequest.URL.EscapedPath(), "/")
 					assert.Equal(t, "files.completeUploadExternal", pathParts[len(pathParts)-1])
 					assert.Contains(t, strings.Split(finalizeRequest.Header.Get("Content-Type"), ";"), "application/json")
 					assert.Equal(t, tokenHeader, finalizeRequest.Header.Get("Authorization"))
+					var finalizeReqBody CompleteFileUploadRequest
+					assert.NoError(t, json.Unmarshal(readBody(finalizeRequest), &finalizeReqBody))
+					assert.Equal(t, test.expectedImageUploads[i], finalizeReqBody)
 				}
 			}
 		})
@@ -661,16 +682,22 @@ func TestNotify_PostMessageWithImage(t *testing.T) {
 
 // slackRequestRecorder is used in tests to record all requests.
 type slackRequestRecorder struct {
-	requests []*http.Request
+	requestCount           int
+	messageRequest         *http.Request
+	initFileUploadRequests []*http.Request
+	fileUploadRequests     []*http.Request
+	completeFileUploads    []*http.Request
 }
 
-func (s *slackRequestRecorder) recordMessageRequest(_ context.Context, r *http.Request, _ logging.Logger) (string, error) {
-	s.requests = append(s.requests, r)
-	return "", nil
+func (s *slackRequestRecorder) recordMessageRequest(_ context.Context, r *http.Request, _ logging.Logger) (slackMessageResponse, error) {
+	s.requestCount++
+	s.messageRequest = r
+	return slackMessageResponse{Ts: "1503435956.000247", Channel: "C123ABC456"}, nil
 }
 
 func (s *slackRequestRecorder) recordInitFileUploadRequest(_ context.Context, r *http.Request, _ logging.Logger) (*FileUploadURLResponse, error) {
-	s.requests = append(s.requests, r)
+	s.requestCount++
+	s.initFileUploadRequests = append(s.initFileUploadRequests, r)
 	return &FileUploadURLResponse{
 		FileID:    "file-id",
 		UploadURL: "TODO: replace this with some function that actually allows you to return something to test the flow",
@@ -678,7 +705,14 @@ func (s *slackRequestRecorder) recordInitFileUploadRequest(_ context.Context, r 
 }
 
 func (s *slackRequestRecorder) recordFileUploadRequest(_ context.Context, r *http.Request, _ logging.Logger) error {
-	s.requests = append(s.requests, r)
+	s.requestCount++
+	s.fileUploadRequests = append(s.fileUploadRequests, r)
+	return nil
+}
+
+func (s *slackRequestRecorder) recordCompleteFileUpload(_ context.Context, r *http.Request, _ logging.Logger) error {
+	s.requestCount++
+	s.completeFileUploads = append(s.completeFileUploads, r)
 	return nil
 }
 
@@ -727,7 +761,7 @@ func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequest
 	sn.sendMessageFn = sr.recordMessageRequest
 	sn.initFileUploadFn = sr.recordInitFileUploadRequest
 	sn.uploadFileFn = sr.recordFileUploadRequest
-	sn.completeFileUploadFn = sr.recordFileUploadRequest
+	sn.completeFileUploadFn = sr.recordCompleteFileUpload
 
 	return sn, sr, nil
 }

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -459,6 +459,45 @@ func TestNotify_PostMessage(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Errors in templates, message is sent",
+		settings: Config{
+			EndpointURL:    APIURL,
+			URL:            APIURL,
+			Token:          "1234",
+			Recipient:      "#test",
+			Text:           `{{ template "undefined" . }}`,
+			Title:          `{{ template "undefined" . }}`,
+			Username:       `{{ template "undefined" . }}`,
+			IconEmoji:      `{{ template "undefined" . }}`,
+			IconURL:        "",
+			MentionChannel: "",
+			MentionUsers:   nil,
+			MentionGroups:  nil,
+		},
+		alerts: []*types.Alert{{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		}},
+		expectedMessage: &slackMessage{
+			Channel:   "#test",
+			Username:  "",
+			IconEmoji: "",
+			Attachments: []attachment{
+				{
+					Title:      "",
+					TitleLink:  "http://localhost/alerting/list",
+					Text:       "",
+					Fallback:   "",
+					Fields:     nil,
+					Footer:     "Grafana v" + appVersion,
+					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
+					Color:      "#D63232",
+				},
+			},
+		},
+	}, {
 		name: "Message is sent to custom URL",
 		settings: Config{
 			EndpointURL:    "https://example.com/api",

--- a/receivers/slack/slack_test.go
+++ b/receivers/slack/slack_test.go
@@ -3,16 +3,14 @@ package slack
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
-	"mime"
-	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/alertmanager/notify"
@@ -203,7 +201,6 @@ func TestNotify_PostMessage(t *testing.T) {
 		name            string
 		alerts          []*types.Alert
 		expectedMessage *slackMessage
-		expectedReplies []interface{} // can contain either slackMessage or map[string]struct{} for multipart/form-data
 		expectedError   string
 		settings        Config
 	}{{
@@ -422,16 +419,16 @@ func TestNotify_PostMessage(t *testing.T) {
 			},
 		},
 	}, {
-		name: "Message is sent and image is uploaded",
+		name: "Errors in templates, message is sent",
 		settings: Config{
 			EndpointURL:    APIURL,
 			URL:            APIURL,
 			Token:          "1234",
 			Recipient:      "#test",
-			Text:           templates.DefaultMessageEmbed,
-			Title:          templates.DefaultMessageTitleEmbed,
-			Username:       "Grafana",
-			IconEmoji:      ":emoji:",
+			Text:           `{{ template "undefined" . }}`,
+			Title:          `{{ template "undefined" . }}`,
+			Username:       `{{ template "undefined" . }}`,
+			IconEmoji:      `{{ template "undefined" . }}`,
 			IconURL:        "",
 			MentionChannel: "",
 			MentionUsers:   nil,
@@ -440,33 +437,24 @@ func TestNotify_PostMessage(t *testing.T) {
 		alerts: []*types.Alert{{
 			Alert: model.Alert{
 				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-				Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "image-on-disk"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
 			},
 		}},
 		expectedMessage: &slackMessage{
 			Channel:   "#test",
-			Username:  "Grafana",
-			IconEmoji: ":emoji:",
+			Username:  "",
+			IconEmoji: "",
 			Attachments: []attachment{
 				{
-					Title:      "[FIRING:1]  (val1)",
+					Title:      "",
 					TitleLink:  "http://localhost/alerting/list",
-					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
-					Fallback:   "[FIRING:1]  (val1)",
+					Text:       "",
+					Fallback:   "",
 					Fields:     nil,
 					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
-			},
-		},
-		expectedReplies: []interface{}{
-			// check that the following parts are present in the multipart/form-data
-			map[string]struct{}{
-				"file":            {},
-				"channels":        {},
-				"initial_comment": {},
-				"thread_ts":       {},
 			},
 		},
 	}, {
@@ -527,9 +515,101 @@ func TestNotify_PostMessage(t *testing.T) {
 				assert.NoError(t, err)
 				assert.True(t, ok)
 
+				require.Len(t, recorder.requests, 1)
+
+				// Get the request and check that it's sending to the URL
+				r := recorder.requests[0]
+				assert.Equal(t, notifier.settings.URL, r.URL.String())
+
+				// Check that the request contains the expected message
+				b, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				message := slackMessage{}
+				require.NoError(t, json.Unmarshal(b, &message))
+				for i, v := range message.Attachments {
+					// Need to update the ts as these cannot be set in the test definition
+					test.expectedMessage.Attachments[i].Ts = v.Ts
+				}
+				assert.Equal(t, *test.expectedMessage, message)
+			}
+		})
+	}
+}
+
+func TestNotify_PostMessageWithImage(t *testing.T) {
+	tests := []struct {
+		name                 string
+		alerts               []*types.Alert
+		expectedMessage      *slackMessage
+		expectedImageUploads int
+		expectedError        string
+		settings             Config
+	}{
+		{
+			name: "Message is sent and image is uploaded",
+			settings: Config{
+				EndpointURL:    APIURL,
+				URL:            APIURL,
+				Token:          "1234",
+				Recipient:      "#test",
+				Text:           templates.DefaultMessageEmbed,
+				Title:          templates.DefaultMessageTitleEmbed,
+				Username:       "Grafana",
+				IconEmoji:      ":emoji:",
+				IconURL:        "",
+				MentionChannel: "",
+				MentionUsers:   nil,
+				MentionGroups:  nil,
+			},
+			alerts: []*types.Alert{{
+				Alert: model.Alert{
+					Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+					Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "image-on-disk"},
+				},
+			}},
+			expectedMessage: &slackMessage{
+				Channel:   "#test",
+				Username:  "Grafana",
+				IconEmoji: ":emoji:",
+				Attachments: []attachment{
+					{
+						Title:      "[FIRING:1]  (val1)",
+						TitleLink:  "http://localhost/alerting/list",
+						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+						Fallback:   "[FIRING:1]  (val1)",
+						Fields:     nil,
+						Footer:     "Grafana v" + appVersion,
+						FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
+						Color:      "#D63232",
+					},
+				},
+			},
+			expectedImageUploads: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			notifier, recorder, err := setupSlackForTests(t, test.settings)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			ctx = notify.WithGroupKey(ctx, "alertname")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+
+			ok, err := notifier.Notify(ctx, test.alerts...)
+			if test.expectedError != "" {
+				assert.EqualError(t, err, test.expectedError)
+				assert.False(t, ok)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, ok)
+
 				// When sending a notification via PostMessage some content, such as images,
 				// are sent as replies to the original message
-				require.Len(t, recorder.requests, len(test.expectedReplies)+1)
+				imageUploadRequestCount := test.expectedImageUploads * 3
+				require.Len(t, recorder.requests, 1+imageUploadRequestCount)
 
 				// Get the request and check that it's sending to the URL
 				r := recorder.requests[0]
@@ -547,23 +627,32 @@ func TestNotify_PostMessage(t *testing.T) {
 				}
 				assert.Equal(t, *test.expectedMessage, message)
 
-				// Check that the replies match expectations
-				for i := 1; i < len(recorder.requests); i++ {
-					r = recorder.requests[i]
-					assert.Equal(t, "https://slack.com/api/files.upload", r.URL.String())
+				tokenHeader := fmt.Sprintf("Bearer %s", test.settings.Token)
 
-					media, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-					require.NoError(t, err)
-					if media == "multipart/form-data" {
-						// Some replies are file uploads, so check the multipart form
-						checkMultipart(t, test.expectedReplies[i-1].(map[string]struct{}), r.Body, params["boundary"])
-					} else {
-						b, err = io.ReadAll(r.Body)
-						require.NoError(t, err)
-						message = slackMessage{}
-						require.NoError(t, json.Unmarshal(b, &message))
-						assert.Equal(t, test.expectedReplies[i-1], message)
-					}
+				for i := 0; i < test.expectedImageUploads; i++ {
+					// check first request is to get the upload URL
+					initRequest := recorder.requests[i*3+1]
+					assert.Equal(t, "GET", initRequest.Method)
+					pathParts := strings.Split(initRequest.URL.EscapedPath(), "/")
+					assert.Equal(t, "files.getUploadURLExternal", pathParts[len(pathParts)-1])
+					assert.Contains(t, strings.Split(initRequest.Header.Get("Content-Type"), ";"), "application/x-www-form-urlencoded")
+					assert.Contains(t, initRequest.URL.Query(), "filename")
+					assert.Contains(t, initRequest.URL.Query(), "length")
+					assert.Equal(t, tokenHeader, initRequest.Header.Get("Authorization"))
+					// check second request is to upload the image
+					uploadRequest := recorder.requests[i*3+2]
+					assert.Equal(t, "POST", uploadRequest.Method)
+					assert.NoError(t, uploadRequest.ParseMultipartForm(32<<20))
+					assert.Equal(t, "test.png", uploadRequest.MultipartForm.File["filename"][0].Filename)
+					assert.Contains(t, strings.Split(uploadRequest.Header.Get("Content-Type"), ";"), "multipart/form-data")
+					assert.Equal(t, tokenHeader, uploadRequest.Header.Get("Authorization"))
+					// check third request is to finalize the upload
+					finalizeRequest := recorder.requests[i*3+3]
+					assert.Equal(t, "POST", finalizeRequest.Method)
+					pathParts = strings.Split(finalizeRequest.URL.EscapedPath(), "/")
+					assert.Equal(t, "files.completeUploadExternal", pathParts[len(pathParts)-1])
+					assert.Contains(t, strings.Split(finalizeRequest.Header.Get("Content-Type"), ";"), "application/json")
+					assert.Equal(t, tokenHeader, finalizeRequest.Header.Get("Authorization"))
 				}
 			}
 		})
@@ -575,24 +664,22 @@ type slackRequestRecorder struct {
 	requests []*http.Request
 }
 
-func (s *slackRequestRecorder) fn(_ context.Context, r *http.Request, _ logging.Logger) (string, error) {
+func (s *slackRequestRecorder) recordMessageRequest(_ context.Context, r *http.Request, _ logging.Logger) (string, error) {
 	s.requests = append(s.requests, r)
 	return "", nil
 }
 
-// checkMulipart checks that each part is present, but not its contents
-func checkMultipart(t *testing.T, expected map[string]struct{}, r io.Reader, boundary string) {
-	m := multipart.NewReader(r, boundary)
-	visited := make(map[string]struct{})
-	for {
-		part, err := m.NextPart()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-		visited[part.FormName()] = struct{}{}
-	}
-	assert.Equal(t, expected, visited)
+func (s *slackRequestRecorder) recordInitFileUploadRequest(_ context.Context, r *http.Request, _ logging.Logger) (*FileUploadURLResponse, error) {
+	s.requests = append(s.requests, r)
+	return &FileUploadURLResponse{
+		FileID:    "file-id",
+		UploadURL: "TODO: replace this with some function that actually allows you to return something to test the flow",
+	}, nil
+}
+
+func (s *slackRequestRecorder) recordFileUploadRequest(_ context.Context, r *http.Request, _ logging.Logger) error {
+	s.requests = append(s.requests, r)
+	return nil
 }
 
 func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequestRecorder, error) {
@@ -601,7 +688,7 @@ func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequest
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
 
-	f, err := os.Create(t.TempDir() + "test.png")
+	f, err := os.Create(t.TempDir() + "/test.png")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = f.Close()
@@ -637,7 +724,11 @@ func setupSlackForTests(t *testing.T, settings Config) (*Notifier, *slackRequest
 	}
 
 	sr := &slackRequestRecorder{}
-	sn.sendFn = sr.fn
+	sn.sendMessageFn = sr.recordMessageRequest
+	sn.initFileUploadFn = sr.recordInitFileUploadRequest
+	sn.uploadFileFn = sr.recordFileUploadRequest
+	sn.completeFileUploadFn = sr.recordFileUploadRequest
+
 	return sn, sr, nil
 }
 
@@ -754,7 +845,7 @@ func TestSendSlackRequest(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			require.NoError(tt, err)
 
-			_, err = sendSlackRequest(context.Background(), req, &logging.FakeLogger{})
+			_, err = sendSlackMessage(context.Background(), req, &logging.FakeLogger{})
 			if !test.expectError {
 				require.NoError(tt, err)
 			} else {


### PR DESCRIPTION
backport of #256 and #284 to v10.4.x
