### PR TITLE
Add custom JSON marshaller for Alertmanager configurations

### DIFF
--- a/definition/json.go
+++ b/definition/json.go
@@ -1,0 +1,85 @@
+package definition
+
+import (
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
+	amcfg "github.com/prometheus/alertmanager/config"
+	commoncfg "github.com/prometheus/common/config"
+)
+
+// secretEncoder encodes Secret to plain text JSON,
+// avoding the default masking behavior of the structure.
+type secretEncoder struct{}
+
+func (encoder *secretEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	stream.WriteString(getStr(ptr))
+}
+
+func (encoder *secretEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	return len(getStr(ptr)) == 0
+}
+
+func getStr(ptr unsafe.Pointer) string {
+	return *(*string)(ptr)
+}
+
+// secretEncoder encodes SecretURL to plain text JSON,
+// avoding the default masking behavior of the structure.
+type secretURLEncoder struct{}
+
+func (encoder *secretURLEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	url := getURL(ptr)
+	if url.URL != nil {
+		stream.WriteString(url.String())
+	} else {
+		stream.WriteNil()
+	}
+}
+
+func (encoder *secretURLEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	url := getURL(ptr)
+	return url.URL == nil
+}
+
+func getURL(ptr unsafe.Pointer) *amcfg.URL {
+	v := (*amcfg.SecretURL)(ptr)
+	url := amcfg.URL(*v)
+	return &url
+}
+
+func newPlainAPI() jsoniter.API {
+	api := jsoniter.ConfigCompatibleWithStandardLibrary
+
+	secretEnc := &secretEncoder{}
+	secretURLEnc := &secretURLEncoder{}
+
+	extension := jsoniter.EncoderExtension{
+		// Value types
+		reflect2.TypeOfPtr((*amcfg.Secret)(nil)).Elem():     secretEnc,
+		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)).Elem(): secretEnc,
+		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)).Elem():  secretURLEnc,
+		// Pointer types
+		reflect2.TypeOfPtr((*amcfg.Secret)(nil)):     &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
+		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)): &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
+		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)):  &jsoniter.OptionalEncoder{ValueEncoder: secretURLEnc},
+	}
+
+	api.RegisterExtension(extension)
+
+	return api
+}
+
+var (
+	plainJSON = newPlainAPI()
+)
+
+// MarshalJSONWithSecrets marshals the given value to JSON with secrets in plain text.
+//
+// alertmanager's and prometeus' Secret and SecretURL types mask their values
+// when marshaled with the standard JSON or YAML marshallers. This function
+// preserves the values of these types by using a custom JSON encoder.
+func MarshalJSONWithSecrets(v any) ([]byte, error) {
+	return plainJSON.Marshal(v)
+}

--- a/definition/json.go
+++ b/definition/json.go
@@ -10,7 +10,7 @@ import (
 )
 
 // secretEncoder encodes Secret to plain text JSON,
