### PR TITLE
Webhook Improvements - Templateable Payloads

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -580,8 +580,10 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 
 	// Prepare the context.
 	alerts := OpenAPIAlertsToAlerts(c.Alerts)
+	labels := model.LabelSet{DefaultGroupLabel: DefaultGroupLabelValue}
+	ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", DefaultReceiverName, labels.Fingerprint(), time.Now().Unix()))
 	ctx = notify.WithReceiverName(ctx, DefaultReceiverName)
-	ctx = notify.WithGroupLabels(ctx, model.LabelSet{DefaultGroupLabel: DefaultGroupLabelValue})
+	ctx = notify.WithGroupLabels(ctx, labels)
 
 	promTmplData := notify.GetTemplateData(ctx, newTmpl, alerts, logger)
 	data := templates.ExtendData(promTmplData, logger)

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -125,7 +125,12 @@ func (am *GrafanaAlertmanager) GetTemplate() (*template.Template, error) {
 
 // parseTestTemplate parses the test template and returns the top-level definitions that should be interpolated as results.
 func parseTestTemplate(name string, text string) ([]string, error) {
-	tmpl, err := tmpltext.New(name).Funcs(tmpltext.FuncMap(template.DefaultFuncs)).Parse(text)
+	tmpl, err := templates.NewRawTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl, err = tmpl.New(name).Parse(text)
 	if err != nil {
 		return nil, err
 	}

--- a/receivers/oncall/oncall.go
+++ b/receivers/oncall/oncall.go
@@ -74,6 +74,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	as, numTruncated := truncateAlerts(n.settings.MaxAlerts, as)
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, n.tmpl, as, n.log, &tmplErr)
+	data.TruncatedAlerts = &numTruncated
 
 	// Augment our Alert data with ImageURLs if available.
 	_ = images.WithStoredImages(ctx, n.log, n.images,

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -18,7 +18,7 @@ type CustomPayload struct {
 
 	// Vars is a map of variables that can be used in the payload template. This is useful for providing
 	// additional context to the payload template without storing it in the template itself.
-	// Variables are accessible in the template through `.Extra.Vars.<key>`.
+	// Variables are accessible in the template through `.Vars.<key>`.
 	Vars map[string]string `json:"vars,omitempty" yaml:"vars,omitempty"`
 }
 

--- a/receivers/webhook/config.go
+++ b/receivers/webhook/config.go
@@ -175,7 +175,7 @@ func OmitRestrictedHeaders(headers map[string]string) (map[string]string, []stri
 			omitted = append(omitted, k)
 			continue
 		}
-		safeHeaders[http.CanonicalHeaderKey(k)] = v
+		safeHeaders[k] = v // We keep the original case of the header, as it might have been intentional.
 	}
 	return safeHeaders, omitted
 }

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -296,6 +296,31 @@ func TestNewConfig(t *testing.T) {
 			}`,
 			expectedInitError: "both HTTP Basic Authentication and Authorization Header are set, only 1 is permitted",
 		},
+		{
+			name: "with custom payload and variables",
+			settings: `{
+				"url": "http://localhost/test1",
+				"payload": {
+					"template": "{{ define \"test\" }}{{ .Receiver }}{{ .Extra.Vars.var1 }}{{ end }}",
+					"vars": {
+						"var1": "variablevalue"
+					}
+				}
+			}`,
+			expectedConfig: Config{
+				URL:        "http://localhost/test1",
+				HTTPMethod: http.MethodPost,
+				MaxAlerts:  0,
+				Title:      templates.DefaultMessageTitleEmbed,
+				Message:    templates.DefaultMessageEmbed,
+				Payload: CustomPayload{
+					Template: `{{ define "test" }}{{ .Receiver }}{{ .Extra.Vars.var1 }}{{ end }}`,
+					Vars: map[string]string{
+						"var1": "variablevalue",
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -302,7 +302,7 @@ func TestNewConfig(t *testing.T) {
 			settings: `{
 				"url": "http://localhost/test1",
 				"payload": {
-					"template": "{{ define \"test\" }}{{ .Receiver }}{{ .Extra.Vars.var1 }}{{ end }}",
+					"template": "{{ define \"test\" }}{{ .Receiver }}{{ .Vars.var1 }}{{ end }}",
 					"vars": {
 						"var1": "variablevalue"
 					}
@@ -315,7 +315,7 @@ func TestNewConfig(t *testing.T) {
 				Title:      templates.DefaultMessageTitleEmbed,
 				Message:    templates.DefaultMessageEmbed,
 				Payload: CustomPayload{
-					Template: `{{ define "test" }}{{ .Receiver }}{{ .Extra.Vars.var1 }}{{ end }}`,
+					Template: `{{ define "test" }}{{ .Receiver }}{{ .Vars.var1 }}{{ end }}`,
 					Vars: map[string]string{
 						"var1": "variablevalue",
 					},

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -141,7 +141,11 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		body = string(payload)
 	}
 
-	headers := make(map[string]string)
+	headers, removed := OmitRestrictedHeaders(wn.settings.ExtraHeaders)
+	if len(removed) > 0 {
+		wn.log.Debug("removed restricted headers", "headers", removed)
+	}
+
 	if wn.settings.AuthorizationScheme != "" && wn.settings.AuthorizationCredentials != "" {
 		headers["Authorization"] = fmt.Sprintf("%s %s", wn.settings.AuthorizationScheme, wn.settings.AuthorizationCredentials)
 	}

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -101,10 +101,8 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		if tmplErr != nil {
 			return false, tmplErr // TODO: Should there be an option to fallback to the default payload?
 		}
-	}
-
-	if body == "" {
-		// We separate the templating Title and Message so we can capture any errors and reset the error state.
+	} else {
+		// We separate templating the Title and Message so we can capture any errors and reset the error state.
 		// Otherwise, if Title fails Message will not be templated either.
 		title := tmpl(wn.settings.Title)
 		if tmplErr != nil {

--- a/receivers/webhook/webhook.go
+++ b/receivers/webhook/webhook.go
@@ -73,7 +73,6 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	if tmplErr != nil {
 		return false, tmplErr
 	}
-	tmplErr = nil // Reset the error for the next template.
 
 	// Augment our Alert data with ImageURLs if available.
 	_ = images.WithStoredImages(ctx, wn.log, wn.images,
@@ -107,12 +106,12 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		title := tmpl(wn.settings.Title)
 		if tmplErr != nil {
 			wn.log.Warn("failed to template webhook title", "error", tmplErr.Error())
-			tmplErr = nil
+			tmplErr = nil // Reset the error for the next template.
 		}
 		message := tmpl(wn.settings.Message)
 		if tmplErr != nil {
 			wn.log.Warn("failed to template webhook message", "error", tmplErr.Error())
-			tmplErr = nil
+			tmplErr = nil // Reset the error for the next template.
 		}
 		payload, err := json.Marshal(webhookMessage{
 			Version:         "1",

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/alerting/models"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
@@ -73,8 +74,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -95,9 +97,11 @@ func TestNotify(t *testing.T) {
 								"ann1": "annv1",
 							},
 							Fingerprint:  "fac0861a85de433a",
-							DashboardURL: "http://localhost/d/abcd",
-							PanelURL:     "http://localhost/d/abcd?viewPanel=efgh",
-							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							DashboardURL: "http://localhost/d/abcd?orgId=1",
+							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -138,18 +142,21 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				}, {
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations:  model.LabelSet{"ann1": "annv2", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				}, {
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val3"},
-						Annotations: model.LabelSet{"ann1": "annv3"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val3"},
+						Annotations:  model.LabelSet{"ann1": "annv3", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -171,8 +178,10 @@ func TestNotify(t *testing.T) {
 							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
-							Fingerprint: "fac0861a85de433a",
-							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							Fingerprint:  "fac0861a85de433a",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						}, {
 							Status: "firing",
 							Labels: templates.KV{
@@ -182,8 +191,10 @@ func TestNotify(t *testing.T) {
 							Annotations: templates.KV{
 								"ann1": "annv2",
 							},
-							Fingerprint: "fab6861a85d5eeb5",
-							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2",
+							Fingerprint:  "fab6861a85d5eeb5",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -200,7 +211,7 @@ func TestNotify(t *testing.T) {
 				TruncatedAlerts: 1,
 				Title:           "Alerts firing: 2",
 				State:           "alerting",
-				Message:         "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
+				Message:         "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2&orgId=1\n",
 				OrgID:           orgID,
 			},
 			expMsgError: nil,
@@ -222,13 +233,15 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				}, {
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations:  model.LabelSet{"ann1": "annv2", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -248,8 +261,10 @@ func TestNotify(t *testing.T) {
 							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
-							Fingerprint: "fac0861a85de433a",
-							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							Fingerprint:  "fac0861a85de433a",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						}, {
 							Status: "firing",
 							Labels: templates.KV{
@@ -259,8 +274,10 @@ func TestNotify(t *testing.T) {
 							Annotations: templates.KV{
 								"ann1": "annv2",
 							},
-							Fingerprint: "fab6861a85d5eeb5",
-							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2",
+							Fingerprint:  "fab6861a85d5eeb5",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -277,7 +294,7 @@ func TestNotify(t *testing.T) {
 				TruncatedAlerts: 0,
 				Title:           "[FIRING:2]  ",
 				State:           "alerting",
-				Message:         "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
+				Message:         "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2&orgId=1\n",
 				OrgID:           orgID,
 			},
 			expMsgError: nil,
@@ -299,8 +316,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -319,9 +337,11 @@ func TestNotify(t *testing.T) {
 								"ann1": "annv1",
 							},
 							Fingerprint:  "fac0861a85de433a",
-							DashboardURL: "http://localhost/d/abcd",
-							PanelURL:     "http://localhost/d/abcd?viewPanel=efgh",
-							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							DashboardURL: "http://localhost/d/abcd?orgId=1",
+							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -340,7 +360,7 @@ func TestNotify(t *testing.T) {
 				GroupKey: "alertname",
 				Title:    "[FIRING:1]  (val1)",
 				State:    "alerting",
-				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1\nDashboard: http://localhost/d/abcd?orgId=1\nPanel: http://localhost/d/abcd?orgId=1&viewPanel=efgh\n",
 				OrgID:    orgID,
 			},
 			expURL:        "http://localhost/test1",
@@ -369,8 +389,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -389,9 +410,11 @@ func TestNotify(t *testing.T) {
 								"ann1": "annv1",
 							},
 							Fingerprint:  "fac0861a85de433a",
-							DashboardURL: "http://localhost/d/abcd",
-							PanelURL:     "http://localhost/d/abcd?viewPanel=efgh",
-							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							DashboardURL: "http://localhost/d/abcd?orgId=1",
+							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -410,7 +433,7 @@ func TestNotify(t *testing.T) {
 				GroupKey: "alertname",
 				Title:    "[FIRING:1]  (val1)",
 				State:    "alerting",
-				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1\nDashboard: http://localhost/d/abcd?orgId=1\nPanel: http://localhost/d/abcd?orgId=1&viewPanel=efgh\n",
 				OrgID:    orgID,
 			},
 			expURL:        "https://localhost/test1",
@@ -439,8 +462,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -459,9 +483,11 @@ func TestNotify(t *testing.T) {
 								"ann1": "annv1",
 							},
 							Fingerprint:  "fac0861a85de433a",
-							DashboardURL: "http://localhost/d/abcd",
-							PanelURL:     "http://localhost/d/abcd?viewPanel=efgh",
-							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							DashboardURL: "http://localhost/d/abcd?orgId=1",
+							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -480,7 +506,7 @@ func TestNotify(t *testing.T) {
 				GroupKey: "alertname",
 				Title:    "[FIRING:1]  (val1)",
 				State:    "alerting",
-				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1\nDashboard: http://localhost/d/abcd?orgId=1\nPanel: http://localhost/d/abcd?orgId=1&viewPanel=efgh\n",
 				OrgID:    orgID,
 			},
 			expURL:        "https://localhost/test1",
@@ -504,8 +530,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -523,8 +550,10 @@ func TestNotify(t *testing.T) {
 							Annotations: templates.KV{
 								"ann1": "annv1",
 							},
-							Fingerprint: "fac0861a85de433a",
-							SilenceURL:  "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1",
+							Fingerprint:  "fac0861a85de433a",
+							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
+							GeneratorURL: "http://localhost/test?orgId=1",
+							OrgId:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -543,7 +572,7 @@ func TestNotify(t *testing.T) {
 				GroupKey: "alertname",
 				Title:    "[FIRING:1]  (val1)",
 				State:    "alerting",
-				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n",
+				Message:  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1\n",
 				OrgID:    orgID,
 			},
 			expURL:        "http://localhost/test1",
@@ -572,8 +601,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -595,8 +625,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -623,8 +654,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -664,8 +696,9 @@ func TestNotify(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -771,8 +804,9 @@ func TestNotify_CustomPayload(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+						GeneratorURL: "http://localhost/test",
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 					},
 				},
 			},
@@ -789,10 +823,11 @@ func TestNotify_CustomPayload(t *testing.T) {
       },
       "startsAt": "0001-01-01T00:00:00Z",
       "endsAt": "0001-01-01T00:00:00Z",
-      "generatorURL": "",
+      "generatorURL": "http://localhost/test?orgId=1",
       "fingerprint": "fac0861a85de433a",
-      "silenceURL": "http://localhost/alerting/silence/new?alertmanager=grafana\u0026matcher=alertname%3Dalert1\u0026matcher=lbl1%3Dval1",
+      "silenceURL": "http://localhost/alerting/silence/new?alertmanager=grafana\u0026matcher=alertname%3Dalert1\u0026matcher=lbl1%3Dval1&orgId=1",
       "dashboardURL": "",
+      "orgId": 1,
       "panelURL": "",
       "values": null,
       "valueString": ""
@@ -810,7 +845,7 @@ func TestNotify_CustomPayload(t *testing.T) {
   "groupLabels": {
     "alertname": ""
   },
-  "message": "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana\u0026matcher=alertname%3Dalert1\u0026matcher=lbl1%3Dval1\n",
+  "message": "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: http://localhost/test?orgId=1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana\u0026matcher=alertname%3Dalert1\u0026matcher=lbl1%3Dval1&orgId=1\n",
   "orgId": 1,
   "receiver": "my_receiver",
   "state": "alerting",
@@ -829,7 +864,7 @@ func TestNotify_CustomPayload(t *testing.T) {
 				HTTPMethod: http.MethodPost,
 				MaxAlerts:  1,
 				Payload: CustomPayload{
-					Template: `{{ .Extra | data.ToJSONPretty " " }}`,
+					Template: `{{ .Vars | data.ToJSONPretty " " }}`,
 					Vars: map[string]string{
 						"var1": "val1",
 						"var2": "val2",
@@ -840,30 +875,23 @@ func TestNotify_CustomPayload(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations:  model.LabelSet{"ann1": "annv1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 						GeneratorURL: "http://localhost/generator",
 					},
 				},
 				{
 					Alert: model.Alert{
 						Labels:       model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
-						Annotations:  model.LabelSet{"ann2": "annv2"},
+						Annotations:  model.LabelSet{"ann2": "annv2", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
 						GeneratorURL: "http://localhost/generator",
 					},
 				},
 			},
 			expMsg: `
 {
- "GroupKey": "alertname",
- "OrgId": 1,
- "State": "alerting",
- "TruncatedAlerts": 1,
- "Vars": {
   "var1": "val1",
   "var2": "val2"
- },
- "Version": "1"
-}
+ }
 `,
 			expMsgError: nil,
 		},
@@ -966,7 +994,7 @@ func TestNotify_CustomPayload(t *testing.T) {
     "client" "Grafana"
     "client_url" ( print .ExternalURL  "/alerting/list")
     "alert_state" .Status
-    "incident_key" .Extra.GroupKey
+    "incident_key" .GroupKey
   )
   | data.ToJSONPretty " " }}`,
 				},

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -101,7 +101,7 @@ func TestNotify(t *testing.T) {
 							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -181,7 +181,7 @@ func TestNotify(t *testing.T) {
 							Fingerprint:  "fac0861a85de433a",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						}, {
 							Status: "firing",
 							Labels: templates.KV{
@@ -194,7 +194,7 @@ func TestNotify(t *testing.T) {
 							Fingerprint:  "fab6861a85d5eeb5",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -264,7 +264,7 @@ func TestNotify(t *testing.T) {
 							Fingerprint:  "fac0861a85de433a",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						}, {
 							Status: "firing",
 							Labels: templates.KV{
@@ -277,7 +277,7 @@ func TestNotify(t *testing.T) {
 							Fingerprint:  "fab6861a85d5eeb5",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -341,7 +341,7 @@ func TestNotify(t *testing.T) {
 							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -414,7 +414,7 @@ func TestNotify(t *testing.T) {
 							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -487,7 +487,7 @@ func TestNotify(t *testing.T) {
 							PanelURL:     "http://localhost/d/abcd?orgId=1&viewPanel=efgh",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{
@@ -553,7 +553,7 @@ func TestNotify(t *testing.T) {
 							Fingerprint:  "fac0861a85de433a",
 							SilenceURL:   "http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1&orgId=1",
 							GeneratorURL: "http://localhost/test?orgId=1",
-							OrgId:        &orgID,
+							OrgID:        &orgID,
 						},
 					},
 					GroupLabels: templates.KV{

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -1023,6 +1023,27 @@ func TestNotify_CustomPayload(t *testing.T) {
 `,
 			expMsgError: nil,
 		},
+		{
+			name: "empty payload",
+			settings: Config{
+				URL:        "http://localhost/test",
+				HTTPMethod: http.MethodPost,
+				Payload: CustomPayload{
+					Template: `{{- print "" -}}`,
+				},
+			},
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations:  model.LabelSet{"ann1": "annv1"},
+						GeneratorURL: "http://localhost/generator",
+					},
+				},
+			},
+			expMsg:      ``,
+			expMsgError: nil,
+		},
 	}
 
 	for _, c := range cases {
@@ -1055,7 +1076,7 @@ func TestNotify_CustomPayload(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, ok)
 
-			require.JSONEq(t, c.expMsg, webhookSender.Webhook.Body)
+			require.Equal(t, c.expMsg, webhookSender.Webhook.Body)
 		})
 	}
 }

--- a/receivers/webhook/webhook_test.go
+++ b/receivers/webhook/webhook_test.go
@@ -789,8 +789,9 @@ func TestNotify_CustomPayload(t *testing.T) {
 		settings Config
 		alerts   []*types.Alert
 
-		expMsg      string
-		expMsgError error
+		expPlaintext bool
+		expMsg       string
+		expMsgError  error
 	}{
 		{
 			name: "Custom payload with one alert",
@@ -1041,8 +1042,9 @@ func TestNotify_CustomPayload(t *testing.T) {
 					},
 				},
 			},
-			expMsg:      ``,
-			expMsgError: nil,
+			expPlaintext: true,
+			expMsg:       ``,
+			expMsgError:  nil,
 		},
 	}
 
@@ -1075,8 +1077,11 @@ func TestNotify_CustomPayload(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.True(t, ok)
-
-			require.Equal(t, c.expMsg, webhookSender.Webhook.Body)
+			if c.expPlaintext {
+				require.Equal(t, c.expMsg, webhookSender.Webhook.Body)
+			} else {
+				require.JSONEq(t, c.expMsg, webhookSender.Webhook.Body)
+			}
 		})
 	}
 }

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -116,7 +116,7 @@ Annotations:
   "commonAnnotations" .CommonAnnotations
   "externalURL" .ExternalURL
   "version" "1"
-  "orgId"  (index .Alerts 0).OrgId
+  "orgId"  (index .Alerts 0).OrgID
   "truncatedAlerts"  .TruncatedAlerts
   "groupKey" .GroupKey
   "state"  (tmpl.Inline "{{ if eq .Status \"resolved\" }}ok{{ else }}alerting{{ end }}" . )

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -105,6 +105,25 @@ Annotations:
 {{- end -}}
 {{- $priority -}}
 {{- end -}}
+
+{{ define "webhook.default.payload" -}}
+  {{ coll.Dict 
+  "receiver" .Receiver
+  "status" .Status
+  "alerts" .Alerts
+  "groupLabels" .GroupLabels
+  "commonLabels" .CommonLabels
+  "commonAnnotations" .CommonAnnotations
+  "externalURL" .ExternalURL
+  "version" .Extra.Version
+  "orgId"  .Extra.OrgId
+  "truncatedAlerts"  .Extra.TruncatedAlerts
+  "groupKey" .Extra.GroupKey
+  "state"  .Extra.State
+  "title" (tmpl.Exec "default.title" . )
+  "message" (tmpl.Exec "default.message" . )
+  | data.ToJSONPretty " "}}
+{{- end }}
 `
 
 // TemplateForTestsString is the template used for unit tests and integration tests.

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -115,11 +115,11 @@ Annotations:
   "commonLabels" .CommonLabels
   "commonAnnotations" .CommonAnnotations
   "externalURL" .ExternalURL
-  "version" .Extra.Version
-  "orgId"  .Extra.OrgId
-  "truncatedAlerts"  .Extra.TruncatedAlerts
-  "groupKey" .Extra.GroupKey
-  "state"  .Extra.State
+  "version" "1"
+  "orgId"  (index .Alerts 0).OrgId
+  "truncatedAlerts"  .TruncatedAlerts
+  "groupKey" .GroupKey
+  "state"  (tmpl.Inline "{{ if eq .Status \"resolved\" }}ok{{ else }}alerting{{ end }}" . )
   "title" (tmpl.Exec "default.title" . )
   "message" (tmpl.Exec "default.message" . )
   | data.ToJSONPretty " "}}

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -143,7 +143,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	tmplDef, err := DefaultTemplate()
 	require.NoError(t, err)
 
-	tmplFromDefinition, err := newTemplate()
+	tmplFromDefinition, err := NewTemplate()
 	require.NoError(t, err)
 	// Parse default template string.
 	err = tmplFromDefinition.Parse(strings.NewReader(tmplDef.Template))

--- a/templates/gomplate/collections.go
+++ b/templates/gomplate/collections.go
@@ -1,3 +1,30 @@
+/*
+ * This file evolved from the MIT licensed: https://github.com/hairyhenderson/gomplate
+ */
+
+/*
+The MIT License (MIT)
+
+# Copyright (c) 2016-2023 Dave Henderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 package gomplate
 
 import (

--- a/templates/gomplate/collections.go
+++ b/templates/gomplate/collections.go
@@ -1,0 +1,63 @@
+package gomplate
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func CreateCollFuncs() Namespace {
+	return Namespace{"coll", &CollFuncs{}}
+}
+
+// Collection Functions.
+type CollFuncs struct {
+}
+
+func (CollFuncs) Dict(in ...any) (map[string]any, error) {
+	dict := map[string]interface{}{}
+	lenv := len(in)
+	for i := 0; i < lenv; i += 2 {
+		key := toString(in[i])
+		if i+1 >= lenv {
+			dict[key] = ""
+			continue
+		}
+		dict[key] = in[i+1]
+	}
+	return dict, nil
+}
+
+func (CollFuncs) Slice(args ...any) []any {
+	return args
+}
+
+func (CollFuncs) Append(v any, list any) ([]any, error) {
+	l, err := interfaceSlice(list)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(l, v), nil
+}
+
+// interfaceSlice converts an array or slice of any type into an []interface{}
+// for use in functions that expect this.
+func interfaceSlice(slice interface{}) ([]interface{}, error) {
+	// avoid all this nonsense if this is already a []interface{}...
+	if s, ok := slice.([]interface{}); ok {
+		return s, nil
+	}
+	s := reflect.ValueOf(slice)
+	kind := s.Kind()
+	switch kind {
+	case reflect.Slice, reflect.Array:
+		l := s.Len()
+		ret := make([]interface{}, l)
+		for i := 0; i < l; i++ {
+			ret[i] = s.Index(i).Interface()
+		}
+		return ret, nil
+	default:
+		return nil, fmt.Errorf("expected an array or slice, but got a %T", s)
+	}
+}

--- a/templates/gomplate/data.go
+++ b/templates/gomplate/data.go
@@ -1,0 +1,87 @@
+package gomplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+func CreateDataFuncs() Namespace {
+	return Namespace{"data", &DataFuncs{}}
+}
+
+// Data Functions.
+type DataFuncs struct {
+}
+
+func (f *DataFuncs) JSON(in any) (any, error) {
+	return JSON(toString(in))
+}
+
+func (f *DataFuncs) ToJSON(in any) (string, error) {
+	return toJSON(in)
+}
+
+func (f *DataFuncs) ToJSONPretty(indent string, in any) (string, error) {
+	return toJSONPretty(indent, in)
+}
+
+// JSON - Unmarshal a JSON Object. Can be ejson-encrypted.
+func JSON(in string) (any, error) {
+	var out any
+	err := yaml.Unmarshal([]byte(in), &out)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal object %s: %w", in, err)
+	}
+
+	return out, err
+}
+
+// toJSON - Stringify a struct as JSON
+func toJSON(in any) (string, error) {
+	s, err := json.Marshal(in) // We use json.Marshal here instead of ugorji/go/codec used in gomplate as there are nil<->zero decoding differences between them. See https://github.com/ugorji/go/issues/386.
+	if err != nil {
+		return "", err
+	}
+	return string(s), nil
+}
+
+// toJSONPretty - Stringify a struct as JSON (indented)
+func toJSONPretty(indent string, in any) (string, error) {
+	out := new(bytes.Buffer)
+	b, err := json.Marshal(in) // We use json.Marshal here instead of ugorji/go/codec used in gomplate as there are nil<->zero decoding differences between them. See https://github.com/ugorji/go/issues/386.
+	if err != nil {
+		return "", err
+	}
+	err = json.Indent(out, b, "", indent)
+	if err != nil {
+		return "", fmt.Errorf("unable to indent JSON %s: %w", b, err)
+	}
+
+	return out.String(), nil
+}
+
+func toString(in any) string {
+	if in == nil {
+		return "nil"
+	}
+	if s, ok := in.(string); ok {
+		return s
+	}
+	if s, ok := in.(fmt.Stringer); ok {
+		return s.String()
+	}
+	if s, ok := in.([]byte); ok {
+		return string(s)
+	}
+
+	v, ok := printableValue(reflect.ValueOf(in))
+	if ok {
+		in = v
+	}
+
+	return fmt.Sprint(in)
+}

--- a/templates/gomplate/data.go
+++ b/templates/gomplate/data.go
@@ -1,3 +1,30 @@
+/*
+ * This file evolved from the MIT licensed: https://github.com/hairyhenderson/gomplate
+ */
+
+/*
+The MIT License (MIT)
+
+# Copyright (c) 2016-2023 Dave Henderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 package gomplate
 
 import (

--- a/templates/gomplate/evalargs.go
+++ b/templates/gomplate/evalargs.go
@@ -1,3 +1,30 @@
+/*
+ * This file evolved from the MIT licensed: https://github.com/hairyhenderson/gomplate
+ */
+
+/*
+The MIT License (MIT)
+
+# Copyright (c) 2016-2023 Dave Henderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 package gomplate
 
 // Copied from text/template stlib package.

--- a/templates/gomplate/evalargs.go
+++ b/templates/gomplate/evalargs.go
@@ -1,0 +1,47 @@
+package gomplate
+
+// Copied from text/template stlib package.
+import (
+	"fmt"
+	"reflect"
+)
+
+var (
+	errorType       = reflect.TypeFor[error]()
+	fmtStringerType = reflect.TypeFor[fmt.Stringer]()
+)
+
+// printableValue returns the, possibly indirected, interface value inside v that
+// is best for a call to formatted printer.
+func printableValue(v reflect.Value) (any, bool) {
+	if v.Kind() == reflect.Pointer {
+		v, _ = indirect(v) // fmt.Fprint handles nil.
+	}
+	if !v.IsValid() {
+		return "<no value>", true
+	}
+
+	if !v.Type().Implements(errorType) && !v.Type().Implements(fmtStringerType) {
+		if v.CanAddr() && (reflect.PointerTo(v.Type()).Implements(errorType) || reflect.PointerTo(v.Type()).Implements(fmtStringerType)) {
+			v = v.Addr()
+		} else {
+			switch v.Kind() {
+			case reflect.Chan, reflect.Func:
+				return nil, false
+			}
+		}
+	}
+	return v.Interface(), true
+}
+
+// indirect returns the item at the end of indirection, and a bool to indicate
+// if it's nil. If the returned bool is true, the returned value's kind will be
+// either a pointer or interface.
+func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
+	for ; v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface; v = v.Elem() {
+		if v.IsNil() {
+			return v, true
+		}
+	}
+	return v, false
+}

--- a/templates/gomplate/funcs.go
+++ b/templates/gomplate/funcs.go
@@ -1,0 +1,32 @@
+package gomplate
+
+import (
+	tmpltext "text/template"
+)
+
+type Namespace struct {
+	Name    string
+	Context any
+}
+
+func (ns Namespace) AddToFuncMap(funcMap tmpltext.FuncMap) {
+	funcMap[ns.Name] = func() any { return ns.Context }
+}
+
+func FuncMap(text *tmpltext.Template) tmpltext.FuncMap {
+	// Functions in these namespaces are based on those from github.com/hairyhenderson/gomplate/v4 with some differences
+	// noted in comments.
+	// Currently gomplate does not allow modularized use of select functions or namespaces, so importing it directly
+	// would require a significant increase in dependencies.
+	// In addition, certain necessary functions have extended functionality in gomplate that makes them risky to use
+	// here, such as the eJSON decryption capability of data.JSON which reads from environment variables.
+	// That being said, none of this is insurmountable, and the plan should be to eventually incorporate the gomplate
+	// library directly.
+	funcMap := tmpltext.FuncMap{}
+	CreateCollFuncs().AddToFuncMap(funcMap)
+	CreateDataFuncs().AddToFuncMap(funcMap)
+	CreateTemplateFuncs(text).AddToFuncMap(funcMap)
+	CreateTimeFuncs().AddToFuncMap(funcMap)
+
+	return funcMap
+}

--- a/templates/gomplate/template.go
+++ b/templates/gomplate/template.go
@@ -1,0 +1,84 @@
+package gomplate
+
+import (
+	"bytes"
+	"fmt"
+	tmpltext "text/template"
+)
+
+func CreateTemplateFuncs(root *tmpltext.Template) Namespace {
+	return Namespace{"tmpl", &TmplFuncs{root}}
+}
+
+// Template Functions.
+type TmplFuncs struct {
+	root *tmpltext.Template
+}
+
+// Inline - a template function to do inline template processing.
+// A simplified copy of the same function in the gomplate.
+//
+// Can be called 2 ways:
+// {{ tmpl.Inline "name" "inline template" }} - named template with default context
+// {{ tmpl.Inline "inline template" $foo }} - unnamed (single-use) template with given context
+func (t *TmplFuncs) Inline(args ...any) (string, error) {
+	name, in, ctx, err := parseArgs(args...)
+	if err != nil {
+		return "", err
+	}
+	return t.inline(name, in, ctx)
+}
+
+func (t *TmplFuncs) inline(name, in string, ctx interface{}) (string, error) {
+	tmpl, err := t.root.New(name).Parse(in)
+	if err != nil {
+		return "", err
+	}
+	return render(tmpl, ctx)
+}
+
+func (t *TmplFuncs) Exec(name string, tmplcontext ...any) (string, error) {
+	var ctx any
+	if len(tmplcontext) == 1 {
+		ctx = tmplcontext[0]
+	}
+	tmpl := t.root.Lookup(name)
+	if tmpl == nil {
+		return "", fmt.Errorf(`template "%s" not defined`, name)
+	}
+	return render(tmpl, ctx)
+}
+
+func render(tmpl *tmpltext.Template, ctx interface{}) (string, error) {
+	out := &bytes.Buffer{}
+	err := tmpl.Execute(out, ctx)
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+// parseArgs is a simplified copy of the same function in the gomplate.
+func parseArgs(args ...interface{}) (name, in string, ctx interface{}, err error) {
+	name = "<inline>"
+
+	if len(args) != 2 {
+		return "", "", nil, fmt.Errorf("wrong number of args for tpl: want 2 - got %d", len(args))
+	}
+	first, ok := args[0].(string)
+	if !ok {
+		return "", "", nil, fmt.Errorf("wrong input: first arg must be string, got %T", args[0])
+	}
+
+	// this can either be (name string, in string) or (in string, ctx interface{})
+	switch second := args[1].(type) {
+	case string:
+		name = first
+		in = second
+	default:
+		in = first
+		ctx = second
+	}
+
+	return name, in, ctx, nil
+}

--- a/templates/gomplate/template.go
+++ b/templates/gomplate/template.go
@@ -1,3 +1,30 @@
+/*
+ * This file evolved from the MIT licensed: https://github.com/hairyhenderson/gomplate
+ */
+
+/*
+The MIT License (MIT)
+
+# Copyright (c) 2016-2023 Dave Henderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 package gomplate
 
 import (

--- a/templates/gomplate/time.go
+++ b/templates/gomplate/time.go
@@ -1,0 +1,17 @@
+package gomplate
+
+import (
+	"time"
+)
+
+func CreateTimeFuncs() Namespace {
+	return Namespace{"time", &TimeFuncs{}}
+}
+
+// Time Functions.
+type TimeFuncs struct {
+}
+
+func (TimeFuncs) Now() time.Time {
+	return time.Now()
+}

--- a/templates/gomplate/time.go
+++ b/templates/gomplate/time.go
@@ -1,3 +1,30 @@
+/*
+ * This file evolved from the MIT licensed: https://github.com/hairyhenderson/gomplate
+ */
+
+/*
+The MIT License (MIT)
+
+# Copyright (c) 2016-2023 Dave Henderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 package gomplate
 
 import (

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -57,7 +57,7 @@ type ExtendedAlert struct {
 	ValueString   string             `json:"valueString"` // TODO: Remove in Grafana 10
 	ImageURL      string             `json:"imageURL,omitempty"`
 	EmbeddedImage string             `json:"embeddedImage,omitempty"`
-	OrgId         *int64             `json:"orgId,omitempty"`
+	OrgID         *int64             `json:"orgId,omitempty"`
 }
 
 type ExtendedAlerts []ExtendedAlert
@@ -149,7 +149,7 @@ func NewRawTemplate(options ...template.Option) (*tmpltext.Template, error) {
 		tmpl = text
 	}
 
-	_, err := NewTemplate(capture)
+	_, err := NewTemplate(append(options, capture)...)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 		if err != nil {
 			level.Debug(logger).Log("msg", "failed to parse org ID annotation", "error", err.Error())
 		} else {
-			extended.OrgId = &orgID
+			extended.OrgID = &orgID
 		}
 	}
 

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -70,6 +70,9 @@ type ExtendedData struct {
 	CommonAnnotations KV `json:"commonAnnotations"`
 
 	ExternalURL string `json:"externalURL"`
+
+	// Optional extra integration-specific data useable in templates.
+	Extra map[string]any `json:"-"`
 }
 
 var DefaultTemplateName = "__default__"
@@ -342,6 +345,8 @@ func ExtendData(data *Data, logger log.Logger) *ExtendedData {
 		CommonAnnotations: removePrivateItems(data.CommonAnnotations),
 
 		ExternalURL: data.ExternalURL,
+
+		Extra: make(map[string]any),
 	}
 	return extended
 }


### PR DESCRIPTION
## Overview
This PR introduces enhancements to the webhook notifier, focusing on three main areas:
1. Customizable webhook payloads using templates
2. Support for custom HTTP headers
3. New template functions to provide support for creating well-formatted, valid JSON in payloads.

## Key Changes

### 1. Custom Payload Templates
- Added support for custom JSON payload templates in webhook notifications
- Users can now define their own payload structure using templates
- Includes a new `CustomPayload` field with:
  - `Template` field for defining the payload structure
  - `Vars` field for providing additional template variables accessible in context via `.Vars.<variable_name>`
- Provides an example payload template which is equivalent to the default payload format for demonstration and regression testing

### 2. Custom HTTP Headers
- Added support for custom HTTP headers in webhook requests, example usage would be to set the `Content-Type` header for your custom payload.
- Implemented security measures to prevent misuse:
  - Restricted headers list to prevent security issues
  - Headers like `Authorization`, `Cookie`, `Host` are protected

### 3. New Template Functions
- Introduced new template functions inspired by [gomplate](https://docs.gomplate.ca/):
  - `coll` namespace for collection operations (`Dict`, `Slice`, `Append`)
  - `data` namespace for JSON operations (`JSON`, `ToJSON`, `ToJSONPretty`)
  - `tmpl` namespace for template operations compatible with pipelines (`Inline`, `Exec`)
  - `time` namespace for time operations (`Now`)
- These functions enable more complex and flexible payload formatting, especially when creating JSON.
- Currently gomplate does not allow modularized use of select functions or namespaces, so importing it directly would require a significant increase in dependencies. In addition, certain necessary functions have extended functionality in gomplate that makes them risky to use as-is such as the `eJSON` decryption capability of `data.JSON` which reads from environment variables. That being said, none of this is insurmountable, and the plan should be to eventually incorporate the gomplate library directly and more broadly.

### 4. Related Improvements
- Added new fields to `ExtendedData` and `ExtendedAlert` to make sure custom payloads have access to all of the information the default webhook payload has:
  - `ExtendedAlert.OrgId`
  - `ExtendedData.GroupKey`
  - `ExtendedData.TruncatedAlerts`

## Related Requests

Issues for supporting new notifiers in Grafana are fairly common and are generally reasonable requests. However, they can come with significant burden of maintenance. Some examples:
- [Telegram Local Bot API support](https://github.com/grafana/grafana/issues/81534)
- [Alerting: Extend Pagerduty notification for Openduty](https://github.com/grafana/grafana/issues/6504)
- [Feature request: New contact point type: Amazon EventBridge](https://github.com/grafana/grafana/issues/82645)
- [FR: Alerting Contact Point Matrix](https://github.com/grafana/grafana/issues/82764)
- [Add web push notifications to Grafana Alerting](https://github.com/grafana/grafana/issues/10306)

Requests for related features are some of the most popular in Alerting:
- [[Feature request] Custom json passed as a webhook alert](https://github.com/grafana/grafana/issues/6956) 
- [Support Backend plugins for Alert notifiers](https://github.com/grafana/grafana/issues/16004)
- [Custom Headers on HTTP webhook](https://github.com/grafana/grafana/issues/9813#top)
- [Support custom headers on the webhook contact point](https://github.com/grafana/grafana/issues/50558#top)
- [Webhook Receiver should support custom headers](https://github.com/grafana/alerting/issues/134#top)

Upstream Prometheus Alertmanager also has significant community requests, although consensus so far has been to keep the webhook notifier as-is with recommendations to set up a small web server to act as a webhook bridge:
- [it's more useful for webhook_config support template and custom the header](https://github.com/prometheus/alertmanager/issues/2268#top)
- [Added functionality to alter Webhook message](https://github.com/prometheus/alertmanager/pull/1422)
- [Reintroduce AWS SNS notifications](https://github.com/prometheus/alertmanager/pull/709#issuecomment-312595545)
- [Add templated text support for webhook receivers](https://github.com/prometheus/alertmanager/pull/2184#issuecomment-586647546)
- [Templating support for body of webhook_config](https://github.com/prometheus/alertmanager/issues/1496#issuecomment-409930740)
- [webhook custom style](https://github.com/prometheus/alertmanager/issues/3110#top)

## Future Work

- Import [gomplate](https://docs.gomplate.ca/) and expand template support to more namespaces.


## Custom Payload Examples

Could be as simple as writing JSON directly:
```json
{
  "alert_name": "{{ .CommonLabels.alertname }}",
  "status": "{{ .Status }}",
  "environment": "{{ .Vars.environment }}",
  "custom_field": "{{ .Vars.custom_field }}"
}
```
Or using new functions to help craft valid JSON:
```blade
  {{ coll.Dict 
  "receiver" .Receiver
  "status" .Status
  "alerts" .Alerts
  "groupLabels" .GroupLabels
  "commonLabels" .CommonLabels
  "commonAnnotations" .CommonAnnotations
  "externalURL" .ExternalURL
  "version" "1"
  "orgId"  (index .Alerts 0).OrgId
  "truncatedAlerts"  .TruncatedAlerts
  "groupKey" .GroupKey
  "state"  (tmpl.Inline "{{ if eq .Status \"resolved\" }}ok{{ else }}alerting{{ end }}" . )
  "title" (tmpl.Exec "default.title" . )
  "message" (tmpl.Exec "default.message" . )
  | data.ToJSONPretty " "}}
```

## Review Tips

- New gomplate-based functions are nearly 1:1 with the library, so testing was skipped given we're going to eventually remove these in favour of and import. Any differences are pointed out in comments.
- Grafana-side PR will be easier to test with as it will include UI support and enhancements to the template builder to help when creating JSON.

