### PR TITLE
Template factory

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -568,7 +568,14 @@ func TestReceivers(
 }
 
 func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []templates.TemplateDefinition, externalURL string, logger log.Logger) (*TestTemplatesResults, error) {
-	definitions, err := templates.ParseTestTemplate(c.Name, c.Template)
+
+	tc := templates.TemplateDefinition{
+		Name:     c.Name,
+		Template: c.Template,
+		Kind:     templates.GrafanaKind,
+	}
+
+	definitions, err := templates.ParseTemplateDefinition(tc)
 	if err != nil {
 		return &TestTemplatesResults{
 			Errors: []TestTemplatesErrorResult{{
@@ -576,12 +583,6 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 				Error: err.Error(),
 			}},
 		}, nil
-	}
-
-	tc := templates.TemplateDefinition{
-		Name:     c.Name,
-		Template: c.Template,
-		Kind:     templates.GrafanaKind,
 	}
 
 	// Recreate the current template replacing the definition blocks that are being tested. This is so that any blocks that were removed don't get defined.
@@ -612,6 +613,9 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 		return nil, err
 	}
 	newTmpl, err := factory.NewTemplate(tc.Kind, captureTemplate)
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepare the context.
 	alerts := OpenAPIAlertsToAlerts(c.Alerts)

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -599,7 +599,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmplsFac
 		}, nil
 	}
 
