### PR TITLE
Fix missing oncall notifier cases in tests

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -123,7 +123,7 @@ func (ns *Client) SendWebhook(ctx context.Context, l log.Logger, webhook *receiv
 	level.Debug(l).Log("msg", "sending webhook", "url", webhook.URL, "http method", webhook.HTTPMethod)
 
 	if webhook.HTTPMethod != http.MethodPost && webhook.HTTPMethod != http.MethodPut {
-		return ErrInvalidMethod
+		return fmt.Errorf("%w: %s", ErrInvalidMethod, webhook.HTTPMethod)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, webhook.HTTPMethod, webhook.URL, bytes.NewReader([]byte(webhook.Body)))

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/alerting/receivers/kafka"
 	"github.com/grafana/alerting/receivers/line"
 	"github.com/grafana/alerting/receivers/mqtt"
+	"github.com/grafana/alerting/receivers/oncall"
 	"github.com/grafana/alerting/receivers/opsgenie"
 	"github.com/grafana/alerting/receivers/pagerduty"
 	"github.com/grafana/alerting/receivers/pushover"
@@ -155,6 +156,10 @@ var AllKnownConfigsForTesting = map[string]NotifierConfigTest{
 	"mqtt": {NotifierType: "mqtt",
 		Config:  mqtt.FullValidConfigForTesting,
 		Secrets: mqtt.FullValidSecretsForTesting,
+	},
+	"oncall": {NotifierType: "oncall",
+		Config:  oncall.FullValidConfigForTesting,
+		Secrets: oncall.FullValidSecretsForTesting,
 	},
 	"opsgenie": {NotifierType: "opsgenie",
 		Config:  opsgenie.FullValidConfigForTesting,

--- a/receivers/oncall/config_test.go
+++ b/receivers/oncall/config_test.go
@@ -74,7 +74,7 @@ func TestNewConfig(t *testing.T) {
 			settings: FullValidConfigForTesting,
 			expectedConfig: Config{
 				URL:                      "http://localhost",
-				HTTPMethod:               "test-httpMethod",
+				HTTPMethod:               "PUT",
 				MaxAlerts:                2,
 				AuthorizationScheme:      "basic",
 				AuthorizationCredentials: "",
@@ -90,7 +90,7 @@ func TestNewConfig(t *testing.T) {
 			secretSettings: receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
 			expectedConfig: Config{
 				URL:                      "http://localhost",
-				HTTPMethod:               "test-httpMethod",
+				HTTPMethod:               "PUT",
 				MaxAlerts:                2,
 				AuthorizationScheme:      "basic",
 				AuthorizationCredentials: "",

--- a/receivers/oncall/testing.go
+++ b/receivers/oncall/testing.go
@@ -3,7 +3,7 @@ package oncall
 // FullValidConfigForTesting is a string representation of a JSON object that contains all fields supported by the notifier Config. It can be used without secrets.
 const FullValidConfigForTesting = `{
 	"url": "http://localhost",
-	"httpMethod": "test-httpMethod",
+	"httpMethod": "PUT",
 	"maxAlerts": "2",
 	"authorization_scheme": "basic",
 	"authorization_credentials": "",


### PR DESCRIPTION
Oncall notifier was missing from test config and our tests did not catch this fact. This PR:

- Adds the oncall notifier to `AllKnownConfigsForTesting` so it gets tested alongside other notifiers.
- Fixes the invalid value for `httpMethod` in oncall's `FullValidConfigForTesting`.
- Improves the `ErrInvalidMethod` to show the invalid method value being attempted.
- Improves the tests in `receivers_test.go` to:
  - Centralize the code that collects all notifiers.
  - Fail if some notifiers aren't present in `AllKnownConfigsForTesting`.