### PR TITLE
Bump go and golangci-lint version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,38 +1,44 @@
+version: "2"
 output:
-  formats: line-number
-
+  formats:
+    text:
+      path: stdout
+      colors: false
 linters:
   enable:
-    - goimports
-    - gofmt
-    - misspell
     - errorlint
+    - misspell
     - revive
-
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - (github.com/go-kit/kit/log.Logger).Log
-      - (github.com/go-kit/log.Logger).Log
-
-  errorlint:
-    # Check for plain error comparisons.
-    comparison: true
-
-    # Do not check for plain type assertions and type switches.
-    asserts: false
-
-    errorf: false
-
-run:
-  timeout: 5m
-
-issues:
-  exclude-dirs:
-    - alerting/channels # TODO(gotjosh): remove this once we get to aligning the notifiers.
-
-  # List of build tags, all linters use it.
-  build-tags:
-    - netgo
-    - requires_docker
-    - requires_libpcap
+  settings:
+    errcheck:
+      exclude-functions:
+        - (github.com/go-kit/kit/log.Logger).Log
+        - (github.com/go-kit/log.Logger).Log
+    errorlint:
+      errorf: false
+      asserts: false
+      comparison: true
+    revive:
+      confidence: 3
+      severity: warning
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,4 @@ mod-check:
 	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.10.0
 
 .tools/bin/golangci-lint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2

--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -540,7 +540,7 @@ func (r *PostableApiReceiver) HasGrafanaIntegrations() bool {
 }
 
 func (r *PostableApiReceiver) GetName() string {
-	return r.Receiver.Name
+	return r.Name
 }
 
 // CopyIntegrations appends all integrations, Mimir and Grafana, from source receiver to destination.

--- a/definition/alertmanager_test.go
+++ b/definition/alertmanager_test.go
@@ -1472,9 +1472,9 @@ func TestCopyIntegrations(t *testing.T) {
 				},
 			},
 		}, dst)
-		require.Same(t, mimirEmail, dst.Receiver.EmailConfigs[0])
-		require.Same(t, mimirSlack, dst.Receiver.SlackConfigs[0])
-		require.Same(t, grafana, dst.PostableGrafanaReceivers.GrafanaManagedReceivers[0])
+		require.Same(t, mimirEmail, dst.EmailConfigs[0])
+		require.Same(t, mimirSlack, dst.SlackConfigs[0])
+		require.Same(t, grafana, dst.GrafanaManagedReceivers[0])
 	})
 
 	t.Run("should append to existing integrations", func(t *testing.T) {

--- a/definition/compat.go
+++ b/definition/compat.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v3"
+
+	"github.com/prometheus/alertmanager/config"
 )
 
 // LoadCompat loads a PostableApiAlertingConfig from a YAML configuration
@@ -243,13 +244,13 @@ func GrafanaToUpstreamConfig(cfg *PostableApiAlertingConfig) config.Config {
 	}
 
 	return config.Config{
-		Global:            cfg.Config.Global,
-		Route:             cfg.Config.Route.AsAMRoute(),
-		InhibitRules:      cfg.Config.InhibitRules,
+		Global:            cfg.Global,
+		Route:             cfg.Route.AsAMRoute(),
+		InhibitRules:      cfg.InhibitRules,
 		Receivers:         rcvs,
-		Templates:         cfg.Config.Templates,
-		MuteTimeIntervals: cfg.Config.MuteTimeIntervals,
-		TimeIntervals:     cfg.Config.TimeIntervals,
+		Templates:         cfg.Templates,
+		MuteTimeIntervals: cfg.MuteTimeIntervals,
+		TimeIntervals:     cfg.TimeIntervals,
 	}
 }
 

