### PR TITLE
BuildReceiverIntegrations to use single email sender

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -2,7 +2,6 @@ package notify
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -12,12 +11,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/alertmanager/notify"
+
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/logging"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
-	"github.com/prometheus/alertmanager/notify"
 )
 
 func TestBuildReceiverIntegrations(t *testing.T) {
@@ -26,9 +26,8 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	imageProvider := &images.URLProvider{}
 	tmpl := templates.ForTests(t)
 
-	emailFactory := func(_ receivers.Metadata) (receivers.EmailSender, error) {
-		return receivers.MockNotificationService(), nil
-	}
+	emailService := receivers.MockNotificationService()
+
 	loggerFactory := func(_ string, _ ...interface{}) logging.Logger {
 		return &logging.FakeLogger{}
 	}
@@ -53,26 +52,16 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			return &logging.FakeLogger{}
 		}
 
-		emails := make(map[receivers.Metadata]struct{}, qty)
-		em := func(n receivers.Metadata) (receivers.EmailSender, error) {
-			emails[n] = struct{}{}
-			return emailFactory(n)
-		}
-
 		wrapped := 0
 		notifyWrapper := func(_ string, n Notifier) Notifier {
 			wrapped++
 			return n
 		}
 
-		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, logger, em, notifyWrapper, orgID, version)
+		integrations := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, logger, emailService, notifyWrapper, orgID, version)
 
-		require.NoError(t, err)
 		require.Len(t, integrations, qty)
 
-		t.Run("should call email factory for each config that needs it", func(t *testing.T) {
-			require.Len(t, emails, 1) // we have only email notifier that needs sender
-		})
 		t.Run("should call notify wrapper for each config", func(t *testing.T) {
 			require.Equal(t, qty, wrapped)
 		})
@@ -94,8 +83,8 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 				}),
 			}
 
-			integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, logger, em, notifyWrapper, orgID, version, clientOpts...)
-			require.NoError(t, err)
+			integrations := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, logger, emailService, notifyWrapper, orgID, version, clientOpts...)
+
 			require.Len(t, integrations, qty)
 			for _, integration := range integrations {
 				if integration.Name() == "email" {
@@ -127,27 +116,10 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			}
 		})
 	})
-	t.Run("should return errors if email factory fails", func(t *testing.T) {
-		fullCfg, _ := getFullConfig(t)
-		calls := 0
-		failingFactory := func(_ receivers.Metadata) (receivers.EmailSender, error) {
-			calls++
-			return nil, errors.New("bad-test")
-		}
-
-		integrations, err := BuildReceiverIntegrations(fullCfg, tmpl, imageProvider, loggerFactory, failingFactory, noopWrapper, orgID, version)
-
-		require.Empty(t, integrations)
-		require.NotNil(t, err)
-		require.ErrorContains(t, err, "bad-test")
-		require.Greater(t, calls, 0)
-	})
 	t.Run("should not produce any integration if config is empty", func(t *testing.T) {
 		cfg := GrafanaReceiverConfig{Name: "test"}
 
-		integrations, err := BuildReceiverIntegrations(cfg, tmpl, imageProvider, loggerFactory, emailFactory, noopWrapper, orgID, version)
-
-		require.NoError(t, err)
+		integrations := BuildReceiverIntegrations(cfg, tmpl, imageProvider, loggerFactory, emailService, noopWrapper, orgID, version)
 		require.Empty(t, integrations)
 	})
 }

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -958,23 +958,18 @@ func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver *APIReceiver, 
 	if err != nil {
 		return nil, err
 	}
-	integrations, err := BuildReceiverIntegrations(
+	integrations := BuildReceiverIntegrations(
 		receiverCfg,
 		tmpl,
 		am.opts.ImageProvider,
 		// TODO change it to use AM's logger with and add type as label
 		am.opts.LoggerFactory,
-		func(_ receivers.Metadata) (receivers.EmailSender, error) {
-			return am.opts.EmailSender, nil
-		},
+		am.opts.EmailSender,
 		func(_ string, n Notifier) Notifier {
 			return n
 		},
 		am.opts.TenantID,
 		am.opts.Version,
 	)
-	if err != nil {
-		return nil, err
-	}
 	return integrations, nil
 }

