### PR TITLE
Receiver\integration specific templates

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -231,7 +231,7 @@ func BuildPrometheusReceiverIntegrations(
 		httpOps      []commoncfg.HTTPClientOption
 		initOnce     = sync.OnceFunc(func() { // lazy evaluate template so we do not create one if we don't need it
 			httpOps = http.ToHTTPClientOption(httpClientOptions...)
-			t, err := tmplProvider.GetTemplate(templates.MimirKind)
+			t, err := tmplProvider.GetTemplate(templates.MimirKind, nil)
 			if err != nil {
 				errs.Add(err)
 				return
@@ -358,7 +358,7 @@ func BuildReceiverIntegrations(
 		if err != nil {
 			return nil, err
 		}
-		tmpl, err := tmpls.GetTemplate(templates.GrafanaKind)
+		tmpl, err := tmpls.GetTemplate(templates.GrafanaKind, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"golang.org/x/sync/errgroup"
 
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
@@ -66,7 +67,7 @@ type ClusterPeer interface {
 }
 
 type TemplatesProvider interface {
-	GetTemplate(kind templates.Kind) (*templates.Template, error)
+	GetTemplate(kind templates.Kind, labels model.LabelSet) (*templates.Template, error)
 }
 
 type GrafanaAlertmanager struct {
@@ -600,7 +601,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmplsFac
 		}, nil
 	}
 
-	newTmpl, err := factory.GetTemplate(tc.Kind)
+	newTmpl, err := factory.GetTemplate(tc.Kind, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -81,6 +81,7 @@ type ConfigReceiver = config.Receiver
 type APIReceiver struct {
 	ConfigReceiver      `yaml:",inline"`
 	GrafanaIntegrations `yaml:",inline"`
+	Labels              model.LabelSet
 }
 
 type GrafanaIntegrations struct {
@@ -179,6 +180,7 @@ func ProcessIntegrationError(config *GrafanaIntegrationConfig, err error) error 
 // GrafanaReceiverConfig represents a parsed and validated APIReceiver
 type GrafanaReceiverConfig struct {
 	Name                string
+	Labels              model.LabelSet
 	AlertmanagerConfigs []*NotifierConfig[alertmanager.Config]
 	DingdingConfigs     []*NotifierConfig[dinding.Config]
 	DiscordConfigs      []*NotifierConfig[discord.Config]
@@ -257,7 +259,8 @@ func NoopDecrypt(_ context.Context, sjd map[string][]byte, key string, fallback 
 // BuildReceiverConfiguration parses, decrypts and validates the APIReceiver.
 func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) (GrafanaReceiverConfig, error) {
 	result := GrafanaReceiverConfig{
-		Name: api.Name,
+		Name:   api.Name,
+		Labels: api.Labels,
 	}
 	for i, receiver := range api.Integrations {
 		err := parseNotifier(ctx, &result, receiver, decode, decrypt, i)

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/templates"
 )
@@ -100,10 +101,10 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 	return TestTemplate(ctx, c, templateFactory, log.With(am.logger, "operation", "TestTemplate"))
 }
 
-func (am *GrafanaAlertmanager) GetTemplate(kind templates.Kind) (*template.Template, error) {
+func (am *GrafanaAlertmanager) GetTemplate(kind templates.Kind, labels model.LabelSet) (*template.Template, error) {
 	am.reloadConfigMtx.RLock()
 	defer am.reloadConfigMtx.RUnlock()
-	t, err := am.templates.GetTemplate(kind)
+	t, err := am.templates.GetTemplate(kind, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -145,7 +146,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 	maps.Copy(seen, validKinds)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			templ, err := f.GetTemplate(tc.kind)
+			templ, err := f.GetTemplate(tc.kind, nil)
 			assert.NoError(t, err)
 			require.NotNil(t, templ)
 			var tmplErr error
@@ -164,7 +165,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 
 	t.Run("should apply user-defined templates", func(t *testing.T) {
 		for kind := range validKinds {
-			templ, err := f.GetTemplate(kind)
+			templ, err := f.GetTemplate(kind, nil)
 			require.NoError(t, err)
 			var tmplErr error
 			tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -183,19 +184,52 @@ func TestFactoryNewTemplate(t *testing.T) {
 			},
 		}, log.NewNopLogger(), "http://localhost", "grafana")
 		require.NoError(t, err)
-		templ, err := f.GetTemplate(GrafanaKind)
+		templ, err := f.GetTemplate(GrafanaKind, nil)
 		require.NoError(t, err)
 		var tmplErr error
 		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
 		result := tmpl(`{{ template "factory_test" . }}`)
 		require.NoError(t, tmplErr)
 		require.Equal(t, `TEST Grafana KIND`, result)
-		templ, err = f.GetTemplate(MimirKind)
+		templ, err = f.GetTemplate(MimirKind, nil)
 		require.NoError(t, err)
 		require.NotNil(t, templ)
 		tmpl, _ = TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
 		_ = tmpl(`{{ template "factory_test" . }}`)
 		require.ErrorContains(t, tmplErr, `template "factory_test" not defined`)
+	})
+
+	t.Run("user-defined should be selectable", func(t *testing.T) {
+		f, err := NewFactory([]TemplateDefinition{
+			{
+				Name:     "test-1",
+				Kind:     GrafanaKind,
+				Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, GrafanaKind),
+			},
+			{
+				Name:     "test-2",
+				Kind:     GrafanaKind,
+				Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND OVERRIDDEN{{ end }}`, GrafanaKind),
+				Matchers: labels.Matchers{
+					{Type: labels.MatchEqual, Name: "test", Value: "test"},
+				},
+			},
+		}, log.NewNopLogger(), "http://localhost", "grafana")
+
+		templ, err := f.GetTemplate(GrafanaKind, model.LabelSet{"test": "test"})
+		require.NoError(t, err)
+		var tmplErr error
+		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+		result := tmpl(`{{ template "factory_test" . }}`)
+		require.NoError(t, tmplErr)
+		require.Equal(t, `TEST Grafana KIND OVERRIDDEN`, result)
+
+		templ, err = f.GetTemplate(GrafanaKind, model.LabelSet{"test": "test2"})
+		require.NoError(t, err)
+		tmpl, _ = TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
+		result = tmpl(`{{ template "factory_test" . }}`)
+		require.NoError(t, tmplErr)
+		require.Equal(t, `TEST Grafana KIND`, result)
 	})
 }
 
@@ -205,7 +239,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	initial := TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST{{ end }}`}
 	f, err := NewFactory([]TemplateDefinition{initial}, log.NewNopLogger(), "http://localhost", "grafana")
 	require.NoError(t, err)
-	templ, err := f.GetTemplate(kind)
+	templ, err := f.GetTemplate(kind, nil)
 	require.NoError(t, err)
 	var tmplErr error
 	tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -216,7 +250,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	t.Run("should add new template", func(t *testing.T) {
 		f2, err := f.WithTemplate(TemplateDefinition{Name: "test2", Kind: kind, Template: `{{ define "factory_test2" }}TEST2{{ end }}`})
 		require.NoError(t, err)
-		templ, err := f2.GetTemplate(kind)
+		templ, err := f2.GetTemplate(kind, nil)
 		require.NoError(t, err)
 		var tmplErr error
 		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)
@@ -228,7 +262,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	t.Run("should replace existing template", func(t *testing.T) {
 		f2, err := f.WithTemplate(TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST2{{ end }}`})
 		require.NoError(t, err)
-		templ, err := f2.GetTemplate(kind)
+		templ, err := f2.GetTemplate(kind, nil)
 		require.NoError(t, err)
 		var tmplErr error
 		tmpl, _ := TmplText(context.Background(), templ, as, log.NewNopLogger(), &tmplErr)

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -290,7 +290,7 @@ func TestCachedTemplateFactory(t *testing.T) {
 	cached := NewCachedFactory(f)
 
 	for i := 0; i < 3; i++ { // check many times to ensure that clone it always return clean clone
-		tmpl, err := cached.GetTemplate(GrafanaKind)
+		tmpl, err := cached.GetTemplate(GrafanaKind, nil)
 		require.NoError(t, err)
 
 		expanded, err := tmpl.ExecuteTextString(`{{ template "factory_test" . }}`, nil)

--- a/templates/mimir_template_test.go
+++ b/templates/mimir_template_test.go
@@ -27,7 +27,7 @@ func Test_withCustomFunctions(t *testing.T) {
 
 	f, err := NewFactory(nil, log.NewNopLogger(), "http://localhost", "test")
 	assert.NoError(t, err)
-	tmpl, err := f.GetTemplate(MimirKind)
+	tmpl, err := f.GetTemplate(MimirKind, nil)
 	assert.NoError(t, err)
 	cases := []tc{
 		{
@@ -153,7 +153,7 @@ func Test_loadTemplates(t *testing.T) {
 			}
 			f, err := NewFactory(def, log.NewNopLogger(), "http://localhost", "grafana")
 			require.NoError(t, err)
-			tmpl, err := f.GetTemplate(MimirKind)
+			tmpl, err := f.GetTemplate(MimirKind, nil)
 			assert.NoError(t, err)
 
 			call := fmt.Sprintf(`{{ template "%s" . }}`, c.invoke)

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/alertmanager/pkg/labels"
 
 	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/notify"
@@ -85,6 +86,8 @@ type TemplateDefinition struct {
 	Template string
 	// Kind of the template. Determines which base templates and functions are available.
 	Kind Kind
+	// Matchers is optional set matchers that let pick the template only if request contains labels that match the set
+	Matchers labels.Matchers
 }
 
 func (t TemplateDefinition) Validate() error {


### PR DESCRIPTION
This PR proposes a more granular control over the templates for each receiver\integrations. The approach based on label matchers approach that is very common in alerting:
- Receiver definition is extended with supporting LabelSet.
- TempalateDefinition is extended with labels.Matchers
- Template factory is updated to select templates based on labels
- Receiver builder is updated to create template per integration. This allowed providing additional label to template factory "integrationType", which provides ability to pick template specific to a integration of a specific template kind.

Also, by adding specific labels to receivers we can merge many Mimir configurations into a single Alertmanager providing isolation for receivers and templates.