### PR TITLE
Allow mixed receiver configurations in PostableApiReceiver

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -566,34 +566,6 @@ func (r *PostableApiReceiver) UnmarshalYAML(unmarshal func(interface{}) error) e
 		return err
 	}
 
-	hasGrafanaReceivers := len(r.PostableGrafanaReceivers.GrafanaManagedReceivers) > 0
-
-	if hasGrafanaReceivers {
-		if len(r.EmailConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager EmailConfigs & Grafana receivers together")
-		}
-		if len(r.PagerdutyConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager PagerdutyConfigs & Grafana receivers together")
-		}
-		if len(r.SlackConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager SlackConfigs & Grafana receivers together")
-		}
-		if len(r.WebhookConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager WebhookConfigs & Grafana receivers together")
-		}
-		if len(r.OpsGenieConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager OpsGenieConfigs & Grafana receivers together")
-		}
-		if len(r.WechatConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager WechatConfigs & Grafana receivers together")
-		}
-		if len(r.PushoverConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager PushoverConfigs & Grafana receivers together")
-		}
-		if len(r.VictorOpsConfigs) > 0 {
-			return fmt.Errorf("cannot have both Alertmanager VictorOpsConfigs & Grafana receivers together")
-		}
-	}
 	return nil
 }
 

--- a/definition/alertmanager_test.go
+++ b/definition/alertmanager_test.go
@@ -47,23 +47,6 @@ func Test_ApiReceiver_Marshaling(t *testing.T) {
 				},
 			},
 		},
-		{
-			desc: "failure mixed",
-			input: PostableApiReceiver{
-				Receiver: config.Receiver{
-					Name: "foo",
-					EmailConfigs: []*config.EmailConfig{{
-						To:      "test@test.com",
-						HTML:    config.DefaultEmailConfig.HTML,
-						Headers: map[string]string{},
-					}},
-				},
-				PostableGrafanaReceivers: PostableGrafanaReceivers{
-					GrafanaManagedReceivers: []*PostableGrafanaReceiver{{}},
-				},
-			},
-			err: true,
-		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			encoded, err := json.Marshal(tc.input)


### PR DESCRIPTION
Since now there is [support](https://github.com/grafana/alerting/pull/339) for building mixed integrations, removing the validation.

Part of https://github.com/grafana/alerting-squad/issues/1152