-// avoding the default masking behavior of the structure.
+// avoiding the default masking behavior of the structure.
 type secretEncoder struct{}
 
 func (encoder *secretEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
@@ -26,7 +26,7 @@ func getStr(ptr unsafe.Pointer) string {
 }
 
 // secretEncoder encodes SecretURL to plain text JSON,
-// avoding the default masking behavior of the structure.
+// avoiding the default masking behavior of the structure.
 type secretURLEncoder struct{}
 
 func (encoder *secretURLEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
@@ -77,7 +77,7 @@ var (
 
 // MarshalJSONWithSecrets marshals the given value to JSON with secrets in plain text.
 //
-// alertmanager's and prometeus' Secret and SecretURL types mask their values
+// alertmanager's and prometheus' Secret and SecretURL types mask their values
 // when marshaled with the standard JSON or YAML marshallers. This function
 // preserves the values of these types by using a custom JSON encoder.
 func MarshalJSONWithSecrets(v any) ([]byte, error) {

--- a/definition/json_test.go
+++ b/definition/json_test.go
@@ -1,0 +1,348 @@
+package definition
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/alertmanager/config"
+	amcfg "github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/timeinterval"
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalJSONWithSecrets(t *testing.T) {
+	u := "https://grafana.com/webhook"
+	testURL, err := url.Parse(u)
+	require.NoError(t, err)
+
+	amsLoc, err := time.LoadLocation("Europe/Amsterdam")
+	require.NoError(t, err)
+
+	// stdlib json escapes < and > characters,
+	// so just marshal the placeholder string to have the same value.
+	maskedSecretBytes, err := json.Marshal("<secret>")
+	require.NoError(t, err)
+	maskedSecret := string(maskedSecretBytes)
+
+	cfg := PostableApiAlertingConfig{
+		Config: Config{
+			Route: &Route{
+				Receiver: "test-receiver",
+			},
+			TimeIntervals: []config.TimeInterval{
+				{
+					Name: "time-interval-1",
+					TimeIntervals: []timeinterval.TimeInterval{
+						{
+							Times: []timeinterval.TimeRange{
+								{
+									StartMinute: 60,
+									EndMinute:   120,
+								},
+							},
+							Weekdays: []timeinterval.WeekdayRange{
+								{
+									InclusiveRange: timeinterval.InclusiveRange{
+										Begin: 1,
+										End:   5,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "time-interval-2",
+					TimeIntervals: []timeinterval.TimeInterval{
+						{
+							Times: []timeinterval.TimeRange{
+								{
+									StartMinute: 120,
+									EndMinute:   240,
+								},
+							},
+							Weekdays: []timeinterval.WeekdayRange{
+								{
+									InclusiveRange: timeinterval.InclusiveRange{
+										Begin: 0,
+										End:   2,
+									},
+								},
+							},
+							Location: &timeinterval.Location{Location: amsLoc},
+						},
+					},
+				},
+			},
+		},
+		Receivers: []*PostableApiReceiver{
+			{
+				Receiver: config.Receiver{
+					Name: "test-receiver",
+					WebhookConfigs: []*config.WebhookConfig{
+						{
+							URL: &config.SecretURL{URL: testURL},
+							HTTPConfig: &commoncfg.HTTPClientConfig{
+								BasicAuth: &commoncfg.BasicAuth{
+									Username: "user",
+									Password: commoncfg.Secret("password"),
+								},
+							},
+						},
+						{
+							URL: &config.SecretURL{URL: testURL},
+							HTTPConfig: &commoncfg.HTTPClientConfig{
+								Authorization: &commoncfg.Authorization{
+									Type:        "Bearer",
+									Credentials: commoncfg.Secret("bearer-token-secret"),
+								},
+							},
+						},
+					},
+					EmailConfigs: []*config.EmailConfig{
+						{
+							To:           "test@grafana.com",
+							From:         "alerts@grafana.com",
+							AuthUsername: "smtp-user",
+							AuthPassword: config.Secret("smtp-password"),
+							AuthSecret:   config.Secret("smtp-secret"),
+							Headers:      map[string]string{},
+							HTML:         "{{ template \"email.default.html\" . }}",
+						},
+						{
+							To:           "test2@grafana.com",
+							From:         "alerts2@grafana.com",
+							AuthUsername: "smtp-user2",
+							AuthPassword: config.Secret(""),
+							AuthSecret:   config.Secret("smtp-secret2"),
+							Headers:      map[string]string{},
+							HTML:         "{{ template \"email.default.html\" . }}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	standardJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	plainJSONBytes, err := MarshalJSONWithSecrets(cfg)
+	require.NoError(t, err)
+	require.True(t, json.Valid(plainJSONBytes))
+
+	require.True(t, json.Valid(standardJSON))
+	require.Contains(t, string(standardJSON), maskedSecret)
+
+	var roundTripCfg PostableApiAlertingConfig
+	err = json.Unmarshal(plainJSONBytes, &roundTripCfg)
+	require.NoError(t, err)
+	require.Equal(t, cfg, roundTripCfg)
+}
+
+func TestSecretTypeMarshaling(t *testing.T) {
+	// stdlib json escapes < and > characters,
+	// so just marshal the placeholder string to have the same value.
+	maskedSecretBytes, err := json.Marshal("<secret>")
+	require.NoError(t, err)
+	maskedSecret := string(maskedSecretBytes)
+
+	tests := []struct {
+		name           string
+		secret         any
+		expectStandard string
+		expectPlain    string
+	}{
+		{
+			name:           "nil",
+			secret:         nil,
+			expectStandard: `null`,
+			expectPlain:    `null`,
+		},
+		{
+			name:           "alertmanager config secret",
+			secret:         config.Secret("my-secret"),
+			expectStandard: maskedSecret,
+			expectPlain:    `"my-secret"`,
+		},
+		{
+			name:           "common config secret",
+			secret:         commoncfg.Secret("common-secret"),
+			expectStandard: maskedSecret,
+			expectPlain:    `"common-secret"`,
+		},
+		{
+			name:           "empty alertmanager secret",
+			secret:         config.Secret(""),
+			expectStandard: maskedSecret,
+			expectPlain:    `""`,
+		},
+		{
+			name:           "empty common secret",
+			secret:         commoncfg.Secret(""),
+			expectStandard: `""`,
+			expectPlain:    `""`,
+		},
+		{
+			name:           "nil alertmanager secret pointer",
+			secret:         (*config.Secret)(nil),
+			expectStandard: "null",
+			expectPlain:    "null",
+		},
+		{
+			name:           "nil common config secret pointer",
+			secret:         (*commoncfg.Secret)(nil),
+			expectStandard: "null",
+			expectPlain:    "null",
+		},
+		{
+			name:           "pointer to alertmanager secret",
+			secret:         func() *config.Secret { s := config.Secret("pointer-secret"); return &s }(),
+			expectStandard: maskedSecret,
+			expectPlain:    `"pointer-secret"`,
+		},
+		{
+			name:           "pointer to common secret",
+			secret:         func() *commoncfg.Secret { s := commoncfg.Secret("pointer-common"); return &s }(),
+			expectStandard: maskedSecret,
+			expectPlain:    `"pointer-common"`,
+		},
+		{
+			name:           "secret with special characters",
+			secret:         config.Secret("secret with spaces\nand\t 🔑"),
+			expectStandard: maskedSecret,
+			expectPlain:    `"secret with spaces\nand\t 🔑"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			standard, err := json.Marshal(tt.secret)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectStandard, string(standard))
+
+			plain, err := MarshalJSONWithSecrets(tt.secret)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectPlain, string(plain))
+		})
+	}
+}
+
+func TestSecretURLTypeMarshaling(t *testing.T) {
+	u := "https://grafana.com/webhook"
+	testURL, err := url.Parse(u)
+	require.NoError(t, err)
+
+	// stdlib json escapes < and > characters,
+	// so just marshal the placeholder string to have the same value.
+	maskedSecretBytes, err := json.Marshal("<secret>")
+	require.NoError(t, err)
+	maskedSecret := string(maskedSecretBytes)
+
+	complexURL, err := url.Parse("https://user:pass@example.com:8080/path?query=value#fragment")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		secretURL      interface{}
+		expectStandard string
+		expectPlain    string
+	}{
+		{
+			name:           "non-empty URL",
+			secretURL:      config.SecretURL{URL: testURL},
+			expectStandard: maskedSecret,
+			expectPlain:    fmt.Sprintf(`"%s"`, u),
+		},
+		{
+			name:           "empty URL",
+			secretURL:      config.SecretURL{},
+			expectStandard: maskedSecret,
+			expectPlain:    `null`,
+		},
+		{
+			name:           "complex URL",
+			secretURL:      config.SecretURL{URL: complexURL},
+			expectStandard: maskedSecret,
+			expectPlain:    fmt.Sprintf(`"%s"`, complexURL.String()),
+		},
+		{
+			name:           "nil URL pointer",
+			secretURL:      (*config.SecretURL)(nil),
+			expectStandard: "null",
+			expectPlain:    "null",
+		},
+		{
+			name:           "URL pointer",
+			secretURL:      &config.SecretURL{URL: testURL},
+			expectStandard: maskedSecret,
+			expectPlain:    fmt.Sprintf(`"%s"`, u),
+		},
+		{
+			name:           "pointer to empty URL",
+			secretURL:      &config.SecretURL{},
+			expectStandard: maskedSecret,
+			expectPlain:    `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			standard, err := json.Marshal(tt.secretURL)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectStandard, string(standard))
+
+			plain, err := MarshalJSONWithSecrets(tt.secretURL)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectPlain, string(plain))
+		})
+	}
+}
+
+func TestSecretOmitempty(t *testing.T) {
+	type testStruct struct {
+		Secret    amcfg.Secret     `json:"secret,omitempty"`
+		SecretPtr *amcfg.Secret    `json:"secret_ptr,omitempty"`
+		URL       amcfg.SecretURL  `json:"url,omitempty"`
+		URLPtr    *amcfg.SecretURL `json:"url_ptr,omitempty"`
+	}
+
+	tests := []struct {
+		name     string
+		value    testStruct
+		expected string
+	}{
+		{
+			name:     "all empty",
+			value:    testStruct{},
+			expected: `{}`,
+		},
+		{
+			name: "all present",
+			value: testStruct{
+				Secret:    amcfg.Secret("secret1"),
+				SecretPtr: func() *amcfg.Secret { s := amcfg.Secret("secret2"); return &s }(),
+				URL:       amcfg.SecretURL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+				URLPtr:    &amcfg.SecretURL{URL: &url.URL{Scheme: "https", Host: "example2.com"}},
+			},
+			expected: `{
+				"secret": "secret1",
+				"secret_ptr": "secret2",
+				"url": "https://example.com",
+				"url_ptr": "https://example2.com"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := MarshalJSONWithSecrets(tt.value)
+			require.NoError(t, err)
+			require.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/google/go-cmp v0.6.0
+	github.com/json-iterator/go v1.1.12
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
+	github.com/modern-go/reflect2 v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.25.0
 	github.com/prometheus/client_golang v1.20.4
@@ -75,6 +77,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/oklog/run v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -413,9 +414,11 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
This PR adds a custom JSON marshaler (`MarshalJSONWithSecrets`) that can serialize Alertmanager configurations with secrets in plain text rather than masked values. It uses `jsoniter` to create custom encoders for secret types from Prometheus and Alertmanager.

It is not used yet.

Prometheus Alertmanager uses a few types of secret structs:
- [prometheus/common Secret](https://github.com/prometheus/common/blob/75c3814dc66c571cc82cee2d3a6bf5f37ee73f1a/config/config.go#L28)
- [prometheus/alertmanager Secret](https://github.com/prometheus/alertmanager/blob/0ce3cfb962db3cbb1649d3e816a49a13c4036cd1/config/config.go#L56)
- [prometheus/alertmanager SecretURL](https://github.com/prometheus/alertmanager/blob/0ce3cfb962db3cbb1649d3e816a49a13c4036cd1/config/config.go#L142)

During marshaling, secrets in these structs are masked (this can be controlled only via a global variable), but sometimes we need to preserve them and this PR adds a custom marshaler for these situations.


Part of https://github.com/grafana/alerting-squad/issues/1152