-	newTmpl, err := factory.NewTemplate(tc.Kind)
+	newTmpl, err := factory.GetTemplate(tc.Kind)
 	if err != nil {
 		return nil, err
 	}

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -583,6 +583,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 	tc := templates.TemplateDefinition{
 		Name:     c.Name,
 		Template: c.Template,
+		Kind:     templates.GrafanaKind,
 	}
 
 	// Recreate the current template replacing the definition blocks that are being tested. This is so that any blocks that were removed don't get defined.

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -588,7 +588,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 	var found bool
 	templateContents := make([]templates.TemplateDefinition, 0, len(tmpls)+1)
 	for _, td := range tmpls {
-		if td.Name == c.Name {
+		if td.Name == tc.Name && td.Kind == tc.Kind {
 			// Template already exists, test with the new definition replacing the old one.
 			templateContents = append(templateContents, tc)
 			found = true
@@ -607,10 +607,11 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []
 	var captureTemplate template.Option = func(text *tmpltext.Template, _ *tmplhtml.Template) {
 		newTextTmpl = text
 	}
-	newTmpl, err := templates.TemplateFromTemplateDefinitions(templateContents, logger, externalURL, captureTemplate)
+	factory, err := templates.NewFactory(templateContents, logger, externalURL)
 	if err != nil {
 		return nil, err
 	}
+	newTmpl, err := factory.NewTemplate(tc.Kind, captureTemplate)
 
 	// Prepare the context.
 	alerts := OpenAPIAlertsToAlerts(c.Alerts)

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -568,11 +568,13 @@ func TestReceivers(
 }
 
 func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmpls []templates.TemplateDefinition, externalURL string, logger log.Logger) (*TestTemplatesResults, error) {
-
 	tc := templates.TemplateDefinition{
 		Name:     c.Name,
 		Template: c.Template,
-		Kind:     templates.GrafanaKind,
+		Kind:     c.Kind,
+	}
+	if !templates.IsKnownKind(tc.Kind) {
+		tc.Kind = templates.GrafanaKind
 	}
 
 	definitions, err := templates.ParseTemplateDefinition(tc)

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/grafana/alerting/receivers"
 )
 
-func setupAMTest(t *testing.T) (*GrafanaAlertmanager, *prometheus.Registry) {
+type withOptsFn func(opts *GrafanaAlertmanagerOpts)
+
+func setupAMTest(t *testing.T, withOpts ...withOptsFn) (*GrafanaAlertmanager, *prometheus.Registry) {
 	t.Helper()
 
 	reg := prometheus.NewPedanticRegistry()
@@ -43,6 +45,9 @@ func setupAMTest(t *testing.T) (*GrafanaAlertmanager, *prometheus.Registry) {
 		EmailSender:   receivers.MockNotificationService(),
 		ImageProvider: images.NewFakeProvider(1),
 		Decrypter:     NoopDecrypt,
+	}
+	for _, fn := range withOpts {
+		fn(&opts)
 	}
 
 	require.NoError(t, opts.Validate())

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -108,10 +108,10 @@ func (e IntegrationTimeoutError) Error() string {
 
 func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, int, error) {
 	am.reloadConfigMtx.RLock()
-	cache := am.templates
+	templates := am.templates
 	am.reloadConfigMtx.RUnlock()
 
-	return TestReceivers(ctx, c, am.buildReceiverIntegrations, cache)
+	return TestReceivers(ctx, c, am.buildReceiverIntegrations, templates)
 }
 
 func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time) types.Alert {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/types"
@@ -40,7 +39,6 @@ import (
 	"github.com/grafana/alerting/receivers/webex"
 	"github.com/grafana/alerting/receivers/webhook"
 	"github.com/grafana/alerting/receivers/wecom"
-	"github.com/grafana/alerting/templates"
 )
 
 const (
@@ -110,13 +108,10 @@ func (e IntegrationTimeoutError) Error() string {
 
 func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiversConfigBodyParams) (*TestReceiversResult, int, error) {
 	am.reloadConfigMtx.RLock()
-
-	tmpls := make([]templates.TemplateDefinition, len(am.templates))
-	copy(tmpls, am.templates)
-
+	cache := am.templates
 	am.reloadConfigMtx.RUnlock()
 
-	return TestReceivers(ctx, c, tmpls, am.buildReceiverIntegrations, am.ExternalURL(), log.With(am.logger, "operation", "TestReceivers"))
+	return TestReceivers(ctx, c, am.buildReceiverIntegrations, cache)
 }
 
 func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time) types.Alert {

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -20,6 +20,9 @@ type TestTemplatesConfigBodyParams struct {
 
 	// Name of the template.
 	Name string
+
+	// Kind of template to test. Default is Grafana
+	Kind templates.Kind
 }
 
 type TestTemplatesResults struct {

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -93,7 +93,7 @@ func (s TemplateScope) Data(data *templates.ExtendedData) any {
 // If an existing template of the same filename as the one being tested is found, it will not be used as context.
 func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams) (*TestTemplatesResults, error) {
 	am.reloadConfigMtx.RLock()
-	templateFactory := am.templates.Factory()
+	templateFactory := am.templates
 	am.reloadConfigMtx.RUnlock()
 
 	return TestTemplate(ctx, c, templateFactory, log.With(am.logger, "operation", "TestTemplate"))

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -98,18 +98,17 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 	return TestTemplate(ctx, c, tmpls, am.ExternalURL(), log.With(am.logger, "operation", "TestTemplate"))
 }
 
-func (am *GrafanaAlertmanager) GetTemplate() (*template.Template, error) {
+func (am *GrafanaAlertmanager) GetTemplate(kind templates.Kind) (*template.Template, error) {
 	am.reloadConfigMtx.RLock()
 	tmpls := make([]templates.TemplateDefinition, len(am.templates))
 	copy(tmpls, am.templates)
 	am.reloadConfigMtx.RUnlock()
 
-	tmpl, err := templates.TemplateFromTemplateDefinitions(tmpls, am.logger, am.ExternalURL())
+	tmpl, err := templates.NewFactory(tmpls, am.logger, am.ExternalURL())
 	if err != nil {
 		return nil, err
 	}
-
-	return tmpl, nil
+	return tmpl.NewTemplate(kind)
 }
 
 // testTemplateScopes tests the given template with the root scope. If the root scope fails, it tries

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -374,6 +374,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Alerts:   []*amv2.PostableAlert{&simpleAlert},
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "slack.default.title" . }}{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		},
 		existingTemplates: nil,
 		expected: TestTemplatesResults{
@@ -390,10 +391,12 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Alerts:   []*amv2.PostableAlert{&simpleAlert},
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "existing" . }}{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		},
 		existingTemplates: []templates.TemplateDefinition{{
 			Name:     "existing",
 			Template: `{{ define "existing" }}Some existing template{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
@@ -409,10 +412,12 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Alerts:   []*amv2.PostableAlert{&simpleAlert},
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}New template{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		},
 		existingTemplates: []templates.TemplateDefinition{{
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}Some existing template{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{
@@ -428,10 +433,12 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Alerts:   []*amv2.PostableAlert{&simpleAlert},
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "slack.alternate_title" . }}{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		},
 		existingTemplates: []templates.TemplateDefinition{{
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}Some existing template{{ end }}{{ define "slack.alternate_title" }}Some existing alternate template{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		}},
 		expected: TestTemplatesResults{
 			Results: nil,
@@ -447,10 +454,12 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			Alerts:   []*amv2.PostableAlert{&simpleAlert},
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}{{ template "slack.alternate_title" . }}{{ end }}{{ define "slack.alternate_title" }}Some new alternate template{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		},
 		existingTemplates: []templates.TemplateDefinition{{
 			Name:     "slack.title",
 			Template: `{{ define "slack.title" }}Some existing template{{ end }}{{ define "slack.alternate_title" }}Some existing alternate template{{ end }}`,
+			Kind:     templates.GrafanaKind,
 		}},
 		expected: TestTemplatesResults{
 			Results: []TestTemplatesResult{{

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -478,7 +478,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if len(test.existingTemplates) > 0 {
 				var err error
-				am.templates, err = templates.NewCachedFactory(test.existingTemplates, log.NewNopLogger(), am.ExternalURL())
+				am.templates, err = templates.NewFactory(test.existingTemplates, log.NewNopLogger(), am.ExternalURL())
 				require.NoError(t, err)
 			}
 			res, err := am.TestTemplate(context.Background(), test.input)

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -152,7 +152,10 @@ func TestDefaultTemplateString(t *testing.T) {
 	tmplFromDefinition.ExternalURL = externalURL
 
 	var tmplDefErr error
-	expandFromDefinition, _ := TmplText(context.Background(), tmplFromDefinition, alerts, l, &tmplDefErr)
+	expandFromDefinition, _ := TmplText(context.Background(), &Template{
+		Template: tmplFromDefinition,
+		Text:     nil,
+	}, alerts, l, &tmplDefErr)
 
 	cases := []struct {
 		templateString string

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -38,7 +38,6 @@ func (tp *Factory) NewTemplate(kind Kind, options ...template.Option) (*Template
 }
 
 // WithTemplate creates a new factory that has the provided TemplateDefinition. If definition with the same name already exists for this kind, it is replaced.
-// If TemplateDefinition.Kind is not known, GrafanaKind automatically assumed.
 func (tp *Factory) WithTemplate(def TemplateDefinition) (*Factory, error) {
 	if err := ValidateKind(def.Kind); err != nil {
 		return nil, err

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -1,0 +1,104 @@
+package templates
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/alertmanager/template"
+)
+
+// Factory is a factory that can be used to create templates of specific kind.
+type Factory struct {
+	templates   map[Kind][]TemplateDefinition
+	externalURL *url.URL
+}
+
+// NewTemplate creates a new template of the given kind. If Kind is not known, GrafanaKind automatically assumed
+func (tp *Factory) NewTemplate(kind Kind, options ...template.Option) (*Template, error) {
+	if err := ValidateKind(kind); err != nil {
+		return nil, err
+	}
+	definitions := tp.templates[kind]
+	content := defaultTemplatesPerKind(kind)
+	for _, def := range definitions { // TODO sort the list by name?
+		content = append(content, def.Template)
+	}
+	t, err := fromContent(content, append(defaultOptionsPerKind(kind), options...)...)
+	if err != nil {
+		return nil, err
+	}
+	if tp.externalURL != nil {
+		t.ExternalURL = new(url.URL)
+		*t.ExternalURL = *tp.externalURL
+	}
+	return t, nil
+}
+
+// WithTemplate creates a new factory that has the provided TemplateDefinition. If definition with the same name already exists for this kind, it is replaced.
+// If TemplateDefinition.Kind is not known, GrafanaKind automatically assumed.
+func (tp *Factory) WithTemplate(def TemplateDefinition) (*Factory, error) {
+	if err := ValidateKind(def.Kind); err != nil {
+		return nil, err
+	}
+
+	added := false
+	templates := make(map[Kind][]TemplateDefinition, len(tp.templates))
+	for kind, definitions := range tp.templates {
+		if kind != def.Kind {
+			templates[kind] = definitions
+			continue
+		}
+		newDefinitions := make([]TemplateDefinition, 0, len(definitions)+1)
+		for _, d := range definitions {
+			if d.Name == def.Name {
+				newDefinitions = append(newDefinitions, def)
+				added = true
+				continue
+			}
+			newDefinitions = append(newDefinitions, d)
+		}
+		templates[kind] = newDefinitions
+	}
+	if !added {
+		templates[def.Kind] = append(templates[def.Kind], def)
+	}
+
+	return &Factory{
+		templates:   templates,
+		externalURL: tp.externalURL,
+	}, nil
+}
+
+// NewFactory creates a new template provider. Accepts list of user-defined templates that are added to the kind's default templates.
+// Returns error if externalURL is not a valid URL or if TemplateDefinition.Kind is not known.
+func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string) (*Factory, error) {
+	extURL, err := url.Parse(externalURL)
+	if err != nil {
+		return nil, err
+	}
+	type seenKey struct {
+		Name string
+		Type Kind
+	}
+	seen := map[seenKey]struct{}{}
+	byType := map[Kind][]TemplateDefinition{}
+
+	for _, def := range t {
+		if err := ValidateKind(def.Kind); err != nil {
+			return nil, fmt.Errorf("invalid template definition %s: %w", def.Name, err)
+		}
+		if _, ok := seen[seenKey{Name: def.Name, Type: def.Kind}]; ok {
+			level.Warn(logger).Log("msg", "template with same name is defined multiple times, skipping...", "template_name", def.Name, "template_type", def.Kind)
+			continue
+		}
+		byType[def.Kind] = append(byType[def.Kind], def)
+		seen[seenKey{Name: def.Name, Type: def.Kind}] = struct{}{}
+	}
+	provider := &Factory{
+		templates:   byType,
+		externalURL: extURL,
+	}
+	return provider, nil
+}

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/alertmanager/template"
 )
 
 // Factory is a factory that can be used to create templates of specific kind.
@@ -17,7 +16,7 @@ type Factory struct {
 }
 
 // NewTemplate creates a new template of the given kind. If Kind is not known, GrafanaKind automatically assumed
-func (tp *Factory) NewTemplate(kind Kind, options ...template.Option) (*Template, error) {
+func (tp *Factory) NewTemplate(kind Kind) (*Template, error) {
 	if err := ValidateKind(kind); err != nil {
 		return nil, err
 	}
@@ -26,7 +25,7 @@ func (tp *Factory) NewTemplate(kind Kind, options ...template.Option) (*Template
 	for _, def := range definitions { // TODO sort the list by name?
 		content = append(content, def.Template)
 	}
-	t, err := fromContent(content, append(defaultOptionsPerKind(kind), options...)...)
+	t, err := fromContent(content, append(defaultOptionsPerKind(kind))...)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -15,8 +15,8 @@ type Factory struct {
 	externalURL *url.URL
 }
 
-// NewTemplate creates a new template of the given kind. If Kind is not known, GrafanaKind automatically assumed
-func (tp *Factory) NewTemplate(kind Kind) (*Template, error) {
+// GetTemplate creates a new template of the given kind. If Kind is not known, GrafanaKind automatically assumed
+func (tp *Factory) GetTemplate(kind Kind) (*Template, error) {
 	if err := ValidateKind(kind); err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (cf *CachedFactory) GetTemplate(kind Kind) (*Template, error) {
 	if t, ok := cf.m[kind]; ok {
 		return t, nil
 	}
-	t, err := cf.factory.NewTemplate(kind)
+	t, err := cf.factory.GetTemplate(kind)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -25,7 +25,7 @@ func (tp *Factory) GetTemplate(kind Kind) (*Template, error) {
 	for _, def := range definitions { // TODO sort the list by name?
 		content = append(content, def.Template)
 	}
-	t, err := fromContent(content, append(defaultOptionsPerKind(kind))...)
+	t, err := fromContent(content, defaultOptionsPerKind(kind)...)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -102,15 +102,11 @@ func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string) (
 	return provider, nil
 }
 
-func NewCachedFactory(t []TemplateDefinition, logger log.Logger, externalURL string) (*CachedFactory, error) {
-	factory, err := NewFactory(t, logger, externalURL)
-	if err != nil {
-		return nil, err
-	}
+func NewCachedFactory(factory *Factory) *CachedFactory {
 	return &CachedFactory{
 		factory: factory,
 		m:       make(map[Kind]*Template, len(validKinds)),
-	}, nil
+	}
 }
 
 // CachedFactory is responsible for managing template instances grouped by their kind.

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -144,7 +144,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 	maps.Copy(seen, validKinds)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			templ, err := f.NewTemplate(tc.kind)
+			templ, err := f.GetTemplate(tc.kind)
 			assert.NoError(t, err)
 			require.NotNil(t, templ)
 			var tmplErr error
@@ -163,7 +163,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 
 	t.Run("should apply user-defined templates", func(t *testing.T) {
 		for kind := range validKinds {
-			templ, err := f.NewTemplate(kind)
+			templ, err := f.GetTemplate(kind)
 			require.NoError(t, err)
 			var tmplErr error
 			tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -182,14 +182,14 @@ func TestFactoryNewTemplate(t *testing.T) {
 			},
 		}, log.NewNopLogger(), "http://localhost")
 		require.NoError(t, err)
-		templ, err := f.NewTemplate(GrafanaKind)
+		templ, err := f.GetTemplate(GrafanaKind)
 		require.NoError(t, err)
 		var tmplErr error
 		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
 		result := tmpl(`{{ template "factory_test" . }}`)
 		require.NoError(t, tmplErr)
 		require.Equal(t, `TEST Grafana KIND`, result)
-		templ, err = f.NewTemplate(MimirKind)
+		templ, err = f.GetTemplate(MimirKind)
 		require.NoError(t, err)
 		require.NotNil(t, templ)
 		tmpl, _ = TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -204,7 +204,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	initial := TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST{{ end }}`}
 	f, err := NewFactory([]TemplateDefinition{initial}, log.NewNopLogger(), "http://localhost")
 	require.NoError(t, err)
-	templ, err := f.NewTemplate(kind)
+	templ, err := f.GetTemplate(kind)
 	require.NoError(t, err)
 	var tmplErr error
 	tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -215,7 +215,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	t.Run("should add new template", func(t *testing.T) {
 		f2, err := f.WithTemplate(TemplateDefinition{Name: "test2", Kind: kind, Template: `{{ define "factory_test2" }}TEST2{{ end }}`})
 		require.NoError(t, err)
-		templ, err := f2.NewTemplate(kind)
+		templ, err := f2.GetTemplate(kind)
 		require.NoError(t, err)
 		var tmplErr error
 		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -227,7 +227,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	t.Run("should replace existing template", func(t *testing.T) {
 		f2, err := f.WithTemplate(TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST2{{ end }}`})
 		require.NoError(t, err)
-		templ, err := f2.NewTemplate(kind)
+		templ, err := f2.GetTemplate(kind)
 		require.NoError(t, err)
 		var tmplErr error
 		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -1,0 +1,243 @@
+package templates
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFactory(t *testing.T) {
+	logger := log.NewNopLogger()
+	externalURL := "http://localhost:3000"
+	tests := []struct {
+		name        string
+		templates   []TemplateDefinition
+		expectError error
+
+		expected map[Kind][]TemplateDefinition // Expected templates grouped by kind
+	}{
+		{
+			name:      "valid templates, no duplicates",
+			templates: []TemplateDefinition{{Name: "t1", Kind: GrafanaKind}, {Name: "t2", Kind: MimirKind}},
+			expected: map[Kind][]TemplateDefinition{
+				GrafanaKind: {{Name: "t1", Kind: GrafanaKind}},
+				MimirKind:   {{Name: "t2", Kind: MimirKind}},
+			},
+		},
+		{
+			name:      "empty templates",
+			templates: nil,
+			expected:  map[Kind][]TemplateDefinition{},
+		},
+		{
+			name:      "duplicate templates",
+			templates: []TemplateDefinition{{Name: "t1", Kind: GrafanaKind, Template: "TEST1"}, {Name: "t1", Kind: GrafanaKind, Template: "TEST2"}},
+			expected: map[Kind][]TemplateDefinition{
+				GrafanaKind: {{Name: "t1", Kind: GrafanaKind, Template: "TEST1"}},
+			},
+		},
+		{
+			name:        "unknown kind defaults to GrafanaKind",
+			templates:   []TemplateDefinition{{Name: "t1", Kind: 1234}},
+			expectError: ErrInvalidKind,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			factory, err := NewFactory(tc.templates, logger, externalURL)
+			if tc.expectError != nil {
+				require.ErrorIs(t, err, ErrInvalidKind)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, externalURL, factory.externalURL.String())
+			// Validate the templates map
+			for kind, expectedTemplates := range tc.expected {
+				require.ElementsMatch(t, expectedTemplates, factory.templates[kind])
+			}
+		})
+	}
+
+	t.Run("error if external URL is invalid", func(t *testing.T) {
+		_, err := NewFactory([]TemplateDefinition{{Name: "t1", Kind: GrafanaKind}}, logger, ":::")
+		require.Error(t, err)
+	})
+}
+
+func TestFactoryNewTemplate(t *testing.T) {
+	as := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
+				StartsAt: timeNow().Add(-1 * time.Hour),
+				EndsAt:   timeNow().Add(1 * time.Hour),
+				Annotations: model.LabelSet{
+					"description": "alert1 description",
+					"summary":     "alert1 summary",
+				},
+			},
+			UpdatedAt: timeNow(),
+			Timeout:   false,
+		},
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
+				StartsAt: timeNow().Add(-2 * time.Hour),
+				EndsAt:   timeNow().Add(-1 * time.Hour),
+				Annotations: model.LabelSet{
+					"description": "alert1 description",
+					"summary":     "alert1 summary",
+				},
+			},
+			UpdatedAt: timeNow(),
+			Timeout:   false,
+		},
+	}
+
+	var def []TemplateDefinition
+	for kind := range validKinds {
+		def = append(def, TemplateDefinition{
+			Name:     "test",
+			Kind:     kind,
+			Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, kind),
+		})
+	}
+	f, err := NewFactory(def, log.NewNopLogger(), "http://localhost")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		kind     Kind
+		template string
+		expected string
+		err      string
+	}{
+		{
+			name:     "Grafana template for Grafana kind",
+			kind:     GrafanaKind,
+			template: `{{ template "default.title" . }}`,
+			expected: "[FIRING:1, RESOLVED:1]  (alert1 val1)",
+		},
+		{
+			name:     "Grafana template does not work for Prometheus kind",
+			kind:     MimirKind,
+			template: `{{ template "default.title" . }}`,
+			err:      `template "default.title" not defined`,
+		},
+		{
+			name:     "Promtheus template for Prometheus kind",
+			kind:     MimirKind,
+			template: `{{ template "__subject" . }}`,
+			expected: `[FIRING:1]  (alert1 val1)`,
+		},
+	}
+	seen := make(map[Kind]struct{}, len(validKinds))
+	maps.Copy(seen, validKinds)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			templ, err := f.NewTemplate(tc.kind)
+			assert.NoError(t, err)
+			require.NotNil(t, templ)
+			var tmplErr error
+			tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+			result := tmpl(tc.template)
+			if tc.err != "" {
+				assert.ErrorContains(t, tmplErr, tc.err)
+			} else {
+				assert.Equal(t, tc.expected, result)
+				assert.NoError(t, tmplErr)
+			}
+		})
+		delete(seen, tc.kind)
+	}
+	assert.Empty(t, seen)
+
+	t.Run("should apply user-defined templates", func(t *testing.T) {
+		for kind := range validKinds {
+			templ, err := f.NewTemplate(kind)
+			require.NoError(t, err)
+			var tmplErr error
+			tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+			result := tmpl(`{{ template "factory_test" . }}`)
+			require.NoError(t, tmplErr)
+			require.Equal(t, fmt.Sprintf(`TEST %s KIND`, kind), result)
+		}
+	})
+
+	t.Run("user-defined template only applies to the given kind", func(t *testing.T) {
+		f, err := NewFactory([]TemplateDefinition{
+			{
+				Name:     "test",
+				Kind:     GrafanaKind,
+				Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, GrafanaKind),
+			},
+		}, log.NewNopLogger(), "http://localhost")
+		require.NoError(t, err)
+		templ, err := f.NewTemplate(GrafanaKind)
+		require.NoError(t, err)
+		var tmplErr error
+		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+		result := tmpl(`{{ template "factory_test" . }}`)
+		require.NoError(t, tmplErr)
+		require.Equal(t, `TEST Grafana KIND`, result)
+		templ, err = f.NewTemplate(MimirKind)
+		require.NoError(t, err)
+		require.NotNil(t, templ)
+		tmpl, _ = TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+		_ = tmpl(`{{ template "factory_test" . }}`)
+		require.ErrorContains(t, tmplErr, `template "factory_test" not defined`)
+	})
+}
+
+func TestFactoryWithTemplate(t *testing.T) {
+	as := []*types.Alert{{}}
+	kind := GrafanaKind
+	initial := TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST{{ end }}`}
+	f, err := NewFactory([]TemplateDefinition{initial}, log.NewNopLogger(), "http://localhost")
+	require.NoError(t, err)
+	templ, err := f.NewTemplate(kind)
+	require.NoError(t, err)
+	var tmplErr error
+	tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+	result := tmpl(`{{ template "factory_test" . }}`)
+	require.NoError(t, tmplErr)
+	assert.Equal(t, `TEST`, result)
+
+	t.Run("should add new template", func(t *testing.T) {
+		f2, err := f.WithTemplate(TemplateDefinition{Name: "test2", Kind: kind, Template: `{{ define "factory_test2" }}TEST2{{ end }}`})
+		require.NoError(t, err)
+		templ, err := f2.NewTemplate(kind)
+		require.NoError(t, err)
+		var tmplErr error
+		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+		result := tmpl(`{{ template "factory_test2" . }}`)
+		require.NoError(t, tmplErr)
+		require.Equal(t, `TEST2`, result)
+	})
+
+	t.Run("should replace existing template", func(t *testing.T) {
+		f2, err := f.WithTemplate(TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST2{{ end }}`})
+		require.NoError(t, err)
+		templ, err := f2.NewTemplate(kind)
+		require.NoError(t, err)
+		var tmplErr error
+		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+		result := tmpl(`{{ template "factory_test" . }}`)
+		require.NoError(t, tmplErr)
+		require.Equal(t, `TEST2`, result)
+	})
+
+	t.Run("should fail if kind is not known", func(t *testing.T) {
+		_, err := f.WithTemplate(TemplateDefinition{Name: "test", Kind: 1234, Template: `{{ define "factory_test" }}TEST{{ end }}`})
+		require.ErrorIs(t, err, ErrInvalidKind)
+	})
+}

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -73,6 +73,8 @@ type TemplateDefinition struct {
 	Name string
 	// Template string that contains the template text.
 	Template string
+	// Kind of the template. Determines which base templates and functions are available.
+	Kind Kind
 }
 
 type ExtendedAlert struct {
@@ -159,6 +161,7 @@ func DefaultTemplate(options ...template.Option) (TemplateDefinition, error) {
 	return TemplateDefinition{
 		Name:     DefaultTemplateName,
 		Template: combinedTemplate.String(),
+		Kind:     GrafanaKind,
 	}, nil
 }
 

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -77,6 +77,22 @@ type TemplateDefinition struct {
 	Kind Kind
 }
 
+func (t TemplateDefinition) Validate() error {
+	if !IsKnownKind(t.Kind) {
+		return fmt.Errorf("template kind is unknown")
+	}
+	// Validate template contents. We try to stick as close to what will actually happen when the templates are parsed
+	// by the alertmanager as possible.
+	tmpl, err := template.New(defaultOptionsPerKind(t.Kind)...)
+	if err != nil {
+		return fmt.Errorf("failed to create template: %w", err)
+	}
+	if err := tmpl.Parse(strings.NewReader(t.Template)); err != nil {
+		return fmt.Errorf("invalid template: %w", err)
+	}
+	return nil
+}
+
 type ExtendedAlert struct {
 	Status        string             `json:"status"`
 	Labels        KV                 `json:"labels"`

--- a/templates/util.go
+++ b/templates/util.go
@@ -110,19 +110,24 @@ func checkNode(node parse.Node, executedTmpls map[string]struct{}) {
 	}
 }
 
-// ParseTestTemplate parses the test template and returns the top-level definitions that should be interpolated as results.
-func ParseTestTemplate(name string, text string) ([]string, error) {
+// ParseTemplateDefinition parses the test template and returns the top-level definitions that should be interpolated as results.
+// If TemplateDefinition.Kind is not known, GrafanaKind is assumed
+func ParseTemplateDefinition(def TemplateDefinition) ([]string, error) {
+	if err := ValidateKind(def.Kind); err != nil {
+		return nil, err
+	}
+
 	var tmpl *tmpltext.Template
 	var capture template.Option = func(text *tmpltext.Template, _ *tmplhtml.Template) {
 		tmpl = text
 	}
 
-	_, err := template.New(append(defaultOptionsPerKind(GrafanaKind), capture)...)
+	_, err := template.New(append(defaultOptionsPerKind(def.Kind), capture)...)
 	if err != nil {
 		return nil, err
 	}
 
-	tmpl, err = tmpl.New(name).Parse(text)
+	tmpl, err = tmpl.New(def.Name).Parse(def.Template)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/util.go
+++ b/templates/util.go
@@ -3,13 +3,10 @@ package templates
 import (
 	"fmt"
 	tmplhtml "html/template"
-	"net/url"
 	"sort"
 	tmpltext "text/template"
 	"text/template/parse"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/alertmanager/template"
 )
 
@@ -136,29 +133,4 @@ func ParseTestTemplate(name string, text string) ([]string, error) {
 	}
 
 	return topLevel, nil
-}
-
-// TemplateFromTemplateDefinitions returns a *Template based on defaults and the provided template contents.
-func TemplateFromTemplateDefinitions(templates []TemplateDefinition, logger log.Logger, externalURL string, options ...template.Option) (*Template, error) {
-	seen := make(map[string]struct{})
-	tmpls := make([]string, 0, len(templates))
-	for _, tc := range templates {
-		if _, ok := seen[tc.Name]; ok {
-			level.Warn(logger).Log("msg", "template with same name is defined multiple times, skipping...", "template_name", tc.Name)
-			continue
-		}
-		tmpls = append(tmpls, tc.Template)
-		seen[tc.Name] = struct{}{}
-	}
-
-	tmpl, err := fromContent(append(defaultTemplatesPerKind(GrafanaKind), tmpls...), append(defaultOptionsPerKind(GrafanaKind), options...)...)
-	if err != nil {
-		return nil, err
-	}
-	extURL, err := url.Parse(externalURL)
-	if err != nil {
-		return nil, err
-	}
-	tmpl.ExternalURL = extURL
-	return tmpl, nil
 }


### PR DESCRIPTION
This PR is continuation of refactoring https://github.com/grafana/alerting/pull/327. 
- It replaces function TemplateFromTemplateDefinitions by a Factory that provides the templates depending on kind. 
- A new field Kind is added to TemplateDefinition, which lets us combine definitions of different kinds.

Usages are updated to use factory, which effectively allows creating Prometheus or Grafana template depending on context. 

Related to https://github.com/grafana/alerting-squad/issues/1113