### PR TITLE
Refactor Grafana Alertmanager

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -112,7 +112,7 @@ type GrafanaAlertmanager struct {
 
 	emailSender   receivers.EmailSender
 	imageProvider images.Provider
-	decrtypter    GetDecryptedValueFn
+	decrypter     GetDecryptedValueFn
 	loggerFactory logging.LoggerFactory
 
 	version string
@@ -211,7 +211,7 @@ func (c *GrafanaAlertmanagerOpts) Validate() error {
 	}
 
 	if c.Decrtypter == nil {
-		return errors.New("decrtypter must be present")
+		return errors.New("decrypter must be present")
 	}
 
 	if c.LoggerFactory == nil {
@@ -255,7 +255,7 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 		tenantID:          opts.TenantID,
 		externalURL:       opts.ExternalURL,
 		loggerFactory:     opts.LoggerFactory,
-		decrtypter:        opts.Decrtypter,
+		decrypter:         opts.Decrtypter,
 		version:           opts.Version,
 		emailSender:       opts.EmailSender,
 		imageProvider:     opts.ImageProvider,
@@ -976,7 +976,7 @@ func (am *GrafanaAlertmanager) tenantString() string {
 }
 
 func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver *APIReceiver, tmpl *templates.Template) ([]*Integration, error) {
-	receiverCfg, err := BuildReceiverConfiguration(context.Background(), receiver, DecodeSecretsFromBase64, am.decrtypter)
+	receiverCfg, err := BuildReceiverConfiguration(context.Background(), receiver, DecodeSecretsFromBase64, am.decrypter)
 	if err != nil {
 		return nil, err
 	}

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -257,6 +257,8 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 		loggerFactory:     opts.LoggerFactory,
 		decrtypter:        opts.Decrtypter,
 		version:           opts.Version,
+		emailSender:       opts.EmailSender,
+		imageProvider:     opts.ImageProvider,
 	}
 
 	var err error

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -328,6 +328,10 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 	return am, nil
 }
 
