### PR TITLE
Use template's Text() function

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -604,6 +604,10 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmplsFac
 	if err != nil {
 		return nil, err
 	}
+	txt, err := newTmpl.Text()
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepare the context.
 	alerts := OpenAPIAlertsToAlerts(c.Alerts)
@@ -612,13 +616,13 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmplsFac
 	ctx = notify.WithReceiverName(ctx, DefaultReceiverName)
 	ctx = notify.WithGroupLabels(ctx, labels)
 
-	promTmplData := notify.GetTemplateData(ctx, newTmpl.Template, alerts, logger)
+	promTmplData := notify.GetTemplateData(ctx, newTmpl, alerts, logger)
 	data := templates.ExtendData(promTmplData, logger)
 
 	// Iterate over each definition in the template and evaluate it.
 	var results TestTemplatesResults
 	for _, def := range definitions {
-		res, scope, err := testTemplateScopes(newTmpl, def, data)
+		res, scope, err := testTemplateScopes(txt, def, data)
 		if err != nil {
 			results.Errors = append(results.Errors, TestTemplatesErrorResult{
 				Name:  def,

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -152,10 +152,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	tmplFromDefinition.ExternalURL = externalURL
 
 	var tmplDefErr error
-	expandFromDefinition, _ := TmplText(context.Background(), &Template{
-		Template: tmplFromDefinition,
-		Text:     nil,
-	}, alerts, l, &tmplDefErr)
+	expandFromDefinition, _ := TmplText(context.Background(), tmplFromDefinition, alerts, l, &tmplDefErr)
 
 	cases := []struct {
 		templateString string


### PR DESCRIPTION
Since https://github.com/grafana/alerting/pull/341 Template supports providing text template. This PR updates code to avoid using captures and maintaining a copy