### PR TITLE
Add updated_at timestamp to debug logs

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -788,7 +788,9 @@ func (am *GrafanaAlertmanager) PutAlerts(postableAlerts amv2.PostableAlerts) err
 			"starts_at",
 			a.StartsAt,
 			"ends_at",
-			a.EndsAt)
+			a.EndsAt,
+			"updated_at",
+			a.UpdatedAt)
 	}
 
 	if err := am.alerts.Put(alerts...); err != nil {


### PR DESCRIPTION
Adding `updated_at` to debug logs before the `alerts.Put()` call