### PR TITLE
Add methods for merging silences and nflog entries

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -309,6 +309,14 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 	return am, nil
 }
 
+func (am *GrafanaAlertmanager) MergeSilences(sil []byte) error {
+	return am.silences.Merge(sil)
+}
+
+func (am *GrafanaAlertmanager) MergeNflog(nflog []byte) error {
+	return am.notificationLog.Merge(nflog)
+}
+
 func (am *GrafanaAlertmanager) TenantID() int64 {
 	return am.opts.TenantID
 }


### PR DESCRIPTION
This PR adds methods for merging silences and nflog entries to the Grafana Alertmanager. This can be used by Grafana to add external state to an Alertmanager.