### PR TITLE
Add OAuth2 Support for HTTP Client Configuration in Webhook Receivers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/prometheus/client_golang v1.20.4
 	github.com/prometheus/common v0.60.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/net v0.29.0
+	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sync v0.8.0
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -97,8 +99,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.29.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect

--- a/http/client.go
+++ b/http/client.go
@@ -15,8 +15,9 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	commoncfg "github.com/prometheus/common/config"
 	"golang.org/x/oauth2"
+
+	commoncfg "github.com/prometheus/common/config"
 
 	"github.com/grafana/alerting/receivers"
 )

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -2,15 +2,20 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/receivers"
@@ -18,29 +23,58 @@ import (
 
 func TestClient(t *testing.T) {
 	t.Run("NewClient", func(t *testing.T) {
-		client := NewClient()
+		client, err := NewClient()
+		require.NoError(t, err)
 		require.NotNil(t, client)
 	})
 
 	t.Run("WithUserAgent", func(t *testing.T) {
-		client := NewClient(WithUserAgent("TEST"))
+		client, err := NewClient(WithUserAgent("TEST"))
+		require.NoError(t, err)
 		require.Equal(t, "TEST", client.cfg.userAgent)
 	})
 
 	t.Run("WithDialer with timeout", func(t *testing.T) {
 		dialer := net.Dialer{Timeout: 5 * time.Second}
-		client := NewClient(WithDialer(dialer))
+		client, err := NewClient(WithDialer(dialer))
+		require.NoError(t, err)
 		require.Equal(t, dialer, client.cfg.dialer)
 	})
 
 	t.Run("WithDialer missing timeout should use default", func(t *testing.T) {
 		// Mostly defensive to ensure that some timeout is set.
 		dialer := net.Dialer{LocalAddr: &net.TCPAddr{IP: net.ParseIP("::")}}
-		client := NewClient(WithDialer(dialer))
+		client, err := NewClient(WithDialer(dialer))
+		require.NoError(t, err)
 
 		expectedDialer := dialer
 		expectedDialer.Timeout = defaultDialTimeout
 		require.Equal(t, expectedDialer, client.cfg.dialer)
+	})
+
+	t.Run("WithOAuth2", func(t *testing.T) {
+		oauth2Config := &OAuth2Config{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			TokenURL:     "https://localhost:8080/oauth2/token",
+		}
+		client, err := NewClient(WithOAuth2(oauth2Config))
+		require.NoError(t, err)
+
+		require.Equal(t, oauth2Config, client.cfg.ouath2Config)
+	})
+
+	t.Run("WithOAuth2 invalid TLS", func(t *testing.T) {
+		oauth2Config := &OAuth2Config{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			TokenURL:     "https://localhost:8080/oauth2/token",
+			TLSConfig: &receivers.TLSConfig{
+				CACertificate: "invalid-ca-cert",
+			},
+		}
+		_, err := NewClient(WithOAuth2(oauth2Config))
+		require.ErrorIs(t, err, ErrOAuth2TLSConfigInvalid)
 	})
 }
 
@@ -54,7 +88,8 @@ func TestSendWebhook(t *testing.T) {
 		got = r
 		w.WriteHeader(http.StatusOK)
 	}))
