### PR TITLE
Copy Mimir templates

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -301,7 +301,7 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 		return nil, fmt.Errorf("unable to initialize the alert provider component of alerting: %w", err)
 	}
 
-	am.templates, err = templates.NewFactory(nil, am.logger, am.ExternalURL())
+	am.templates, err = templates.NewFactory(nil, am.logger, am.ExternalURL(), fmt.Sprintf("%d", am.TenantID()))
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +677,7 @@ func (am *GrafanaAlertmanager) buildTimeIntervals(timeIntervals []config.TimeInt
 // ApplyConfig applies a new configuration by re-initializing all components using the configuration provided.
 // It is not safe to call concurrently.
 func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err error) {
-	factory, err := templates.NewFactory(cfg.Templates, am.logger, am.ExternalURL())
+	factory, err := templates.NewFactory(cfg.Templates, am.logger, am.ExternalURL(), fmt.Sprintf("%d", am.TenantID()))
 	if err != nil {
 		return err
 	}

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -478,7 +478,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if len(test.existingTemplates) > 0 {
 				var err error
-				am.templates, err = templates.NewFactory(test.existingTemplates, log.NewNopLogger(), am.ExternalURL())
+				am.templates, err = templates.NewFactory(test.existingTemplates, log.NewNopLogger(), am.ExternalURL(), "grafana")
 				require.NoError(t, err)
 			}
 			res, err := am.TestTemplate(context.Background(), test.input)

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -200,7 +200,7 @@ Labels:
 `
 
 func ForTests(t *testing.T) *Template {
-	tmpl, err := fromContent(append(defaultTemplatesPerKind(GrafanaKind), TemplateForTestsString), defaultOptionsPerKind(GrafanaKind)...)
+	tmpl, err := fromContent(append(defaultTemplatesPerKind(GrafanaKind), TemplateForTestsString), defaultOptionsPerKind(GrafanaKind, "grafana")...)
 	require.NoError(t, err)
 	externalURL, err := url.Parse("http://test.com")
 	require.NoError(t, err)

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -130,7 +130,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	alert1Dashboard := fmt.Sprintf("http://localhost/grafana/d/dbuid123?from=%d&orgId=1&to=%d", alerts[0].StartsAt.Add(-time.Hour).UnixMilli(), constNow.UnixMilli())         // Firing.
 	alert4Dashboard := fmt.Sprintf("http://localhost/grafana/d/dbuid456?from=%d&orgId=1&to=%d", alerts[3].StartsAt.Add(-time.Hour).UnixMilli(), alerts[3].EndsAt.UnixMilli()) // Resolved.
 
-	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind)...)
+	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind, "grafana")...)
 	require.NoError(t, err)
 
 	externalURL, err := url.Parse("http://localhost/grafana")
@@ -144,7 +144,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	tmplDef, err := DefaultTemplate()
 	require.NoError(t, err)
 
-	tmplFromDefinition, err := template.New(defaultOptionsPerKind(GrafanaKind)...)
+	tmplFromDefinition, err := template.New(defaultOptionsPerKind(GrafanaKind, "grafana")...)
 	require.NoError(t, err)
 	// Parse default template string.
 	err = tmplFromDefinition.Parse(strings.NewReader(tmplDef.Template))

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -13,6 +13,7 @@ import (
 type Factory struct {
 	templates   map[Kind][]TemplateDefinition
 	externalURL *url.URL
+	orgID       string
 }
 
 // GetTemplate creates a new template of the given kind. If Kind is not known, GrafanaKind automatically assumed
@@ -25,7 +26,7 @@ func (tp *Factory) GetTemplate(kind Kind) (*Template, error) {
 	for _, def := range definitions { // TODO sort the list by name?
 		content = append(content, def.Template)
 	}
-	t, err := fromContent(content, defaultOptionsPerKind(kind)...)
+	t, err := fromContent(content, defaultOptionsPerKind(kind, tp.orgID)...)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (tp *Factory) WithTemplate(def TemplateDefinition) (*Factory, error) {
 
 // NewFactory creates a new template provider. Accepts list of user-defined templates that are added to the kind's default templates.
 // Returns error if externalURL is not a valid URL or if TemplateDefinition.Kind is not known.
-func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string) (*Factory, error) {
+func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string, orgID string) (*Factory, error) {
 	extURL, err := url.Parse(externalURL)
 	if err != nil {
 		return nil, err
@@ -98,6 +99,7 @@ func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string) (
 	provider := &Factory{
 		templates:   byType,
 		externalURL: extURL,
+		orgID:       orgID,
 	}
 	return provider, nil
 }

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -54,7 +54,7 @@ func TestNewFactory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			factory, err := NewFactory(tc.templates, logger, externalURL)
+			factory, err := NewFactory(tc.templates, logger, externalURL, "grafana")
 			if tc.expectError != nil {
 				require.ErrorIs(t, err, ErrInvalidKind)
 				return
@@ -69,7 +69,7 @@ func TestNewFactory(t *testing.T) {
 	}
 
 	t.Run("error if external URL is invalid", func(t *testing.T) {
-		_, err := NewFactory([]TemplateDefinition{{Name: "t1", Kind: GrafanaKind}}, logger, ":::")
+		_, err := NewFactory([]TemplateDefinition{{Name: "t1", Kind: GrafanaKind}}, logger, ":::", "grafana")
 		require.Error(t, err)
 	})
 }
@@ -112,7 +112,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 			Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, kind),
 		})
 	}
-	f, err := NewFactory(def, log.NewNopLogger(), "http://localhost")
+	f, err := NewFactory(def, log.NewNopLogger(), "http://localhost", "grafana")
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -181,7 +181,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 				Kind:     GrafanaKind,
 				Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, GrafanaKind),
 			},
-		}, log.NewNopLogger(), "http://localhost")
+		}, log.NewNopLogger(), "http://localhost", "grafana")
 		require.NoError(t, err)
 		templ, err := f.GetTemplate(GrafanaKind)
 		require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	as := []*types.Alert{{}}
 	kind := GrafanaKind
 	initial := TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST{{ end }}`}
