### PR TITLE
Notification history

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -54,7 +54,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 			return n
 		}
 
-		integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version)
+		integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, nil)
 		require.NoError(t, err)
 
 		require.Len(t, integrations, qty)
@@ -80,7 +80,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 				}),
 			}
 
-			integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, clientOpts...)
+			integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, nil, clientOpts...)
 			require.NoError(t, err)
 
 			require.Len(t, integrations, qty)
@@ -117,7 +117,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	t.Run("should not produce any integration if config is empty", func(t *testing.T) {
 		cfg := GrafanaReceiverConfig{Name: "test"}
 
-		integrations, err := BuildGrafanaReceiverIntegrations(cfg, tmpl, imageProvider, log.NewNopLogger(), emailService, noopWrapper, orgID, version)
+		integrations, err := BuildGrafanaReceiverIntegrations(cfg, tmpl, imageProvider, log.NewNopLogger(), emailService, noopWrapper, orgID, version, nil)
 		require.NoError(t, err)
 		require.Empty(t, integrations)
 	})
@@ -169,6 +169,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			},
 			version,
 			log.NewNopLogger(),
+			nil,
 		)
 		require.NoError(t, err)
 		require.Contains(t, actual, "test1")
@@ -215,6 +216,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			},
 			version,
 			log.NewNopLogger(),
+			nil,
 		)
 		require.NoError(t, err)
 		require.Contains(t, actual, "test")

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -179,6 +179,8 @@ type GrafanaAlertmanagerOpts struct {
 	Peer    ClusterPeer
 	Logger  log.Logger
 	Metrics *GrafanaAlertmanagerMetrics
+
+	NotificationHistorian nfstatus.NotificationHistorian
 }
 
 func (c *GrafanaAlertmanagerOpts) Validate() error {
@@ -697,6 +699,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 		NoWrap,
 		am.opts.Version,
 		am.logger,
+		am.opts.NotificationHistorian,
 	)
 	if err != nil {
 		return err
@@ -945,5 +948,6 @@ func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver *APIReceiver, 
 		NoWrap,
 		am.opts.Version,
 		am.logger,
+		am.opts.NotificationHistorian,
 	)
 }

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -597,8 +597,8 @@ func TestGrafanaAlertmanager_setInhibitionRulesMetrics(t *testing.T) {
 func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
 	fn := &fakeNotifier{}
 	integrations := []*nfstatus.Integration{
-		nfstatus.NewIntegration(fn, fn, "grafana-oncall", 0, "test-grafana-oncall"),
-		nfstatus.NewIntegration(fn, fn, "sns", 1, "test-sns"),
+		nfstatus.NewIntegration(fn, fn, "grafana-oncall", 0, "test-grafana-oncall", nil),
+		nfstatus.NewIntegration(fn, fn, "sns", 1, "test-sns", nil),
 	}
 
 	am, reg := setupAMTest(t)

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -11,7 +11,7 @@ import (
 )
 
 type NotificationHistorian interface {
-	Record(ctx context.Context, alerts []*types.Alert, notificationErr error) <-chan error
+	Record(ctx context.Context, alerts []*types.Alert, retry bool, notificationErr error, duration time.Duration) <-chan error
 }
 
 // Integration wraps an upstream notify.Integration, adding the ability to
@@ -99,7 +99,7 @@ func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Ale
 	duration := time.Since(start)
 
 	if n.notificationHistorian != nil {
-		n.notificationHistorian.Record(ctx, alerts, err)
+		n.notificationHistorian.Record(ctx, alerts, retry, err, duration)
 	}
 
 	n.mtx.Lock()

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -10,6 +10,10 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+type NotificationHistorian interface {
+	Record(ctx context.Context, alerts []*types.Alert, notificationErr error) error
+}
+
 // Integration wraps an upstream notify.Integration, adding the ability to
 // capture notification status.
 type Integration struct {
@@ -18,9 +22,9 @@ type Integration struct {
 }
 
 // NewIntegration returns a new integration.
-func NewIntegration(notifier notify.Notifier, rs notify.ResolvedSender, name string, idx int, receiverName string) *Integration {
+func NewIntegration(notifier notify.Notifier, rs notify.ResolvedSender, name string, idx int, receiverName string, notificationHistorian NotificationHistorian) *Integration {
 	// Wrap the provided Notifier with our own, which will capture notification attempt errors.
-	status := &statusCaptureNotifier{upstream: notifier}
+	status := &statusCaptureNotifier{upstream: notifier, notificationHistorian: notificationHistorian}
 
 	integration := notify.NewIntegration(status, rs, name, idx, receiverName)
 
@@ -79,7 +83,8 @@ func GetIntegrations(integrations []*Integration) []*notify.Integration {
 
 // statusCaptureNotifier is used to wrap a notify.Notifer and capture information about attempts.
 type statusCaptureNotifier struct {
-	upstream notify.Notifier
+	upstream              notify.Notifier
+	notificationHistorian NotificationHistorian
 
 	mtx                       sync.RWMutex
 	lastNotifyAttempt         time.Time
@@ -92,6 +97,8 @@ func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Ale
 	start := time.Now()
 	retry, err := n.upstream.Notify(ctx, alerts...)
 	duration := time.Since(start)
+
+	n.notificationHistorian.Record(ctx, alerts, err)
 
 	n.mtx.Lock()
 	defer n.mtx.Unlock()

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -11,7 +11,7 @@ import (
 )
 
 type NotificationHistorian interface {
-	Record(ctx context.Context, alerts []*types.Alert, notificationErr error) error
+	Record(ctx context.Context, alerts []*types.Alert, notificationErr error) <-chan error
 }
 
 // Integration wraps an upstream notify.Integration, adding the ability to

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -98,7 +98,9 @@ func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Ale
 	retry, err := n.upstream.Notify(ctx, alerts...)
 	duration := time.Since(start)
 
-	n.notificationHistorian.Record(ctx, alerts, err)
+	if n.notificationHistorian != nil {
+		n.notificationHistorian.Record(ctx, alerts, err)
+	}
 
 	n.mtx.Lock()
 	defer n.mtx.Unlock()

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -503,6 +503,7 @@ func TestHTTPConfig(t *testing.T) {
 					NoWrap,
 					rand.Int63(),
 					fmt.Sprintf("Grafana v%d", rand.Uint32()),
+					nil,
 					alertingHttp.WithDialer(net.Dialer{
 						// Prevent all network calls not going to oauth2Server or testServer.
 						// Since we're actually calling the real Notify method, this is to ensure that

--- a/receivers/jira/jira_test.go
+++ b/receivers/jira/jira_test.go
@@ -542,9 +542,8 @@ func TestNotify(t *testing.T) {
 								transition,
 							},
 						}), 200)
-					} else {
-						return cmd.Validation(nil, 200)
 					}
+					return cmd.Validation(nil, 200)
 				default:
 					t.Fatalf("unexpected url: %s", cmd.URL)
 					return nil
@@ -747,9 +746,8 @@ func TestNotify(t *testing.T) {
 								transition,
 							},
 						}), 200)
-					} else {
-						return cmd.Validation(nil, 200)
 					}
+					return cmd.Validation(nil, 200)
 				default:
 					t.Fatalf("unexpected url: %s", cmd.URL)
 					return nil


### PR DESCRIPTION
This PR introduces a concept of "Notification Historian". A notification historian is similar to a state historian used by Alert State History. Instead of capturing state transitions, a notification historian captures the result of integration's `Notify` method call.

This is useful for the ongoing Notification History project and will allow to write notification logs to Loki. The actual implementation of Loki notification historian will be added in https://github.com/grafana/grafana/pull/107644.