-	s := NewClient(WithUserAgent("TEST"))
+	s, err := NewClient(WithUserAgent("TEST"))
+	require.NoError(t, err)
 
 	// The method should be either POST or PUT.
 	cmd := receivers.SendWebhookSettings{
@@ -138,7 +173,8 @@ func TestSendWebhookHMAC(t *testing.T) {
 		server := initServer(httptest.NewServer)
 		defer server.Close()
 
-		client := NewClient()
+		client, err := NewClient()
+		require.NoError(t, err)
 		webhook := &receivers.SendWebhookSettings{
 			URL:        server.URL,
 			Body:       "test-body",
@@ -150,7 +186,7 @@ func TestSendWebhookHMAC(t *testing.T) {
 			},
 		}
 
-		err := client.SendWebhook(context.Background(), log.NewNopLogger(), webhook)
+		err = client.SendWebhook(context.Background(), log.NewNopLogger(), webhook)
 		require.NoError(t, err)
 
 		require.NotNil(t, capturedRequest)
@@ -169,7 +205,8 @@ func TestSendWebhookHMAC(t *testing.T) {
 		cfg, err := tlsConfig.ToCryptoTLSConfig()
 		require.NoError(t, err)
 
-		client := NewClient()
+		client, err := NewClient()
+		require.NoError(t, err)
 		webhook := &receivers.SendWebhookSettings{
 			URL:        server.URL,
 			Body:       "test-body",
@@ -190,6 +227,253 @@ func TestSendWebhookHMAC(t *testing.T) {
 		timestamp := capturedRequest.Header.Get("X-Custom-Timestamp")
 		require.NotEmpty(t, timestamp)
 	})
+}
+
+func TestSendWebhookOAuth2(t *testing.T) {
+	type oauth2Response struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	}
+
+	customDialError := fmt.Errorf("custom dial function error")
+	tcs := []struct {
+		name            string
+		oauth2Config    OAuth2Config // TokenURL is added dynamically in the test.
+		otherClientOpts []ClientOption
+		oauth2Response  oauth2Response
+
+		expOAuth2AuthHeaders   http.Header
+		expOAuth2RequestValues url.Values
+		expClientError         error
+		expOAuthError          error
+	}{
+		{
+			name: "valid simple OAuth2 config",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+			oauth2Response: oauth2Response{
+				AccessToken: "12345",
+				TokenType:   "Bearer",
+			},
+
+			expOAuth2RequestValues: url.Values{
+				"grant_type": []string{"client_credentials"},
+			},
+			expOAuth2AuthHeaders: http.Header{
+				"Authorization": []string{GetBasicAuthHeader("test-client-id", "test-client-secret")},
+			},
+		},
+		{
+			name: "client with useragent should use in oauth2 request",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+			otherClientOpts: []ClientOption{WithUserAgent("TEST")},
+			oauth2Response: oauth2Response{
+				AccessToken: "12345",
+				TokenType:   "Bearer",
+			},
+
+			expOAuth2RequestValues: url.Values{
+				"grant_type": []string{"client_credentials"},
+			},
+			expOAuth2AuthHeaders: http.Header{
+				"Authorization": []string{GetBasicAuthHeader("test-client-id", "test-client-secret")},
+				"User-Agent":    []string{"TEST"},
+			},
+		},
+		{
+			name: "valid with scopes",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				Scopes:       []string{"scope1", "scope2"},
+			},
+			oauth2Response: oauth2Response{
+				AccessToken: "12345",
+				TokenType:   "Bearer",
+			},
+
+			expOAuth2RequestValues: url.Values{
+				"grant_type": []string{"client_credentials"},
+				"scope":      []string{"scope1 scope2"},
+			},
+			expOAuth2AuthHeaders: http.Header{
+				"Authorization": []string{GetBasicAuthHeader("test-client-id", "test-client-secret")},
+			},
+		},
+		{
+			name: "valid with endpoint params",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				EndpointParams: map[string]string{
+					"audience": "test-audience",
+				},
+			},
+			oauth2Response: oauth2Response{
+				AccessToken: "12345",
+				TokenType:   "Bearer",
+			},
+
+			expOAuth2RequestValues: url.Values{
+				"grant_type": []string{"client_credentials"},
+				"audience":   []string{"test-audience"},
+			},
+			expOAuth2AuthHeaders: http.Header{
+				"Authorization": []string{GetBasicAuthHeader("test-client-id", "test-client-secret")},
+			},
+		},
+		{
+			name: "valid with scopes and endpoint params",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				Scopes:       []string{"scope1", "scope2"},
+				EndpointParams: map[string]string{
+					"audience": "test-audience",
+				},
+			},
+			oauth2Response: oauth2Response{
+				AccessToken: "12345",
+				TokenType:   "Bearer",
+			},
+
+			expOAuth2RequestValues: url.Values{
+				"grant_type": []string{"client_credentials"},
+				"audience":   []string{"test-audience"},
+				"scope":      []string{"scope1 scope2"},
+			},
+			expOAuth2AuthHeaders: http.Header{
+				"Authorization": []string{GetBasicAuthHeader("test-client-id", "test-client-secret")},
+			},
+		},
+		{
+			name: "invalid OAuth2 - client id",
+			oauth2Config: OAuth2Config{
+				ClientSecret: "test-client-secret",
+			},
+			expClientError: ErrOAuth2ClientIDRequired,
+		},
+		{
+			name: "invalid OAuth2 - client secret",
+			oauth2Config: OAuth2Config{
+				ClientID: "test-client-id",
+			},
+			expClientError: ErrOAuth2ClientSecretRequired,
+		},
+		{
+			name: "invalid OAuth2 - tlsConfig",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				TLSConfig: &receivers.TLSConfig{
+					CACertificate: "invalid-ca-cert",
+				},
+			},
+			expClientError: ErrOAuth2TLSConfigInvalid,
+		},
+		{
+			name: "client with custom dialer should use in oauth2 request",
+			oauth2Config: OAuth2Config{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+			otherClientOpts: []ClientOption{
+				WithDialer(net.Dialer{
+					// Override the Resolver so that configurations with invalid hostnames also return
+					// "custom dial function error" instead of "no such host".
+					Resolver: &net.Resolver{
+						Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
+							return nil, customDialError
+						},
+					},
+					Control: func(_, _ string, _ syscall.RawConn) error {
+						return customDialError
+					},
+				}),
+			},
+			oauth2Response: oauth2Response{
+				AccessToken: "12345",
+				TokenType:   "Bearer",
+			},
+
+			expOAuth2RequestValues: url.Values{
+				"grant_type": []string{"client_credentials"},
+			},
+			expOAuth2AuthHeaders: http.Header{
+				"Authorization": []string{GetBasicAuthHeader("test-client-id", "test-client-secret")},
+			},
+			expOAuthError: customDialError,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			oathRequestCnt := 0
+			oauth2Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				oathRequestCnt++
+
+				for k := range tc.expOAuth2AuthHeaders {
+					assert.Equalf(t, tc.expOAuth2AuthHeaders.Get(k), r.Header.Get(k), "expected OAuth2 request header %s to match, got: %v", k, r.Header.Get(k))
+				}
+
+				err := r.ParseForm()
+				assert.NoError(t, err, "expected no error parsing form")
+
+				assert.Equalf(t, tc.expOAuth2RequestValues, r.Form, "expected OAuth2 request values to match, got: %v", r.Form)
+
+				res, _ := json.Marshal(tc.oauth2Response)
+				w.Header().Add("Content-Type", "application/json")
+				_, _ = w.Write(res)
+			}))
+			defer oauth2Server.Close()
+
+			webhookRequestCnt := 0
+			webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				webhookRequestCnt++
+				assert.Equalf(t, tc.oauth2Response.TokenType+" "+tc.oauth2Response.AccessToken, r.Header.Get("Authorization"),
+					"expected Authorization header from Access Token to match, got: %s", r.Header.Get("Authorization"))
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer webhookServer.Close()
+
+			oauthConfig := tc.oauth2Config
+			oauthConfig.TokenURL = oauth2Server.URL
+			client, err := NewClient(append(tc.otherClientOpts, WithOAuth2(&oauthConfig))...)
+			if tc.expClientError != nil {
+				assert.ErrorIs(t, err, tc.expClientError, "expected client creation error to match")
+				return
+			}
+			require.NoError(t, err, "expected no error creating client")
+
+			err = client.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{
+				URL:        webhookServer.URL,
+				Body:       "test-body",
+				HTTPMethod: http.MethodPost,
+			})
+			if tc.expOAuthError != nil {
+				assert.Equal(t, 0, oathRequestCnt, "expected %d OAuth2 request to be sent, got: %d", 1, oathRequestCnt)
+				assert.Equal(t, 0, webhookRequestCnt, "expected %d webhook request to be sent, got: %d", 1, webhookRequestCnt)
+				assert.ErrorIs(t, err, tc.expOAuthError, "expected error to match")
+				return
+			}
+			assert.Equal(t, 1, oathRequestCnt, "expected %d OAuth2 request to be sent, got: %d", 1, oathRequestCnt)
+			assert.Equal(t, 1, webhookRequestCnt, "expected %d webhook request to be sent, got: %d", 1, webhookRequestCnt)
+			assert.NoError(t, err, "expected no error")
+
+			// Check that the OAuth2 request is sent only once, and the token is reused.
+			_ = client.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{
+				URL:        webhookServer.URL,
+				Body:       "test-body",
+				HTTPMethod: http.MethodPost,
+			})
+			assert.Equal(t, 1, oathRequestCnt, "expected %d OAuth2 request to be sent, got: %d", 1, oathRequestCnt)
+			assert.Equal(t, 2, webhookRequestCnt, "expected %d webhook request to be sent, got: %d", 2, webhookRequestCnt)
+		})
+	}
 }
 
 func TestToHTTPClientOption(t *testing.T) {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -459,13 +459,13 @@ func TestSendWebhookOAuth2(t *testing.T) {
 
 			oauth2Server := httptest.NewServer(http.HandlerFunc(oauthHandler))
 			defer oauth2Server.Close()
-			tokenUrl := oauth2Server.URL + "/oauth2/token"
+			tokenURL := oauth2Server.URL + "/oauth2/token"
 
 			proxyRequestCnt := 0
 			proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				proxyRequestCnt++
 				// Verify this is a proxy request.
-				assert.Equal(t, tokenUrl, r.RequestURI, "expected request to be sent to oauth server")
+				assert.Equal(t, tokenURL, r.RequestURI, "expected request to be sent to oauth server")
 
 				// Simulate forwarding the request to the OAuth2 handler.
 				oauthHandler(w, r)
@@ -482,7 +482,7 @@ func TestSendWebhookOAuth2(t *testing.T) {
 			defer webhookServer.Close()
 
 			oauthConfig := tc.oauth2Config
-			oauthConfig.TokenURL = tokenUrl
+			oauthConfig.TokenURL = tokenURL
 
 			if oauthConfig.ProxyConfig != nil && oauthConfig.ProxyConfig.ProxyURL != "" {
 				oauthConfig.ProxyConfig.ProxyURL = proxyServer.URL

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -419,8 +419,8 @@ func TestSendWebhookOAuth2(t *testing.T) {
 			oauth2Config: OAuth2Config{
 				ClientID:     "test-client-id",
 				ClientSecret: "test-client-secret",
-				ProxyConfig: &ProxyConfig{
-					ProxyURL: "xxxx", // This will be replaced with the test server URL.
+				ProxyConfig: ProxyConfig{
+					ProxyURL: mustURL("http://<server>.com"), // This will be replaced with the test server URL.
 				},
 			},
 			oauth2Response: oauth2Response{
@@ -484,8 +484,8 @@ func TestSendWebhookOAuth2(t *testing.T) {
 			oauthConfig := tc.oauth2Config
 			oauthConfig.TokenURL = tokenURL
 
-			if oauthConfig.ProxyConfig != nil && oauthConfig.ProxyConfig.ProxyURL != "" {
-				oauthConfig.ProxyConfig.ProxyURL = proxyServer.URL
+			if oauthConfig.ProxyConfig.ProxyURL.URL != nil && oauthConfig.ProxyConfig.ProxyURL.String() != "" {
+				oauthConfig.ProxyConfig.ProxyURL = mustURL(proxyServer.URL)
 			}
 			expectedProxyRequestCnt := 0
 			if tc.expProxyRequests {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -549,5 +549,5 @@ func TestToHTTPClientOption(t *testing.T) {
 	// Verify number of fields using reflection
 	tp := reflect.TypeOf(clientConfiguration{})
 	// You need to increase the number of fields covered in this test, if you add a new field to the configuration struct.
-	require.Equalf(t, 3, tp.NumField(), "Not all fields are converted to HTTPClientOption, which means that the configuration will not be supported in upstream integrations")
+	require.Equalf(t, 4, tp.NumField(), "Not all fields are converted to HTTPClientOption, which means that the configuration will not be supported in upstream integrations")
 }

--- a/http/config.go
+++ b/http/config.go
@@ -1,0 +1,128 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/http/httpproxy"
+
+	"github.com/grafana/alerting/receivers"
+)
+
+var (
+	// ErrInvalidOAuth2Config is returned when the OAuth2 configuration is invalid.
+	ErrInvalidOAuth2Config = fmt.Errorf("invalid OAuth2 configuration")
+	// ErrInvalidProxyConfig is returned when the proxy configuration is invalid.
+	ErrInvalidProxyConfig = fmt.Errorf("invalid proxy configuration")
+)
+
+// HTTPClientConfig holds common configuration for notifier HTTP clients.
+type HTTPClientConfig struct {
+	// The OAuth2 client credentials used to fetch a token for the targets.
+	OAuth2 *OAuth2Config `yaml:"oauth2,omitempty" json:"oauth2,omitempty"`
+}
+
+// Decrypt decrypts sensitive fields in the HTTPClientConfig.
+func (c *HTTPClientConfig) Decrypt(decryptFn receivers.DecryptFunc) {
+	if c.OAuth2 != nil {
+		c.OAuth2.ClientSecret = decryptFn("http_config.oauth2.client_secret", c.OAuth2.ClientSecret)
+		if c.OAuth2.TLSConfig != nil {
+			c.OAuth2.TLSConfig.CACertificate = decryptFn("http_config.oauth2.tls_config.caCertificate", c.OAuth2.TLSConfig.CACertificate)
+			c.OAuth2.TLSConfig.ClientCertificate = decryptFn("http_config.oauth2.tls_config.clientCertificate", c.OAuth2.TLSConfig.ClientCertificate)
+			c.OAuth2.TLSConfig.ClientKey = decryptFn("http_config.oauth2.tls_config.clientKey", c.OAuth2.TLSConfig.ClientKey)
+		}
+	}
+}
+
+func ValidateHTTPClientConfig(cfg *HTTPClientConfig) error {
+	if cfg != nil {
+		if err := ValidateOAuth2Config(cfg.OAuth2); err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidOAuth2Config, err)
+		}
+	}
+	return nil
+}
+
+type ProxyConfig struct {
+	// ProxyURL is the HTTP proxy server to use to connect to the targets.
+	ProxyURL string `yaml:"proxy_url,omitempty" json:"proxy_url,omitempty"`
+	// NoProxy contains addresses that should not use a proxy.
+	NoProxy string `yaml:"no_proxy,omitempty" json:"no_proxy,omitempty"`
+	// ProxyFromEnvironment uses environment HTTP_PROXY, HTTPS_PROXY and NO_PROXY to determine proxies.
+	ProxyFromEnvironment bool `yaml:"proxy_from_environment,omitempty" json:"proxy_from_environment,omitempty"`
+	// ProxyConnectHeader optionally specifies headers to send to proxies during CONNECT requests.
+	ProxyConnectHeader map[string]string `yaml:"proxy_connect_header,omitempty" json:"proxy_connect_header,omitempty"`
+}
+
+// Proxy returns the Proxy URL for a request.
+func (cfg *ProxyConfig) Proxy() (fn func(*http.Request) (*url.URL, error), err error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	if cfg.ProxyFromEnvironment {
+		proxyFn := httpproxy.FromEnvironment().ProxyFunc()
+		return func(req *http.Request) (*url.URL, error) {
+			return proxyFn(req.URL)
+		}, nil
+	}
+	if cfg.ProxyURL != "" {
+		proxyUrl, err := url.Parse(cfg.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL %q: %w", cfg.ProxyURL, err)
+		}
+		if cfg.NoProxy == "" {
+			return http.ProxyURL(proxyUrl), nil
+		}
+		proxy := &httpproxy.Config{
+			HTTPProxy:  proxyUrl.String(),
+			HTTPSProxy: proxyUrl.String(),
+			NoProxy:    cfg.NoProxy,
+		}
+		proxyFn := proxy.ProxyFunc()
+		return func(req *http.Request) (*url.URL, error) {
+			return proxyFn(req.URL)
+		}, nil
+	}
+	return nil, nil
+}
+
+func (cfg *ProxyConfig) GetProxyConnectHeader() http.Header {
+	if cfg == nil || len(cfg.ProxyConnectHeader) == 0 {
+		return nil
+	}
+	// Return a copy of the header to avoid modifying the original.
+	headerCopy := make(http.Header, len(cfg.ProxyConnectHeader))
+	for k, v := range cfg.ProxyConnectHeader {
+		headerCopy.Add(k, v)
+	}
+	return headerCopy
+}
+
+func ValidateProxyConfig(cfg *ProxyConfig) error {
+	if cfg == nil {
+		// If no proxy config is provided, we consider it valid.
+		return nil
+	}
+	if len(cfg.ProxyConnectHeader) > 0 && !cfg.ProxyFromEnvironment && cfg.ProxyURL == "" {
+		return errors.New("if proxy_connect_header is configured, proxy_url or proxy_from_environment must also be configured")
+	}
+	if cfg.ProxyFromEnvironment && cfg.ProxyURL != "" {
+		return errors.New("if proxy_from_environment is configured, proxy_url must not be configured")
+	}
+	if cfg.ProxyFromEnvironment && cfg.NoProxy != "" {
+		return errors.New("if proxy_from_environment is configured, no_proxy must not be configured")
+	}
+	if cfg.ProxyURL == "" && cfg.NoProxy != "" {
+		return errors.New("if no_proxy is configured, proxy_url must also be configured")
+	}
+
+	if cfg.ProxyURL != "" {
+		if _, err := url.Parse(cfg.ProxyURL); err != nil {
+			return fmt.Errorf("invalid proxy URL %q: %w", cfg.ProxyURL, err)
+		}
+	}
+
+	return nil
+}

--- a/http/config.go
+++ b/http/config.go
@@ -28,14 +28,17 @@ type HTTPClientConfig struct {
 
 // Decrypt decrypts sensitive fields in the HTTPClientConfig.
 func (c *HTTPClientConfig) Decrypt(decryptFn receivers.DecryptFunc) {
-	if c.OAuth2 != nil {
-		c.OAuth2.ClientSecret = decryptFn("http_config.oauth2.client_secret", c.OAuth2.ClientSecret)
-		if c.OAuth2.TLSConfig != nil {
-			c.OAuth2.TLSConfig.CACertificate = decryptFn("http_config.oauth2.tls_config.caCertificate", c.OAuth2.TLSConfig.CACertificate)
-			c.OAuth2.TLSConfig.ClientCertificate = decryptFn("http_config.oauth2.tls_config.clientCertificate", c.OAuth2.TLSConfig.ClientCertificate)
-			c.OAuth2.TLSConfig.ClientKey = decryptFn("http_config.oauth2.tls_config.clientKey", c.OAuth2.TLSConfig.ClientKey)
-		}
+	if c.OAuth2 == nil {
+		return
 	}
+	c.OAuth2.ClientSecret = decryptFn("http_config.oauth2.client_secret", c.OAuth2.ClientSecret)
+
+	if c.OAuth2.TLSConfig == nil {
+		return
+	}
+	c.OAuth2.TLSConfig.CACertificate = decryptFn("http_config.oauth2.tls_config.caCertificate", c.OAuth2.TLSConfig.CACertificate)
+	c.OAuth2.TLSConfig.ClientCertificate = decryptFn("http_config.oauth2.tls_config.clientCertificate", c.OAuth2.TLSConfig.ClientCertificate)
+	c.OAuth2.TLSConfig.ClientKey = decryptFn("http_config.oauth2.tls_config.clientKey", c.OAuth2.TLSConfig.ClientKey)
 }
 
 func ValidateHTTPClientConfig(cfg *HTTPClientConfig) error {

--- a/http/config.go
+++ b/http/config.go
@@ -19,6 +19,8 @@ var (
 )
 
 // HTTPClientConfig holds common configuration for notifier HTTP clients.
+//
+//nolint:revive
 type HTTPClientConfig struct {
 	// The OAuth2 client credentials used to fetch a token for the targets.
 	OAuth2 *OAuth2Config `yaml:"oauth2,omitempty" json:"oauth2,omitempty"`
@@ -68,16 +70,16 @@ func (cfg *ProxyConfig) Proxy() (fn func(*http.Request) (*url.URL, error), err e
 		}, nil
 	}
 	if cfg.ProxyURL != "" {
-		proxyUrl, err := url.Parse(cfg.ProxyURL)
+		proxyURL, err := url.Parse(cfg.ProxyURL)
 		if err != nil {
 			return nil, fmt.Errorf("invalid proxy URL %q: %w", cfg.ProxyURL, err)
 		}
 		if cfg.NoProxy == "" {
-			return http.ProxyURL(proxyUrl), nil
+			return http.ProxyURL(proxyURL), nil
 		}
 		proxy := &httpproxy.Config{
-			HTTPProxy:  proxyUrl.String(),
-			HTTPSProxy: proxyUrl.String(),
+			HTTPProxy:  proxyURL.String(),
+			HTTPSProxy: proxyURL.String(),
 			NoProxy:    cfg.NoProxy,
 		}
 		proxyFn := proxy.ProxyFunc()

--- a/http/config_test.go
+++ b/http/config_test.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClientConfigValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *HTTPClientConfig
+		expError error
+	}{
+		{
+			name: "valid config with OAuth2",
+			cfg: &HTTPClientConfig{
+				OAuth2: &OAuth2Config{
+					ClientID:     "client-id",
+					ClientSecret: "client-secret",
+					TokenURL:     "https://example.com/token",
+				},
+			},
+			expError: nil,
+		},
+		{
+			name:     "nil config",
+			cfg:      nil,
+			expError: nil,
+		},
+		{
+			name: "invalid OAuth2 config",
+			cfg: &HTTPClientConfig{
+				OAuth2: &OAuth2Config{
+					ClientID: "",
+				},
+			},
+			expError: ErrInvalidOAuth2Config,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHTTPClientConfig(tt.cfg)
+			if tt.expError != nil {
+				require.ErrorIs(t, err, tt.expError)
+				return
+			}
+			require.NoError(t, err, "expected no error for valid config")
+		})
+	}
+}
+
+func TestProxyConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *ProxyConfig
+		wantErr bool
+	}{
+		{
+			name: "valid proxy config with URL",
+			cfg: &ProxyConfig{
+				ProxyURL: "http://proxy.example.com:8080",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty proxy config",
+			cfg:     nil,
+			wantErr: false,
+		},
+		{
+			name: "invalid proxy URL",
+			cfg: &ProxyConfig{
+				ProxyURL: "ht tp://l ocalhost :12 34",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid proxy URL and environment",
+			cfg: &ProxyConfig{
+				ProxyURL:             "http://proxy.example.com:8080",
+				ProxyFromEnvironment: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid proxy environment with no proxy",
+			cfg: &ProxyConfig{
+				ProxyFromEnvironment: true,
+				NoProxy:              "localhost",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid no proxy with empty URL",
+			cfg: &ProxyConfig{
+				NoProxy: "localhost",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid proxy connect header without URL or environment",
+			cfg: &ProxyConfig{
+				ProxyConnectHeader: map[string]string{"X-Header": "value"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProxyConfig(tt.cfg)
+			if tt.wantErr {
+				require.Error(t, err, "expected error for invalid proxy config")
+			} else {
+				require.NoError(t, err, "expected no error for valid proxy config")
+			}
+		})
+	}
+}

--- a/http/config_test.go
+++ b/http/config_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,39 +55,32 @@ func TestHTTPClientConfigValidation(t *testing.T) {
 func TestProxyConfigValidation(t *testing.T) {
 	tests := []struct {
 		name    string
-		cfg     *ProxyConfig
+		cfg     ProxyConfig
 		wantErr bool
 	}{
 		{
 			name: "valid proxy config with URL",
-			cfg: &ProxyConfig{
-				ProxyURL: "http://proxy.example.com:8080",
+			cfg: ProxyConfig{
+				ProxyURL: mustURL("http://proxy.example.com:8080"),
 			},
 			wantErr: false,
 		},
 		{
-			name:    "empty proxy config",
-			cfg:     nil,
+			name:    "valid empty proxy config",
+			cfg:     ProxyConfig{},
 			wantErr: false,
-		},
-		{
-			name: "invalid proxy URL",
-			cfg: &ProxyConfig{
-				ProxyURL: "ht tp://l ocalhost :12 34",
-			},
-			wantErr: true,
 		},
 		{
 			name: "invalid proxy URL and environment",
-			cfg: &ProxyConfig{
-				ProxyURL:             "http://proxy.example.com:8080",
+			cfg: ProxyConfig{
+				ProxyURL:             mustURL("http://proxy.example.com:8080"),
 				ProxyFromEnvironment: true,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid proxy environment with no proxy",
-			cfg: &ProxyConfig{
+			cfg: ProxyConfig{
 				ProxyFromEnvironment: true,
 				NoProxy:              "localhost",
 			},
@@ -94,14 +88,14 @@ func TestProxyConfigValidation(t *testing.T) {
 		},
 		{
 			name: "invalid no proxy with empty URL",
-			cfg: &ProxyConfig{
+			cfg: ProxyConfig{
 				NoProxy: "localhost",
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid proxy connect header without URL or environment",
-			cfg: &ProxyConfig{
+			cfg: ProxyConfig{
 				ProxyConnectHeader: map[string]string{"X-Header": "value"},
 			},
 			wantErr: true,
@@ -118,4 +112,12 @@ func TestProxyConfigValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustURL(u string) URL {
+	res, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return URL{res}
 }

--- a/http/config_test.go
+++ b/http/config_test.go
@@ -119,5 +119,5 @@ func mustURL(u string) URL {
 	if err != nil {
 		panic(err)
 	}
-	return URL{res}
+	return URL{URL: res}
 }

--- a/http/oauth2.go
+++ b/http/oauth2.go
@@ -1,0 +1,128 @@
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+
+	"github.com/grafana/alerting/receivers"
+	commoncfg "github.com/prometheus/common/config"
+)
+
+var (
+	// ErrOAuth2ClientIDRequired is returned when OAuth2 ClientID is required but not provided.
+	ErrOAuth2ClientIDRequired = fmt.Errorf("OAuth2 ClientID is required")
+	// ErrOAuth2ClientSecretRequired is returned when OAuth2 ClientSecret is required but not provided.
+	ErrOAuth2ClientSecretRequired = fmt.Errorf("OAuth2 ClientSecret is required")
+	// ErrOAuth2TokenURLRequired is returned when OAuth2 TokenURL is required but not provided.
+	ErrOAuth2TokenURLRequired = fmt.Errorf("OAuth2 TokenURL is required")
+	// ErrOAuth2TLSConfigInvalid is returned when the provided TLS configuration is invalid.
+	ErrOAuth2TLSConfigInvalid = fmt.Errorf("invalid TLS configuration")
+)
+
+// OAuth2Config is the oauth2 client configuration.
+type OAuth2Config struct {
+	ClientID       string               `json:"client_id" yaml:"client_id"`
+	ClientSecret   string               `json:"client_secret" yaml:"client_secret"`
+	TokenURL       string               `json:"token_url" yaml:"token_url"`
+	Scopes         []string             `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	EndpointParams map[string]string    `json:"endpoint_params,omitempty" yaml:"endpoint_params,omitempty"`
+	TLSConfig      *receivers.TLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
+}
+
+func ValidateOAuth2Config(config OAuth2Config) error {
+	if config.ClientID == "" {
+		return ErrOAuth2ClientIDRequired
+	}
+	if config.ClientSecret == "" {
+		return ErrOAuth2ClientSecretRequired
+	}
+	if config.TokenURL == "" {
+		return ErrOAuth2TokenURLRequired
+	}
+	if config.TLSConfig != nil {
+		if _, err := config.TLSConfig.ToCryptoTLSConfig(); err != nil {
+			return fmt.Errorf("%w: %w", ErrOAuth2TLSConfigInvalid, err)
+		}
+	}
+	return nil
+}
+
+type OAuth2RoundTripper struct {
+	rt http.RoundTripper
+}
+
+func NewOAuth2RoundTripper(tokenSource oauth2.TokenSource, next http.RoundTripper) *OAuth2RoundTripper {
+	return &OAuth2RoundTripper{
+		rt: &oauth2.Transport{
+			Base:   next,
+			Source: tokenSource,
+		},
+	}
+}
+
+func NewOAuth2TokenSource(clientConfig clientConfiguration) (oauth2.TokenSource, error) {
+	config := clientConfig.ouath2Config
+	if config == nil {
+		// This should never happen, but we add this check defensively.
+		return nil, fmt.Errorf("OAuth2 configuration is required")
+	}
+	credconfig := &clientcredentials.Config{
+		ClientID:       config.ClientID,
+		ClientSecret:   config.ClientSecret,
+		Scopes:         config.Scopes,
+		TokenURL:       config.TokenURL,
+		EndpointParams: url.Values{},
+	}
+
+	for name, value := range config.EndpointParams {
+		credconfig.EndpointParams.Set(name, value)
+	}
+
+	var tlsConfig *tls.Config
+	if config.TLSConfig != nil {
+		var err error
+		tlsConfig, err = config.TLSConfig.ToCryptoTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrOAuth2TLSConfigInvalid, err)
+		}
+	}
+
+	// From prometheus/common oauth2RoundTripper.
+	var rt http.RoundTripper = &http.Transport{
+		TLSClientConfig:       tlsConfig,
+		MaxIdleConns:          20,
+		MaxIdleConnsPerHost:   1, // see https://github.com/golang/go/issues/13801
+		IdleConnTimeout:       10 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+
+		// The following differs from upstream.
+		DialContext: clientConfig.dialer.DialContext,
+	}
+
+	// Ensure that OAuth2 requests use the same user agent as the rest of the HTTP client.
+	if clientConfig.userAgent != "" {
+		rt = commoncfg.NewUserAgentRoundTripper(clientConfig.userAgent, rt)
+	}
+
+	return credconfig.TokenSource(
+		context.WithValue(
+			context.Background(),
+			oauth2.HTTPClient,
+			&http.Client{
+				Transport: rt,
+			},
+		),
+	), nil
+}
+
+func (rt *OAuth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt.rt.RoundTrip(req)
+}

--- a/http/oauth2.go
+++ b/http/oauth2.go
@@ -130,6 +130,7 @@ func NewOAuth2TokenSource(clientConfig clientConfiguration) (oauth2.TokenSource,
 			oauth2.HTTPClient,
 			&http.Client{
 				Transport: rt,
+				Timeout:   time.Second * 30,
 			},
 		),
 	), nil

--- a/http/oauth2_test.go
+++ b/http/oauth2_test.go
@@ -1,0 +1,74 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+)
+
+func TestValidateOAuth2Config(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  OAuth2Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: OAuth2Config{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				TokenURL:     "https://example.com/token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing client ID",
+			config: OAuth2Config{
+				ClientSecret: "client-secret",
+				TokenURL:     "https://example.com/token",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing client secret",
+			config: OAuth2Config{
+				ClientID: "client-id",
+				TokenURL: "https://example.com/token",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing token URL",
+			config: OAuth2Config{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid TLS config",
+			config: OAuth2Config{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				TokenURL:     "https://example.com/token",
+				TLSConfig: &receivers.TLSConfig{
+					CACertificate: "invalid-cert",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOAuth2Config(tt.config)
+			if tt.wantErr {
+				require.Errorf(t, err, "ValidateOAuth2Config() expected error, got nil")
+				return
+			}
+			require.NoError(t, err, "ValidateOAuth2Config() expected nil error, got %v", err)
+		})
+	}
+}

--- a/http/oauth2_test.go
+++ b/http/oauth2_test.go
@@ -65,9 +65,8 @@ func TestValidateOAuth2Config(t *testing.T) {
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
 				TokenURL:     "https://example.com/token",
-				ProxyConfig: &ProxyConfig{
-					ProxyURL:             "http://invalid-proxy",
-					ProxyFromEnvironment: true,
+				ProxyConfig: ProxyConfig{
+					NoProxy: "localhost",
 				},
 			},
 			expError: ErrInvalidProxyConfig,

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -197,7 +197,7 @@ func BuildGrafanaReceiverIntegrations(
 	for i, cfg := range receiver.WebhookConfigs {
 		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
 			return webhook.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
-		}, http.WithOAuth2(cfg.Settings.OAuth2Config))
+		}, http.WithHTTPClientConfig(cfg.Settings.HTTPConfig))
 	}
 	for i, cfg := range receiver.WecomConfigs {
 		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -2,7 +2,9 @@ package notify
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/go-kit/log"
@@ -73,91 +75,141 @@ func BuildGrafanaReceiverIntegrations(
 	orgID int64,
 	version string,
 	httpClientOptions ...http.ClientOption,
-) []*Integration {
+) ([]*Integration, error) {
 	type notificationChannel interface {
 		notify.Notifier
 		notify.ResolvedSender
 	}
 	var (
 		integrations []*Integration
-		ci           = func(idx int, cfg receivers.Metadata, n notificationChannel) {
+		errs         error
+		ci           = func(idx int, cfg receivers.Metadata, newInt func(cli *http.Client) notificationChannel, opts ...http.ClientOption) {
+			client, err := http.NewClient(slices.Concat(httpClientOptions, opts)...)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to create HTTP client for %q notifier %q (UID: %q): %w", cfg.Type, cfg.Name, cfg.UID, err))
+				return
+			}
+			n := newInt(client)
 			notify := wrapNotifier(cfg.Name, n)
 			i := NewIntegration(notify, n, cfg.Type, idx, cfg.Name)
 			integrations = append(integrations, i)
 		}
-		cli = http.NewClient(httpClientOptions...)
 	)
 	// Range through each notification channel in the receiver and create an integration for it.
 	for i, cfg := range receiver.AlertmanagerConfigs {
-		ci(i, cfg.Metadata, alertmanager.New(cfg.Settings, cfg.Metadata, img, logger))
+		ci(i, cfg.Metadata, func(_ *http.Client) notificationChannel {
+			return alertmanager.New(cfg.Settings, cfg.Metadata, img, logger)
+		})
 	}
 	for i, cfg := range receiver.DingdingConfigs {
-		ci(i, cfg.Metadata, dinding.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return dinding.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
+		})
 	}
 	for i, cfg := range receiver.DiscordConfigs {
-		ci(i, cfg.Metadata, discord.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return discord.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
+		})
 	}
 	for i, cfg := range receiver.EmailConfigs {
-		ci(i, cfg.Metadata, email.New(cfg.Settings, cfg.Metadata, tmpl, emailSender, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return email.New(cfg.Settings, cfg.Metadata, tmpl, emailSender, img, logger)
+		})
 	}
 	for i, cfg := range receiver.GooglechatConfigs {
-		ci(i, cfg.Metadata, googlechat.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return googlechat.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
+		})
 	}
 	for i, cfg := range receiver.JiraConfigs {
-		ci(i, cfg.Metadata, jira.New(cfg.Settings, cfg.Metadata, tmpl, http.NewForkedSender(cli), logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return jira.New(cfg.Settings, cfg.Metadata, tmpl, http.NewForkedSender(cli), logger)
+		})
 	}
 	for i, cfg := range receiver.KafkaConfigs {
-		ci(i, cfg.Metadata, kafka.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return kafka.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.LineConfigs {
-		ci(i, cfg.Metadata, line.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return line.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
+		})
 	}
 	for i, cfg := range receiver.MqttConfigs {
-		ci(i, cfg.Metadata, mqtt.New(cfg.Settings, cfg.Metadata, tmpl, logger, nil))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return mqtt.New(cfg.Settings, cfg.Metadata, tmpl, logger, nil)
+		})
 	}
 	for i, cfg := range receiver.OnCallConfigs {
-		ci(i, cfg.Metadata, oncall.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return oncall.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
+		})
 	}
 	for i, cfg := range receiver.OpsgenieConfigs {
-		ci(i, cfg.Metadata, opsgenie.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return opsgenie.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.PagerdutyConfigs {
-		ci(i, cfg.Metadata, pagerduty.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return pagerduty.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.PushoverConfigs {
-		ci(i, cfg.Metadata, pushover.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return pushover.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.SensugoConfigs {
-		ci(i, cfg.Metadata, sensugo.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return sensugo.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.SNSConfigs {
-		ci(i, cfg.Metadata, sns.New(cfg.Settings, cfg.Metadata, tmpl, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel { return sns.New(cfg.Settings, cfg.Metadata, tmpl, logger) })
 	}
 	for i, cfg := range receiver.SlackConfigs {
-		ci(i, cfg.Metadata, slack.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return slack.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
+		})
 	}
 	for i, cfg := range receiver.TeamsConfigs {
-		ci(i, cfg.Metadata, teams.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return teams.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.TelegramConfigs {
-		ci(i, cfg.Metadata, telegram.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return telegram.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.ThreemaConfigs {
-		ci(i, cfg.Metadata, threema.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return threema.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
+		})
 	}
 	for i, cfg := range receiver.VictoropsConfigs {
-		ci(i, cfg.Metadata, victorops.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return victorops.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
+		})
 	}
 	for i, cfg := range receiver.WebhookConfigs {
-		ci(i, cfg.Metadata, webhook.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return webhook.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
+		}, http.WithOAuth2(cfg.Settings.OAuth2Config))
 	}
 	for i, cfg := range receiver.WecomConfigs {
-		ci(i, cfg.Metadata, wecom.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return wecom.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
+		})
 	}
 	for i, cfg := range receiver.WebexConfigs {
-		ci(i, cfg.Metadata, webex.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID))
+		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+			return webex.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
+		})
 	}
-	return integrations
+	return integrations, errs
 }
 
 // BuildPrometheusReceiverIntegrations builds a list of integration notifiers off of a receiver config.
@@ -308,7 +360,7 @@ func BuildReceiverIntegrations(
 		if err != nil {
 			return nil, err
 		}
-		integrations = BuildGrafanaReceiverIntegrations(
+		integrations, err = BuildGrafanaReceiverIntegrations(
 			receiverCfg,
 			tmpl,
 			images,
@@ -319,6 +371,9 @@ func BuildReceiverIntegrations(
 			version,
 			httpClientOptions...,
 		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	mimir, err := BuildPrometheusReceiverIntegrations(receiver.ConfigReceiver, tmpls, httpClientOptions, logger, wrapNotifierFunc)
 	if err != nil {

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -112,7 +112,7 @@ func BuildGrafanaReceiverIntegrations(
 		})
 	}
 	for i, cfg := range receiver.EmailConfigs {
-		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+		ci(i, cfg.Metadata, func(_ *http.Client) notificationChannel {
 			return email.New(cfg.Settings, cfg.Metadata, tmpl, emailSender, img, logger)
 		})
 	}
@@ -137,7 +137,7 @@ func BuildGrafanaReceiverIntegrations(
 		})
 	}
 	for i, cfg := range receiver.MqttConfigs {
-		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {
+		ci(i, cfg.Metadata, func(_ *http.Client) notificationChannel {
 			return mqtt.New(cfg.Settings, cfg.Metadata, tmpl, logger, nil)
 		})
 	}
@@ -167,7 +167,9 @@ func BuildGrafanaReceiverIntegrations(
 		})
 	}
 	for i, cfg := range receiver.SNSConfigs {
-		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel { return sns.New(cfg.Settings, cfg.Metadata, tmpl, logger) })
+		ci(i, cfg.Metadata, func(_ *http.Client) notificationChannel {
+			return sns.New(cfg.Settings, cfg.Metadata, tmpl, logger)
+		})
 	}
 	for i, cfg := range receiver.SlackConfigs {
 		ci(i, cfg.Metadata, func(cli *http.Client) notificationChannel {

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -53,7 +53,8 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			return n
 		}
 
-		integrations := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version)
+		integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version)
+		require.NoError(t, err)
 
 		require.Len(t, integrations, qty)
 
@@ -78,7 +79,8 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 				}),
 			}
 
-			integrations := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, clientOpts...)
+			integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, clientOpts...)
+			require.NoError(t, err)
 
 			require.Len(t, integrations, qty)
 			for _, integration := range integrations {
@@ -114,7 +116,8 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	t.Run("should not produce any integration if config is empty", func(t *testing.T) {
 		cfg := GrafanaReceiverConfig{Name: "test"}
 
-		integrations := BuildGrafanaReceiverIntegrations(cfg, tmpl, imageProvider, log.NewNopLogger(), emailService, noopWrapper, orgID, version)
+		integrations, err := BuildGrafanaReceiverIntegrations(cfg, tmpl, imageProvider, log.NewNopLogger(), emailService, noopWrapper, orgID, version)
+		require.NoError(t, err)
 		require.Empty(t, integrations)
 	})
 }

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/alertmanager/config"
 	commoncfg "github.com/prometheus/common/config"
-	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/notify"
 
@@ -160,7 +161,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			tmpl,
 			imageProvider,
 			NoopDecrypt,
-			NoopDecode,
+			DecodeSecretsFromBase64,
 			emailService,
 			nil,
 			func(_ string, n notify.Notifier) notify.Notifier {
@@ -206,7 +207,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			tmpl,
 			imageProvider,
 			NoopDecrypt,
-			NoopDecode,
+			DecodeSecretsFromBase64,
 			emailService,
 			nil,
 			func(_ string, n notify.Notifier) notify.Notifier {

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -96,6 +96,22 @@ func TestNewConfig(t *testing.T) {
 					Header:          "X-Grafana-Alerting-Signature",
 					TimestampHeader: "X-Grafana-Alerting-Timestamp",
 				},
+				OAuth2Config: &alertingHttp.OAuth2Config{
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+					TokenURL:     "https://localhost/auth/token",
+					Scopes:       []string{"scope1", "scope2"},
+					EndpointParams: map[string]string{
+						"param1": "value1",
+						"param2": "value2",
+					},
+					TLSConfig: &receivers.TLSConfig{
+						InsecureSkipVerify: false,
+						ClientCertificate:  alertingHttp.TestCertPem,
+						ClientKey:          alertingHttp.TestKeyPem,
+						CACertificate:      alertingHttp.TestCACert,
+					},
+				},
 			},
 		},
 		{
@@ -122,6 +138,22 @@ func TestNewConfig(t *testing.T) {
 					Secret:          "test-override-hmac-secret",
 					Header:          "X-Grafana-Alerting-Signature",
 					TimestampHeader: "X-Grafana-Alerting-Timestamp",
+				},
+				OAuth2Config: &alertingHttp.OAuth2Config{
+					ClientID:     "test-client-id",
+					ClientSecret: "test-override-oauth2-secret",
+					TokenURL:     "https://localhost/auth/token",
+					Scopes:       []string{"scope1", "scope2"},
+					EndpointParams: map[string]string{
+						"param1": "value1",
+						"param2": "value2",
+					},
+					TLSConfig: &receivers.TLSConfig{
+						InsecureSkipVerify: false,
+						ClientCertificate:  alertingHttp.TestCertPem,
+						ClientKey:          alertingHttp.TestKeyPem,
+						CACertificate:      alertingHttp.TestCACert,
+					},
 				},
 			},
 		},

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -112,8 +113,8 @@ func TestNewConfig(t *testing.T) {
 							ClientKey:          alertingHttp.TestKeyPem,
 							CACertificate:      alertingHttp.TestCACert,
 						},
-						ProxyConfig: &alertingHttp.ProxyConfig{
-							ProxyURL:             "http://localproxy:8080",
+						ProxyConfig: alertingHttp.ProxyConfig{
+							ProxyURL:             mustURL("http://localproxy:8080"),
 							NoProxy:              "localhost",
 							ProxyFromEnvironment: false,
 							ProxyConnectHeader: map[string]string{
@@ -165,8 +166,8 @@ func TestNewConfig(t *testing.T) {
 							ClientKey:          alertingHttp.TestKeyPem,
 							CACertificate:      alertingHttp.TestCACert,
 						},
-						ProxyConfig: &alertingHttp.ProxyConfig{
-							ProxyURL:             "http://localproxy:8080",
+						ProxyConfig: alertingHttp.ProxyConfig{
+							ProxyURL:             mustURL("http://localproxy:8080"),
 							NoProxy:              "localhost",
 							ProxyFromEnvironment: false,
 							ProxyConnectHeader: map[string]string{
@@ -431,4 +432,12 @@ func TestNewConfig(t *testing.T) {
 			require.Equal(t, c.expectedConfig, actual)
 		})
 	}
+}
+
+func mustURL(u string) alertingHttp.URL {
+	res, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return alertingHttp.URL{res}
 }

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -439,5 +439,5 @@ func mustURL(u string) alertingHttp.URL {
 	if err != nil {
 		panic(err)
 	}
-	return alertingHttp.URL{res}
+	return alertingHttp.URL{URL: res}
 }

--- a/receivers/webhook/config_test.go
+++ b/receivers/webhook/config_test.go
@@ -96,20 +96,30 @@ func TestNewConfig(t *testing.T) {
 					Header:          "X-Grafana-Alerting-Signature",
 					TimestampHeader: "X-Grafana-Alerting-Timestamp",
 				},
-				OAuth2Config: &alertingHttp.OAuth2Config{
-					ClientID:     "test-client-id",
-					ClientSecret: "test-client-secret",
-					TokenURL:     "https://localhost/auth/token",
-					Scopes:       []string{"scope1", "scope2"},
-					EndpointParams: map[string]string{
-						"param1": "value1",
-						"param2": "value2",
-					},
-					TLSConfig: &receivers.TLSConfig{
-						InsecureSkipVerify: false,
-						ClientCertificate:  alertingHttp.TestCertPem,
-						ClientKey:          alertingHttp.TestKeyPem,
-						CACertificate:      alertingHttp.TestCACert,
+				HTTPConfig: &alertingHttp.HTTPClientConfig{
+					OAuth2: &alertingHttp.OAuth2Config{
+						ClientID:     "test-client-id",
+						ClientSecret: "test-client-secret",
+						TokenURL:     "https://localhost/auth/token",
+						Scopes:       []string{"scope1", "scope2"},
+						EndpointParams: map[string]string{
+							"param1": "value1",
+							"param2": "value2",
+						},
+						TLSConfig: &receivers.TLSConfig{
+							InsecureSkipVerify: false,
+							ClientCertificate:  alertingHttp.TestCertPem,
+							ClientKey:          alertingHttp.TestKeyPem,
+							CACertificate:      alertingHttp.TestCACert,
+						},
+						ProxyConfig: &alertingHttp.ProxyConfig{
+							ProxyURL:             "http://localproxy:8080",
+							NoProxy:              "localhost",
+							ProxyFromEnvironment: false,
+							ProxyConnectHeader: map[string]string{
+								"X-Proxy-Header": "proxy-value",
+							},
+						},
 					},
 				},
 			},
@@ -139,20 +149,30 @@ func TestNewConfig(t *testing.T) {
 					Header:          "X-Grafana-Alerting-Signature",
 					TimestampHeader: "X-Grafana-Alerting-Timestamp",
 				},
-				OAuth2Config: &alertingHttp.OAuth2Config{
-					ClientID:     "test-client-id",
-					ClientSecret: "test-override-oauth2-secret",
-					TokenURL:     "https://localhost/auth/token",
-					Scopes:       []string{"scope1", "scope2"},
-					EndpointParams: map[string]string{
-						"param1": "value1",
-						"param2": "value2",
-					},
-					TLSConfig: &receivers.TLSConfig{
-						InsecureSkipVerify: false,
-						ClientCertificate:  alertingHttp.TestCertPem,
-						ClientKey:          alertingHttp.TestKeyPem,
-						CACertificate:      alertingHttp.TestCACert,
+				HTTPConfig: &alertingHttp.HTTPClientConfig{
+					OAuth2: &alertingHttp.OAuth2Config{
+						ClientID:     "test-client-id",
+						ClientSecret: "test-override-oauth2-secret",
+						TokenURL:     "https://localhost/auth/token",
+						Scopes:       []string{"scope1", "scope2"},
+						EndpointParams: map[string]string{
+							"param1": "value1",
+							"param2": "value2",
+						},
+						TLSConfig: &receivers.TLSConfig{
+							InsecureSkipVerify: false,
+							ClientCertificate:  alertingHttp.TestCertPem,
+							ClientKey:          alertingHttp.TestKeyPem,
+							CACertificate:      alertingHttp.TestCACert,
+						},
+						ProxyConfig: &alertingHttp.ProxyConfig{
+							ProxyURL:             "http://localproxy:8080",
+							NoProxy:              "localhost",
+							ProxyFromEnvironment: false,
+							ProxyConnectHeader: map[string]string{
+								"X-Proxy-Header": "proxy-value",
+							},
+						},
 					},
 				},
 			},

--- a/receivers/webhook/testing.go
+++ b/receivers/webhook/testing.go
@@ -28,22 +28,32 @@ var FullValidConfigForTesting = fmt.Sprintf(`{
 		"header": "X-Grafana-Alerting-Signature",
 		"timestampHeader": "X-Grafana-Alerting-Timestamp"
 	},
-    "oauth2Config": {
-		"client_id": "test-client-id",
-		"client_secret": "test-client-secret",
-		"token_url": "https://localhost/auth/token",
-		"scopes": ["scope1", "scope2"],
-		"endpoint_params": {
-			"param1": "value1",
-			"param2": "value2"
-		},
-		"tls_config": {
-			"insecureSkipVerify": false,
-			"clientCertificate": %[1]q,
-			"clientKey": %[2]q,
-			"caCertificate": %[3]q
+	"http_config": {
+		"oauth2": {
+			"client_id": "test-client-id",
+			"client_secret": "test-client-secret",
+			"token_url": "https://localhost/auth/token",
+			"scopes": ["scope1", "scope2"],
+			"endpoint_params": {
+				"param1": "value1",
+				"param2": "value2"
+			},
+			"tls_config": {
+				"insecureSkipVerify": false,
+				"clientCertificate": %[1]q,
+				"clientKey": %[2]q,
+				"caCertificate": %[3]q
+			},
+			"proxy_config": {
+				"proxy_url": "http://localproxy:8080",
+				"no_proxy": "localhost",
+				"proxy_from_environment": false,
+				"proxy_connect_header": {
+					"X-Proxy-Header": "proxy-value"
+				}
+			}
 		}
-	}
+    }
 }`, http.TestCertPem, http.TestKeyPem, http.TestCACert)
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
@@ -54,8 +64,8 @@ var FullValidSecretsForTesting = fmt.Sprintf(`{
 	"tlsConfig.clientKey": %q,
 	"tlsConfig.caCertificate": %q,
 	"hmacConfig.secret": "test-override-hmac-secret",
-	"oauth2Config.client_secret": "test-override-oauth2-secret",
-	"oauth2Config.tls_config.clientCertificate": %[1]q,
-	"oauth2Config.tls_config.clientKey": %[2]q,
-	"oauth2Config.tls_config.caCertificate": %[3]q
+	"http_config.oauth2.client_secret": "test-override-oauth2-secret",
+	"http_config.oauth2.tls_config.clientCertificate": %[1]q,
+	"http_config.oauth2.tls_config.clientKey": %[2]q,
+	"http_config.oauth2.tls_config.caCertificate": %[3]q
 }`, http.TestCertPem, http.TestKeyPem, http.TestCACert)

--- a/receivers/webhook/testing.go
+++ b/receivers/webhook/testing.go
@@ -27,6 +27,22 @@ var FullValidConfigForTesting = fmt.Sprintf(`{
 		"secret": "test-hmac-secret",
 		"header": "X-Grafana-Alerting-Signature",
 		"timestampHeader": "X-Grafana-Alerting-Timestamp"
+	},
+    "oauth2Config": {
+		"client_id": "test-client-id",
+		"client_secret": "test-client-secret",
+		"token_url": "https://localhost/auth/token",
+		"scopes": ["scope1", "scope2"],
+		"endpoint_params": {
+			"param1": "value1",
+			"param2": "value2"
+		},
+		"tls_config": {
+			"insecureSkipVerify": false,
+			"clientCertificate": %[1]q,
+			"clientKey": %[2]q,
+			"caCertificate": %[3]q
+		}
 	}
 }`, http.TestCertPem, http.TestKeyPem, http.TestCACert)
 
@@ -37,5 +53,9 @@ var FullValidSecretsForTesting = fmt.Sprintf(`{
 	"tlsConfig.clientCertificate": %q,
 	"tlsConfig.clientKey": %q,
 	"tlsConfig.caCertificate": %q,
-	"hmacConfig.secret": "test-override-hmac-secret"
+	"hmacConfig.secret": "test-override-hmac-secret",
+	"oauth2Config.client_secret": "test-override-oauth2-secret",
+	"oauth2Config.tls_config.clientCertificate": %[1]q,
+	"oauth2Config.tls_config.clientKey": %[2]q,
+	"oauth2Config.tls_config.caCertificate": %[3]q
 }`, http.TestCertPem, http.TestKeyPem, http.TestCACert)


### PR DESCRIPTION
This PR introduces OAuth2 `client_credentials` grant type support for HTTP client configurations in webhook receivers.

### Current vs Future Work

This PR introduces `HTTPClientConfig` with a single field  `OAuth2` containing the new OAuth2 configuration options. This setup intentionally mimics upstream alertmanager's common `http_config` as the intention is to bring this change to all relevant integrations and eventually include other common http client configuration options in a standardized way between notifier types.

### All added configuration fields:

```yaml
http_config:
  oauth2:
    client_id: "test-client-id"
    client_secret: "test-client-secret"
    token_url: "https://localhost/auth/token"
    scopes:
      - "scope1"
      - "scope2"
    endpoint_params:
      param1: "value1"
      param2: "value2"
    tls_config:
      insecureSkipVerify: false
      caCertificate: "-----BEGIN CERTIFICATE..."
      clientCertificate: "-----BEGIN CERTIFICATE..."
      clientKey: "-----BEGIN EC PRIVATE KEY..."
    proxy_config:
      proxy_url: "http://localproxy:8080"
      no_proxy: "localhost,1.2.3.4"
      proxy_from_environment: false
      proxy_connect_header:
        X-Proxy-Header: "proxy-value"
```

### Notable differences from upstream
- `oauth2`: Does not add support for:
  -  `client_secret_file`
  -  `client_secret_ref`
- `oauth2.tls_config`:
  - Does not add support for:
    - `ca_file`
    - `cert_file`
    - `key_file`
    - `ca_ref`
    - `cert_ref`
    - `key_ref`
    - `server_name`
    - `min_version`
    - `max_version`
  - Uses the existing `TLSConfig` struct. This means out json fields does not match. Ex: `cert` vs `clientCertificate`. I'm on the fence here on whether it's worth defining a new struct to keep the field namings the same, thoughts?
- `oauth2.tls_config`:
  - `proxy_connect_header` values are not secured in Grafana as secure map values are not supported. We can consider breaking similar with upstream and adding a field specifically for `Proxy-Authorization`, thoughts?
  - Proxying is enabled (compared to Mimir AM) as we apply to firewall dialer to the oauth2 client.

### Implementation Notes
- `OAuth2` config validation is done during client creation. This is for two reasons:
  - The `tokenSource` needs to be stored outside `Notify` as the token is re-used until expiration.
  - Prefer failing invalid configuration early when creating the contact point, instead of silently failing to send notifications afterwards.
- `BuildReceiverIntegrations`: The above change means this function needs to return an error again (it was recently removed).
- It will make sense to move/extend various existing configs to the new common `http_config`, but this is not done yet. For example, the webhook notifer already has `tlsConfig` and `hmacConfig` and it would make sense to move these to `http_config`. This will require a migration though, as the config path will change and the current implementation of these options fail on Send instead of on Create.
- Since this is not the simplest feature to test/validate I added vairly comprehensive unit tests. Local testing can be done with your choice of local or cloud oauth2 provider (ex. Keycloak, Ory Hydra, Auth0, ...)

### Copilot Summary :robot: 

#### OAuth2 Integration:
* Added support for OAuth2 in `http/client.go`, including a new `oauth2.TokenSource` field in the `Client` struct and validation for OAuth2 configurations during client initialization. (`[[1]](diffhunk://#diff-db6dcd51441efbbef50fb4f0e52a2a24d0207a8cf997c2c2d18f1345e0b4b255R28-R39)`, `[[2]](diffhunk://#diff-db6dcd51441efbbef50fb4f0e52a2a24d0207a8cf997c2c2d18f1345e0b4b255L50-R71)`)
* Introduced the `WithHTTPClientConfig` option to pass HTTP client configurations, including OAuth2 settings. (`[http/client.goR88-R95](diffhunk://#diff-db6dcd51441efbbef50fb4f0e52a2a24d0207a8cf997c2c2d18f1345e0b4b255R88-R95)`)
* Enhanced the `SendWebhook` method to include OAuth2 token handling via an OAuth2 round-tripper. (`[http/client.goR149-R153](diffhunk://#diff-db6dcd51441efbbef50fb4f0e52a2a24d0207a8cf997c2c2d18f1345e0b4b255R149-R153)`)

#### Proxy Configuration:
* Added a new `ProxyConfig` struct in `http/config.go` to manage proxy settings, including support for proxy URLs, no-proxy addresses, and headers for CONNECT requests. (`[http/config.goR1-R128](diffhunk://#diff-9cd5b98b32603671d06faab6568b1be0d3f2790b8ee426270cb20cb91824997aR1-R128)`)
* Implemented validation logic for proxy configurations to ensure proper usage of proxy-related fields. (`[http/config.goR1-R128](diffhunk://#diff-9cd5b98b32603671d06faab6568b1be0d3f2790b8ee426270cb20cb91824997aR1-R128)`)

#### Test Coverage Enhancements:
* Updated tests in `http/client_test.go` to validate OAuth2 integration, including scenarios for valid and invalid configurations, token reuse, and proxy interactions. (`[[1]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6R5-R81)`, `[[2]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6R234-R531)`)
* Added a comprehensive test suite for OAuth2, covering various configurations such as scopes, endpoint parameters, and custom dialers. (`[http/client_test.goR234-R531](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6R234-R531)`)