--- a/receivers/email_sender.go
+++ b/receivers/email_sender.go
@@ -44,7 +44,7 @@ type defaultEmailSender struct {
 	dialFn func(*defaultEmailSender) (gomail.SendCloser, error)
 }
 
-// NewEmailSender takes a configuration and returns a new EmailSender factory function.
+// NewEmailSender takes a configuration and returns a new EmailSender.
 func NewEmailSender(cfg EmailSenderConfig) (EmailSender, error) {
 	tmpl, err := template.New("templates").
 		Funcs(template.FuncMap{

--- a/receivers/email_sender.go
+++ b/receivers/email_sender.go
@@ -44,26 +44,24 @@ type defaultEmailSender struct {
 	dialFn func(*defaultEmailSender) (gomail.SendCloser, error)
 }
 
-// NewEmailSenderFactory takes a configuration and returns a new EmailSender factory function.
-func NewEmailSenderFactory(cfg EmailSenderConfig) func(Metadata) (EmailSender, error) {
-	return func(_ Metadata) (EmailSender, error) {
-		tmpl, err := template.New("templates").
-			Funcs(template.FuncMap{
-				"Subject":                 subjectTemplateFunc,
-				"__dangerouslyInjectHTML": __dangerouslyInjectHTML,
-			}).Funcs(sprig.FuncMap()).
-			ParseFS(defaultEmailTemplate, "templates/*")
-		if err != nil {
-			return nil, err
-		}
-		return &defaultEmailSender{
-			cfg:  cfg,
-			tmpl: tmpl,
-			dialFn: func(s *defaultEmailSender) (gomail.SendCloser, error) {
-				return s.dial()
-			},
-		}, nil
+// NewEmailSender takes a configuration and returns a new EmailSender factory function.
+func NewEmailSender(cfg EmailSenderConfig) (EmailSender, error) {
+	tmpl, err := template.New("templates").
+		Funcs(template.FuncMap{
+			"Subject":                 subjectTemplateFunc,
+			"__dangerouslyInjectHTML": __dangerouslyInjectHTML,
+		}).Funcs(sprig.FuncMap()).
+		ParseFS(defaultEmailTemplate, "templates/*")
+	if err != nil {
+		return nil, err
 	}
+	return &defaultEmailSender{
+		cfg:  cfg,
+		tmpl: tmpl,
+		dialFn: func(s *defaultEmailSender) (gomail.SendCloser, error) {
+			return s.dial()
+		},
+	}, nil
 }
 
 // Message representats an email message.

--- a/receivers/email_sender_test.go
+++ b/receivers/email_sender_test.go
@@ -15,7 +15,7 @@ import (
 func TestEmbedTemplate(t *testing.T) {
 	// Test the email templates are embedded and parsed correctly.
 	require.NotEmpty(t, defaultEmailTemplate)
-	s, err := NewEmailSenderFactory(EmailSenderConfig{})(Metadata{})
+	s, err := NewEmailSender(EmailSenderConfig{})
 	require.NoError(t, err)
 
 	ds, ok := s.(*defaultEmailSender)
@@ -95,11 +95,11 @@ func TestBuildEmailMessage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s, err := NewEmailSenderFactory(EmailSenderConfig{
+			s, err := NewEmailSender(EmailSenderConfig{
 				ContentTypes: test.contentTypes,
 				ExternalURL:  externalURL,
 				SentBy:       sentBy,
-			})(Metadata{})
+			})
 			require.NoError(t, err)
 			ds, ok := s.(*defaultEmailSender)
 			require.True(t, ok)
@@ -178,7 +178,7 @@ func TestCreateDialer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s, err := NewEmailSenderFactory(test.cfg)(Metadata{})
+			s, err := NewEmailSender(test.cfg)
 			require.NoError(t, err)
 			ds, ok := s.(*defaultEmailSender)
 			require.True(t, ok)
@@ -206,7 +206,7 @@ func TestBuildEmail(t *testing.T) {
 		},
 	}
 
-	s, err := NewEmailSenderFactory(cfg)(Metadata{})
+	s, err := NewEmailSender(cfg)
 	require.NoError(t, err)
 	ds, ok := s.(*defaultEmailSender)
 	require.True(t, ok)


### PR DESCRIPTION
This PR refactors function BuildReceiverIntegrations to accept only single EmailSender instead of a factory function.
This simplifies the function interfaces and its usages.