+func (am *GrafanaAlertmanager) TenantID() int64 {
+	return am.tenantID
+}
+
 func (am *GrafanaAlertmanager) Ready() bool {
 	// We consider AM as ready only when the config has been
 	// applied at least once successfully. Until then, some objects

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -984,7 +984,7 @@ func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver *APIReceiver, 
 		am.imageProvider,
 		// TODO change it to use AM's logger with and add type as label
 		am.loggerFactory,
-		func(n receivers.Metadata) (receivers.EmailSender, error) {
+		func(_ receivers.Metadata) (receivers.EmailSender, error) {
 			return am.emailSender, nil
 		},
 		func(_ string, n Notifier) Notifier {

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -44,7 +44,7 @@ func setupAMTest(t *testing.T) (*GrafanaAlertmanager, *prometheus.Registry) {
 		EmailSender:   receivers.MockNotificationService(),
 		ImageProvider: images.NewFakeProvider(1),
 		Decrtypter:    NoopDecrypt,
-		LoggerFactory: func(loggerName string, ctx ...interface{}) logging.Logger {
+		LoggerFactory: func(_ string, _ ...interface{}) logging.Logger {
 			return logging.FakeLogger{}
 		},
 	}

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/images"
@@ -44,7 +43,7 @@ func setupAMTest(t *testing.T) (*GrafanaAlertmanager, *prometheus.Registry) {
 		Metrics:       NewGrafanaAlertmanagerMetrics(reg, log.NewNopLogger()),
 		EmailSender:   receivers.MockNotificationService(),
 		ImageProvider: images.NewFakeProvider(1),
-		Decrtypter:    NoopDecrypt,
+		Decrypter:     NoopDecrypt,
 		LoggerFactory: func(_ string, _ ...interface{}) logging.Logger {
 			return logging.FakeLogger{}
 		},
@@ -622,43 +621,6 @@ func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
         	            	grafana_alerting_alertmanager_receivers{org="1",state="active"} 2
         	            	grafana_alerting_alertmanager_receivers{org="1",state="inactive"} 2
 `), "grafana_alerting_alertmanager_receivers", "grafana_alerting_alertmanager_integrations"))
-}
-
-func TestNewGrafanaAlertmanager(t *testing.T) {
-	reg := prometheus.NewPedanticRegistry()
-
-	opts := GrafanaAlertmanagerOpts{
-		Silences: newFakeMaintanenceOptions(t),
-		Nflog:    newFakeMaintanenceOptions(t),
-
-		TenantKey:     "org",
-		TenantID:      1,
-		Peer:          &NilPeer{},
-		Logger:        log.NewNopLogger(),
-		Metrics:       NewGrafanaAlertmanagerMetrics(reg, log.NewNopLogger()),
-		EmailSender:   receivers.MockNotificationService(),
-		ImageProvider: images.NewFakeProvider(1),
-		Decrtypter:    NoopDecrypt,
-		LoggerFactory: func(_ string, _ ...interface{}) logging.Logger {
-			return logging.FakeLogger{}
-		},
-	}
-
-	require.NoError(t, opts.Validate())
-
-	am, err := NewGrafanaAlertmanager(opts)
-	require.NoError(t, err)
-
-	assert.Equal(t, opts.TenantID, am.tenantID)
-	assert.Equal(t, opts.Peer, am.peer)
-	assert.Equal(t, opts.Metrics, am.Metrics)
-	assert.Equal(t, opts.EmailSender, am.emailSender)
-	assert.Equal(t, opts.ImageProvider, am.imageProvider)
-	assert.NotNil(t, opts.Decrtypter)
-	assert.NotNil(t, opts.LoggerFactory)
-	assert.NotNil(t, am.silences)
-	assert.NotNil(t, am.notificationLog)
-	assert.NotNil(t, am.alerts)
 }
 
 // Tests cleanup of expired Silences. We rely on prometheus/alertmanager for

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -116,7 +116,7 @@ func (am *GrafanaAlertmanager) TestReceivers(ctx context.Context, c TestReceiver
 
 	am.reloadConfigMtx.RUnlock()
 
-	return TestReceivers(ctx, c, tmpls, am.buildReceiverIntegrationsFunc, am.ExternalURL())
+	return TestReceivers(ctx, c, tmpls, am.buildReceiverIntegrations, am.ExternalURL())
 }
 
 func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time) types.Alert {

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -477,7 +477,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 
 func TestTemplateAlertData(t *testing.T) {
 	am, _ := setupAMTest(t)
-	am.externalURL = "http://localhost:9093"
+	am.opts.ExternalURL = "http://localhost:9093"
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This pull request introduces significant refactoring and enhancements to the `GrafanaAlertmanager` implementation in the `notify` package. The changes focus on improving configuration management, adding new dependencies, and simplifying the construction of `GrafanaAlertmanager` instances. Key updates include replacing the `GrafanaAlertmanagerConfig` struct with `GrafanaAlertmanagerOpts`, introducing new fields and validation logic, and refactoring the configuration application process to improve maintainability and extensibility.

### Refactoring and Configuration Updates:
* Replaced `GrafanaAlertmanagerConfig` with `GrafanaAlertmanagerOpts`, which includes additional fields such as `EmailSender`, `ImageProvider`, `Decrtypter`, `LoggerFactory`, `Version`, `TenantKey`, and `TenantID`. Most of those fields are needed to build notifiers. Added validation logic to ensure all required fields are present.
* Refactored `ApplyConfig` to use the new `NotificationsConfiguration` struct, which consolidates configuration fields like `RoutingTree`, `InhibitRules`, and `Receivers`. Removed the `BuildReceiverIntegrationsFunc` method in favor of a new `buildReceiverIntegrations` method which is the carbon copy of the method in Grafana repository.

### Dependency Injection Enhancements:
* Added support for injecting dependencies like `EmailSender`, `ImageProvider`, and `LoggerFactory` into `GrafanaAlertmanager` to improve testability and flexibility.

### Constructor Simplification:
* Simplified the `NewGrafanaAlertmanager` constructor by replacing multiple parameters with the new `GrafanaAlertmanagerOpts` struct. This change reduces the complexity of creating `GrafanaAlertmanager` instances.