-	f, err := NewFactory([]TemplateDefinition{initial}, log.NewNopLogger(), "http://localhost")
+	f, err := NewFactory([]TemplateDefinition{initial}, log.NewNopLogger(), "http://localhost", "grafana")
 	require.NoError(t, err)
 	templ, err := f.GetTemplate(kind)
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestCachedTemplateFactory(t *testing.T) {
 			Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, GrafanaKind),
 		},
 	}
-	f, err := NewFactory(def, log.NewNopLogger(), "http://localhost")
+	f, err := NewFactory(def, log.NewNopLogger(), "http://localhost", "grafana")
 	require.NoError(t, err)
 	cached := NewCachedFactory(f)
 

--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -19,7 +19,7 @@ func defaultTemplatesPerKind(kind Kind) []string {
 	}
 }
 
-func defaultOptionsPerKind(kind Kind) []template.Option {
+func defaultOptionsPerKind(kind Kind, orgID string) []template.Option {
 	switch kind {
 	case GrafanaKind:
 		return []template.Option{

--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -26,6 +26,7 @@ func defaultOptionsPerKind(kind Kind, orgID string) []template.Option {
 	case GrafanaKind:
 		return []template.Option{
 			addFuncs,
+			mimir.WithCustomFunctions(orgID),
 		}
 	case MimirKind:
 		return []template.Option{

--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -2,6 +2,8 @@ package templates
 
 import (
 	"github.com/prometheus/alertmanager/template"
+
+	"github.com/grafana/alerting/templates/mimir"
 )
 
 var (
@@ -24,6 +26,10 @@ func defaultOptionsPerKind(kind Kind, orgID string) []template.Option {
 	case GrafanaKind:
 		return []template.Option{
 			addFuncs,
+		}
+	case MimirKind:
+		return []template.Option{
+			mimir.WithCustomFunctions(orgID),
 		}
 	default:
 		return nil

--- a/templates/mimir/template.go
+++ b/templates/mimir/template.go
@@ -1,0 +1,89 @@
+// this is a partial copy of https://github.com/grafana/mimir/blob/9757b8fed9a2482dee5bdf01367ef868601ed263/pkg/alertmanager/alertmanager_template.go
+
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package mimir
+
+import (
+	"encoding/json"
+	"fmt"
+	tmplhtml "html/template"
+	"net/url"
+	tmpltext "text/template"
+
+	"github.com/prometheus/alertmanager/template"
+)
+
+type grafanaDatasource struct {
+	Type string `json:"type,omitempty"`
+	UID  string `json:"uid,omitempty"`
+}
+
+type grafanaExploreRange struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type grafanaExploreQuery struct {
+	Datasource grafanaDatasource `json:"datasource"`
+	Expr       string            `json:"expr"`
+	Instant    bool              `json:"instant"`
+	Range      bool              `json:"range"`
+	RefID      string            `json:"refId"`
+}
+
+type grafanaExploreParams struct {
+	Range   grafanaExploreRange   `json:"range"`
+	Queries []grafanaExploreQuery `json:"queries"`
+}
+
+// grafanaExploreURL is a template helper function to generate Grafana range query explore URL in the alert template.
+func grafanaExploreURL(grafanaURL, datasource, from, to, expr string) (string, error) {
+	res, err := json.Marshal(&grafanaExploreParams{
+		Range: grafanaExploreRange{
+			From: from,
+			To:   to,
+		},
+		Queries: []grafanaExploreQuery{
+			{
+				Datasource: grafanaDatasource{
+					Type: "prometheus",
+					UID:  datasource,
+				},
+				Expr:    expr,
+				Instant: false,
+				Range:   true,
+				RefID:   "A",
+			},
+		},
+	})
+	return grafanaURL + "/explore?left=" + url.QueryEscape(string(res)), err
+}
+
+// queryFromGeneratorURL returns a PromQL expression parsed out from a GeneratorURL in Prometheus alert
+func queryFromGeneratorURL(generatorURL string) (string, error) {
+	u, err := url.Parse(generatorURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse generator URL: %w", err)
+	}
+	// See https://github.com/prometheus/prometheus/blob/259bb5c69263635887541964d1bfd7acc46682c6/util/strutil/strconv.go#L28
+	queryParam, ok := u.Query()["g0.expr"]
+	if !ok || len(queryParam) < 1 {
+		return "", fmt.Errorf("query not found in the generator URL")
+	}
+	return queryParam[0], nil
+}
+
+// WithCustomFunctions returns template.Option which adds additional template functions
+// to the default ones.
+func WithCustomFunctions(userID string) template.Option {
+	funcs := tmpltext.FuncMap{
+		"tenantID":              func() string { return userID },
+		"grafanaExploreURL":     grafanaExploreURL,
+		"queryFromGeneratorURL": queryFromGeneratorURL,
+	}
+	return func(text *tmpltext.Template, html *tmplhtml.Template) {
+		text.Funcs(funcs)
+		html.Funcs(funcs)
+	}
+}

--- a/templates/mimir_template_test.go
+++ b/templates/mimir_template_test.go
@@ -1,0 +1,190 @@
+// This is a copy of https://github.com/grafana/mimir/blob/9757b8fed9a2482dee5bdf01367ef868601ed263/pkg/alertmanager/alertmanager_template_test.go
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package templates
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_withCustomFunctions(t *testing.T) {
+	type tc struct {
+		name        string
+		template    string
+		alerts      template.Alerts
+		result      string
+		expectError bool
+	}
+
+	f, err := NewFactory(nil, log.NewNopLogger(), "http://localhost", "test")
+	assert.NoError(t, err)
+	tmpl, err := f.GetTemplate(MimirKind)
+	assert.NoError(t, err)
+	cases := []tc{
+		{
+			name:     "template tenant ID",
+			template: "{{ tenantID }}",
+			result:   "test",
+		},
+		{
+			name: "parse out query from GeneratorURL",
+			alerts: template.Alerts{
+				template.Alert{
+					GeneratorURL: "http://localhost:9090" + TableLinkForExpression(`sum by (foo)(rate(bar{foo="bar"}[3m]))`),
+				},
+			},
+			template: `{{ queryFromGeneratorURL (index .Alerts 0).GeneratorURL }}`,
+			result:   `sum by (foo)(rate(bar{foo="bar"}[3m]))`,
+		},
+		{
+			name: "error on missing query in GeneratorURL",
+			alerts: template.Alerts{
+				template.Alert{
+					GeneratorURL: "http://localhost:9090?foo=bar",
+				},
+			},
+			template:    `{{ queryFormGeneratorURL (index .Alerts 0).GeneratorURL }}`,
+			expectError: true,
+		},
+		{
+			name: "error on URL decoding query in GeneratorURL",
+			alerts: template.Alerts{
+				template.Alert{
+					GeneratorURL: "http://localhost:9090?g0.expr=up{foo=bar}",
+				},
+			},
+			template:    `{{ queryFormGeneratorURL (index .Alerts 0).GeneratorURL }}`,
+			expectError: true,
+		},
+		{
+			name:     "generate grafana explore URL",
+			template: `{{ grafanaExploreURL "https://foo.bar" "test_datasoruce" "now-12h" "now" "up{foo!=\"bar\"}" }}`,
+			result:   `https://foo.bar/explore?left=` + url.QueryEscape(`{"range":{"from":"now-12h","to":"now"},"queries":[{"datasource":{"type":"prometheus","uid":"test_datasoruce"},"expr":"up{foo!=\"bar\"}","instant":false,"range":true,"refId":"A"}]}`),
+		},
+		{
+			name:        "invalid params for grafanaExploreURL",
+			template:    `{{ grafanaExploreURL "https://foo.bar" 3 2 1 0 }}`,
+			expectError: true,
+		},
+		{
+			name: "Generate Grafana Explore URL from GeneratorURL query",
+			alerts: template.Alerts{
+				template.Alert{
+					GeneratorURL: "http://localhost:9090" + TableLinkForExpression(`up{foo!="bar"}`),
+				},
+			},
+			template: `{{ grafanaExploreURL "https://foo.bar" "test_datasoruce" "now-12h" "now" (queryFromGeneratorURL (index .Alerts 0).GeneratorURL) }}`,
+			result:   `https://foo.bar/explore?left=` + url.QueryEscape(`{"range":{"from":"now-12h","to":"now"},"queries":[{"datasource":{"type":"prometheus","uid":"test_datasoruce"},"expr":"up{foo!=\"bar\"}","instant":false,"range":true,"refId":"A"}]}`),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := tmpl.ExecuteTextString(c.template, template.Data{Alerts: c.alerts})
+			if c.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, c.result, res)
+		})
+	}
+}
+
+func Test_loadTemplates(t *testing.T) {
+	type tc struct {
+		name   string
+		loaded []string
+		invoke string
+		exp    string
+		expErr string
+	}
+
+	cases := []tc{
+		{
+			name: "can reference loaded templates",
+			loaded: []string{
+				`
+{{ define "my_tmpl_1" }}My Template 1{{ end }}
+`,
+			},
+			invoke: "my_tmpl_1",
+			exp:    "My Template 1",
+		},
+		{
+			name: "fails to reference nonexistant templates",
+			loaded: []string{
+				`
+{{ define "my_tmpl_1" }}My Template 1{{ end }}
+`,
+			},
+			invoke: "does_not_exist",
+			expErr: "not defined",
+		},
+		{
+			name:   "can reference default templates without loading them",
+			invoke: "discord.default.message",
+			exp:    "Alerts Firing:\nLabels:\nAnnotations:\nSource: http://localhost:9090",
+		},
+		{
+			name:   "can reference default email templates without loading them",
+			invoke: "email.default.html",
+			exp:    "DOCTYPE html",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var def []TemplateDefinition
+			for idx, content := range c.loaded {
+				def = append(def, TemplateDefinition{
+					Name:     fmt.Sprintf("test_%d", idx),
+					Template: content,
+					Kind:     MimirKind,
+				})
+			}
+			f, err := NewFactory(def, log.NewNopLogger(), "http://localhost", "grafana")
+			require.NoError(t, err)
+			tmpl, err := f.GetTemplate(MimirKind)
+			assert.NoError(t, err)
+
+			call := fmt.Sprintf(`{{ template "%s" . }}`, c.invoke)
+
+			data := templateDataForTests(t, tmpl)
+			res, err := tmpl.ExecuteTextString(call, data)
+			if c.expErr != "" {
+				assert.Contains(t, err.Error(), c.expErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Contains(t, res, c.exp)
+			}
+		})
+	}
+}
+
+func templateDataForTests(t *testing.T, tmpl *Template) *template.Data {
+	t.Helper()
+
+	eurl, _ := url.Parse("http://localhost:9090")
+	tmpl.ExternalURL = eurl // This is done externally, by the system using the templates.
+	return tmpl.Data("receiver", model.LabelSet{}, &types.Alert{
+		Alert: model.Alert{
+			GeneratorURL: "http://localhost:9090",
+		},
+	})
+}
+
+// TableLinkForExpression creates an escaped relative link to the table view of
+// the provided expression.
+func TableLinkForExpression(expr string) string {
+	escapedExpression := url.QueryEscape(expr)
+	return fmt.Sprintf("/graph?g0.expr=%s&g0.tab=1", escapedExpression)
+}

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -94,7 +94,7 @@ func (t TemplateDefinition) Validate() error {
 	}
 	// Validate template contents. We try to stick as close to what will actually happen when the templates are parsed
 	// by the alertmanager as possible.
-	tmpl, err := template.New(defaultOptionsPerKind(t.Kind)...)
+	tmpl, err := template.New(defaultOptionsPerKind(t.Kind, "grafana")...)
 	if err != nil {
 		return fmt.Errorf("failed to create template: %w", err)
 	}
@@ -156,7 +156,7 @@ func DefaultTemplate() (TemplateDefinition, error) {
 	// The underlying template is not accessible, so we capture it via template.Option.
 
 	// Call fromContent without any user-provided templates to get the combined default template.
-	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind)...)
+	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind, "grafana")...)
 	if err != nil {
 		return TemplateDefinition{}, err
 	}

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -23,9 +23,8 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/alerting/templates/gomplate"
-
 	"github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/templates/gomplate"
 )
 
 type KV = template.KV

--- a/templates/util.go
+++ b/templates/util.go
@@ -122,7 +122,7 @@ func ParseTemplateDefinition(def TemplateDefinition) ([]string, error) {
 		tmpl = text
 	}
 
-	_, err := template.New(append(defaultOptionsPerKind(def.Kind), capture)...)
+	_, err := template.New(append(defaultOptionsPerKind(def.Kind, "grafana"), capture)...) // use static orgID because we don't need real one here
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR copies additional functions from Mimir into alerting.
https://github.com/grafana/mimir/blob/9757b8fed9a2482dee5bdf01367ef868601ed263/pkg/alertmanager/alertmanager_template.go

 It adds those functions to both kinds as it's done in Mimir now 
https://github.com/grafana/mimir/blob/a14e502853e077d57d8541a729b65f06386d9352/pkg/alertmanager/alertmanager.go#L643-L649