--- a/definition/json_test.go
+++ b/definition/json_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/alertmanager/config"
-	amcfg "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/timeinterval"
 	commoncfg "github.com/prometheus/common/config"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalJSONWithSecrets(t *testing.T) {
@@ -305,10 +305,10 @@ func TestSecretURLTypeMarshaling(t *testing.T) {
 
 func TestSecretOmitempty(t *testing.T) {
 	type testStruct struct {
-		Secret    amcfg.Secret     `json:"secret,omitempty"`
-		SecretPtr *amcfg.Secret    `json:"secret_ptr,omitempty"`
-		URL       amcfg.SecretURL  `json:"url,omitempty"`
-		URLPtr    *amcfg.SecretURL `json:"url_ptr,omitempty"`
+		Secret    config.Secret     `json:"secret,omitempty"`
+		SecretPtr *config.Secret    `json:"secret_ptr,omitempty"`
+		URL       config.SecretURL  `json:"url,omitempty"`
+		URLPtr    *config.SecretURL `json:"url_ptr,omitempty"`
 	}
 
 	tests := []struct {
@@ -324,10 +324,10 @@ func TestSecretOmitempty(t *testing.T) {
 		{
 			name: "all present",
 			value: testStruct{
-				Secret:    amcfg.Secret("secret1"),
-				SecretPtr: func() *amcfg.Secret { s := amcfg.Secret("secret2"); return &s }(),
-				URL:       amcfg.SecretURL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
-				URLPtr:    &amcfg.SecretURL{URL: &url.URL{Scheme: "https", Host: "example2.com"}},
+				Secret:    config.Secret("secret1"),
+				SecretPtr: func() *config.Secret { s := config.Secret("secret2"); return &s }(),
+				URL:       config.SecretURL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+				URLPtr:    &config.SecretURL{URL: &url.URL{Scheme: "https", Host: "example2.com"}},
 			},
 			expected: `{
 				"secret": "secret1",

--- a/definition/mimir_validation.go
+++ b/definition/mimir_validation.go
@@ -181,7 +181,7 @@ func validateReceiverHTTPConfig(cfg commoncfg.HTTPClientConfig) error {
 			return errOAuth2SecretFileNotAllowed
 		}
 		// Mimir's "firewall" doesn't protect OAuth2 client, so we disallow Proxy settings here.
-		if cfg.OAuth2.ProxyURL.URL != nil && cfg.OAuth2.ProxyURL.URL.String() != "" {
+		if cfg.OAuth2.ProxyURL.URL != nil && cfg.OAuth2.ProxyURL.String() != "" {
 			return errProxyURLNotAllowed
 		}
 		if cfg.OAuth2.ProxyFromEnvironment {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/grafana/alerting
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.1

--- a/http/config.go
+++ b/http/config.go
@@ -76,13 +76,13 @@ func (cfg *ProxyConfig) Proxy() func(*http.Request) (*url.URL, error) {
 			return proxyFn(req.URL)
 		}
 	}
-	if cfg.ProxyURL.URL != nil && cfg.ProxyURL.URL.String() != "" {
+	if cfg.ProxyURL.URL != nil && cfg.ProxyURL.String() != "" {
 		if cfg.NoProxy == "" {
 			return http.ProxyURL(cfg.ProxyURL.URL)
 		}
 		proxy := &httpproxy.Config{
-			HTTPProxy:  cfg.ProxyURL.URL.String(),
-			HTTPSProxy: cfg.ProxyURL.URL.String(),
+			HTTPProxy:  cfg.ProxyURL.String(),
+			HTTPSProxy: cfg.ProxyURL.String(),
 			NoProxy:    cfg.NoProxy,
 		}
 		proxyFn := proxy.ProxyFunc()
@@ -109,7 +109,7 @@ func ValidateProxyConfig(cfg ProxyConfig) error {
 	if len(cfg.ProxyConnectHeader) > 0 && !cfg.ProxyFromEnvironment && (cfg.ProxyURL.URL == nil || cfg.ProxyURL.String() == "") {
 		return errors.New("if proxy_connect_header is configured, proxy_url or proxy_from_environment must also be configured")
 	}
-	if cfg.ProxyFromEnvironment && !(cfg.ProxyURL.URL == nil || cfg.ProxyURL.String() == "") {
+	if cfg.ProxyFromEnvironment && cfg.ProxyURL.URL != nil && cfg.ProxyURL.String() != "" {
 		return errors.New("if proxy_from_environment is configured, proxy_url must not be configured")
 	}
 	if cfg.ProxyFromEnvironment && cfg.NoProxy != "" {

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -325,8 +325,8 @@ func BuildReceiversIntegrations(
 	nameToReceiver := make(map[string]*APIReceiver, len(apiReceivers))
 	for _, receiver := range apiReceivers {
 		if existing, ok := nameToReceiver[receiver.Name]; ok {
-			itypes := make([]string, 0, len(existing.ReceiverConfig.Integrations))
-			for _, i := range existing.ReceiverConfig.Integrations {
+			itypes := make([]string, 0, len(existing.Integrations))
+			for _, i := range existing.Integrations {
 				itypes = append(itypes, i.Type)
 			}
 			level.Warn(logger).Log("msg", "receiver with same name is defined multiple times. Only the last one will be used", "receiver_name", receiver.Name, "overwritten_integrations", itypes)

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -848,14 +848,14 @@ func PostableAlertsToAlertmanagerAlerts(postableAlerts amv2.PostableAlerts, now 
 				continue
 			}
 
-			alert.Alert.Labels[model.LabelName(k)] = model.LabelValue(v)
+			alert.Labels[model.LabelName(k)] = model.LabelValue(v)
 		}
 
 		for k, v := range a.Annotations {
 			if len(v) == 0 { // Skip empty annotation.
 				continue
 			}
-			alert.Alert.Annotations[model.LabelName(k)] = model.LabelValue(v)
+			alert.Annotations[model.LabelName(k)] = model.LabelValue(v)
 		}
 
 		// Ensure StartsAt is set.

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -173,7 +173,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, NoopDecode, NoopDecrypt)
 		require.NoError(t, err)
 		require.Equal(t, recCfg.Name, parsed.Name)
-		for _, notifier := range recCfg.ReceiverConfig.Integrations {
+		for _, notifier := range recCfg.Integrations {
 			if notifier.Type == "prometheus-alertmanager" {
 				require.Equal(t, notifier.SecureSettings["basicAuthPassword"], parsed.AlertmanagerConfigs[0].Settings.Password)
 			}
@@ -212,7 +212,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.Equal(t, recCfg.Name, parsed.Name)
 
 		expectedNotifiers := make(map[string]struct{})
-		for _, notifier := range recCfg.ReceiverConfig.Integrations {
+		for _, notifier := range recCfg.Integrations {
 			expectedNotifiers[notifier.Type] = struct{}{}
 		}
 
@@ -220,10 +220,10 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		all, _ := allReceivers(&parsed)
 		require.Len(t, all, len(notifytest.AllKnownV1ConfigsForTesting), "mismatch in number of notifiers, expected %d, got %d", len(notifytest.AllKnownV1ConfigsForTesting), len(all))
 		for _, recv := range all {
-			if _, ok := expectedNotifiers[recv.Metadata.Type]; ok {
-				delete(expectedNotifiers, recv.Metadata.Type)
+			if _, ok := expectedNotifiers[recv.Type]; ok {
+				delete(expectedNotifiers, recv.Type)
 			} else {
-				t.Errorf("unexpected notifier type: %s", recv.Metadata.Type)
+				t.Errorf("unexpected notifier type: %s", recv.Type)
 			}
 		}
 		require.Empty(t, expectedNotifiers, "not all expected notifiers were found in the parsed configuration")
@@ -257,7 +257,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedNotifiers := make(map[string]struct{})
-		for _, notifier := range recCfg.ReceiverConfig.Integrations {
+		for _, notifier := range recCfg.Integrations {
 			expectedNotifiers[notifier.Type] = struct{}{}
 		}
 
@@ -265,10 +265,10 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		all, _ := allReceivers(&parsed)
 		require.Len(t, all, len(notifytest.AllKnownV1ConfigsForTesting), "mismatch in number of notifiers, expected %d, got %d", len(notifytest.AllKnownV1ConfigsForTesting), len(all))
 		for _, recv := range all {
-			if _, ok := expectedNotifiers[recv.Metadata.Type]; ok {
-				delete(expectedNotifiers, recv.Metadata.Type)
+			if _, ok := expectedNotifiers[recv.Type]; ok {
+				delete(expectedNotifiers, recv.Type)
 			} else {
-				t.Errorf("unexpected notifier type: %s", recv.Metadata.Type)
+				t.Errorf("unexpected notifier type: %s", recv.Type)
 			}
 		}
 		require.Empty(t, expectedNotifiers, "not all expected notifiers were found in the parsed configuration")

--- a/receivers/mqtt/v1/config.go
+++ b/receivers/mqtt/v1/config.go
@@ -59,15 +59,15 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.MessageFormat = MessageFormatJSON
 	}
 	if settings.MessageFormat != MessageFormatJSON && settings.MessageFormat != MessageFormatText {
-		return Config{}, errors.New("Invalid message format, must be 'json' or 'text'")
+		return Config{}, errors.New("invalid message format, must be 'json' or 'text'")
 	}
 
 	qos, err := settings.QoS.Int64()
 	if err != nil {
-		return Config{}, fmt.Errorf("Failed to parse QoS: %w", err)
+		return Config{}, fmt.Errorf("failed to parse QoS: %w", err)
 	}
 	if qos < 0 || qos > 2 {
-		return Config{}, fmt.Errorf("Invalid QoS level: %d. Must be 0, 1 or 2", qos)
+		return Config{}, fmt.Errorf("invalid QoS level: %d. Must be 0, 1 or 2", qos)
 	}
 
 	settings.Password = decryptFn("password", settings.Password)
@@ -82,7 +82,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 
 	parsedURL, err := url.Parse(settings.BrokerURL)
 	if err != nil {
-		return Config{}, errors.New("Failed to parse broker URL")
+		return Config{}, errors.New("failed to parse broker URL")
 	}
 	settings.TLSConfig.ServerName = parsedURL.Hostname()
 

--- a/receivers/mqtt/v1/config_test.go
+++ b/receivers/mqtt/v1/config_test.go
@@ -37,7 +37,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:              "Invalid message format",
 			settings:          `{ "brokerUrl" : "tcp://localhost:1883", "topic": "grafana/alerts", "messageFormat": "invalid"}`,
-			expectedInitError: `Invalid message format, must be 'json' or 'text'`,
+			expectedInitError: `invalid message format, must be 'json' or 'text'`,
 		},
 		{
 			name:     "Minimal valid configuration",

--- a/receivers/mqtt/v1/mqtt.go
+++ b/receivers/mqtt/v1/mqtt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-kit/log/level"
+
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 
@@ -82,7 +83,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	err = n.client.Connect(ctx, n.settings.BrokerURL, n.settings.ClientID, n.settings.Username, n.settings.Password, tlsCfg)
 	if err != nil {
 		level.Error(l).Log("msg", "Failed to connect to MQTT broker", "err", err.Error())
-		return false, fmt.Errorf("Failed to connect to MQTT broker: %s", err.Error())
+		return false, fmt.Errorf("failed to connect to MQTT broker: %s", err.Error())
 	}
 	defer func() {
 		err := n.client.Disconnect(ctx)
@@ -94,7 +95,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	qos, err := n.settings.QoS.Int64()
 	if err != nil {
 		level.Error(l).Log("msg", "Failed to parse QoS", "err", err.Error())
-		return false, fmt.Errorf("Failed to parse QoS: %s", err.Error())
+		return false, fmt.Errorf("failed to parse QoS: %s", err.Error())
 	}
 
 	err = n.client.Publish(
@@ -109,7 +110,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	if err != nil {
 		level.Error(l).Log("msg", "Failed to publish MQTT message", "err", err.Error())
-		return false, fmt.Errorf("Failed to publish MQTT message: %s", err.Error())
+		return false, fmt.Errorf("failed to publish MQTT message: %s", err.Error())
 	}
 
 	return true, nil
@@ -146,7 +147,7 @@ func (n *Notifier) buildMessage(ctx context.Context, l log.Logger, as ...*types.
 
 		return string(jsonMsg), nil
 	default:
-		return "", errors.New("Invalid message format")
+		return "", errors.New("invalid message format")
 	}
 }
 

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+
 	"github.com/prometheus/common/model"
 )
 
@@ -72,7 +73,7 @@ func (cfg *TLSConfig) ToCryptoTLSConfig() (*tls.Config, error) {
 		tlsCfg.RootCAs = x509.NewCertPool()
 		ok := tlsCfg.RootCAs.AppendCertsFromPEM([]byte(cfg.CACertificate))
 		if !ok {
-			return nil, errors.New("Unable to use the provided CA certificate")
+			return nil, errors.New("unable to use the provided CA certificate")
 		}
 	}
 

--- a/receivers/webhook/v1/webhook_test.go
+++ b/receivers/webhook/v1/webhook_test.go
@@ -609,7 +609,7 @@ func TestNotify(t *testing.T) {
 					},
 				},
 			},
-			expMsgError: fmt.Errorf("Unable to use the provided CA certificate"),
+			expMsgError: fmt.Errorf("unable to use the provided CA certificate"),
 		},
 		{
 			name: "bad template in url",

--- a/receivers/webhook/v1/webhook_test.go
+++ b/receivers/webhook/v1/webhook_test.go
@@ -1143,7 +1143,7 @@ func TestNotify_ExtraData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that extra data is present in the alerts
-	require.Len(t, webhookMsg.ExtendedData.Alerts, 2)
+	require.Len(t, webhookMsg.Alerts, 2)
 
 	// Check first alert's extra data
 	require.JSONEq(t, string(extraData1), string(webhookMsg.ExtendedData.Alerts[0].ExtraData))

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -250,7 +250,7 @@ func DefaultTemplate(omitTemplates []string) (TemplateDefinition, error) {
 		if name == "" || slices.Contains(omitTemplates, name) {
 			continue
 		}
-		def := tmpl.Tree.Root.String()
+		def := tmpl.Root.String()
 		if tmpl.Name() == "__text_values_list" {
 			// Temporary fix for https://github.com/golang/go/commit/6fea4094242fe4e7be8bd7ec0b55df9f6df3f025.
 			// TODO: Can remove with GO v1.24.

--- a/templates/util.go
+++ b/templates/util.go
@@ -29,7 +29,7 @@ func topTemplates(tmpl *tmpltext.Template) ([]string, error) {
 	// "name" but keep all of its named templates
 	candidateTmpls := make([]*tmpltext.Template, 0, len(definedTmpls))
 	for _, next := range definedTmpls {
-		if !(next.Name() == tmpl.ParseName && parse.IsEmptyTree(next.Root)) {
+		if next.Name() != tmpl.ParseName || !parse.IsEmptyTree(next.Root) {
 			candidateTmpls = append(candidateTmpls, next)
 		}
 	}


### PR DESCRIPTION
Bumping to go 1.24 breaks golangci-lint. So, the v1 .golangci.yml is migrated to v2 at a similar version to Grafana and various innocuous differences are fixed in code to make it pass.