### PR TITLE
Utility to calculate hash of an arbitrary object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/at-wat/mqtt-go v0.19.4
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/benbjohnson/clock v1.3.5
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/google/go-cmp v0.6.0
@@ -37,7 +38,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/utils/hash/hash.go
+++ b/utils/hash/hash.go
@@ -1,0 +1,24 @@
+package hash
+
+import (
+	"hash"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+var configForHash = &spew.ConfigState{
+	Indent:                  " ",
+	SortKeys:                true,
+	DisableMethods:          true,
+	SpewKeys:                true,
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+}
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	configForHash.Fprintf(hasher, "%#v", objectToWrite)
+}

--- a/utils/hash/hash_test.go
+++ b/utils/hash/hash_test.go
@@ -1,0 +1,150 @@
+package hash
+
+import (
+	"hash/fnv"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type test struct {
+	Str     string
+	private int
+}
+
+type complex struct {
+	Test    *test
+	TestMap *map[test]any
+}
+
+func TestDeepHashObject_Map(t *testing.T) {
+	u, err := url.Parse("http://localhost:3000")
+	require.NoError(t, err)
+	u2, err := url.Parse("http://admin:admin@localhost:3000")
+	require.NoError(t, err)
+
+	testCases := [][]any{
+		{
+			map[string]string{"a": "b", "c": "d", "e": "f"},
+			map[string]string{"a": "b", "c": "d"},
+		},
+		{
+			map[int]int{1: 2},
+			map[int]int{2: 1},
+		},
+		{
+			map[test]string{{"test", 1}: "b", {"test", 2}: "d"},
+			map[test]string{{"test", 2}: "b", {"test", 3}: "d"},
+		},
+		{
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c", "d"},
+		},
+		{
+			&[]bool{true, false},
+			&[]bool{false, true},
+		},
+		{
+			[]*complex{
+				nil,
+				{Test: &test{"test", 1}},
+			},
+			[]*complex{
+				{Test: &test{"test", 1}},
+			},
+		},
+		{
+			[]*complex{
+				nil,
+				{Test: &test{"test", 1}},
+			},
+			[]*complex{
+				{TestMap: &map[test]any{
+					{"test", 1}: &test{"test", 1},
+					{"test", 2}: float64(1),
+				}},
+			},
+		},
+		{
+			nil,
+			[]any{},
+		},
+		{
+			map[any]any{
+				"a": "b",
+				&test{"test", 1}: complex{
+					Test: &test{"test", 1},
+					TestMap: &map[test]any{
+						{"test", 1}: &test{"test", 1},
+						{"test", 2}: 1,
+					},
+				},
+				1:          1,
+				true:       true,
+				time.Now(): time.Now(),
+			},
+			nil,
+		},
+		{
+			1,
+			2,
+		},
+		{
+			"test",
+			"test ",
+		},
+		{
+			true,
+			false,
+		},
+		{
+			u,
+			u2,
+		},
+		{
+			time.Now(),
+			time.Now().UTC(),
+		},
+		{
+			complex{
+				Test: &test{"test", 1},
+				TestMap: &map[test]any{
+					{"test", 1}: &test{"test", 1},
+					{"test", 2}: 1,
+				},
+			},
+			complex{
+				Test: &test{"test", 1},
+				TestMap: &map[test]any{
+					{"test", 1}: &test{"test", 1},
+					{"test", 2}: float64(1),
+				},
+			},
+		},
+	}
+
+	for idx, tc := range testCases {
+		h := fnv.New64a()
+		DeepHashObject(h, tc[0])
+		hash11 := h.Sum64()
+		DeepHashObject(h, tc[0])
+		hash12 := h.Sum64()
+
+		if hash12 != hash11 {
+			t.Log(configForHash.Sprintf("%#v", tc[0]))
+			require.Failf(t, "DeepHashObject returned different result for the same object.", "test case %d", idx)
+		}
+
+		DeepHashObject(h, tc[1])
+		hash21 := h.Sum64()
+		if hash21 == hash11 {
+			t.Log("Object 1")
+			t.Log(configForHash.Sprintf("%#v", tc[0]))
+			t.Log("Object 2")
+			t.Log(configForHash.Sprintf("%#v", tc[1]))
+			require.Failf(t, "DeepHashObject returned same result for different objects.", "test case %d", idx)
+		}
+	}
+}

--- a/utils/hash/hash_test.go
+++ b/utils/hash/hash_test.go
@@ -14,7 +14,7 @@ type test struct {
 	private int
 }
 
-type complex struct {
+type complexStruct struct {
 	Test    *test
 	TestMap *map[test]any
 }
@@ -47,20 +47,20 @@ func TestDeepHashObject_Map(t *testing.T) {
 			&[]bool{false, true},
 		},
 		{
-			[]*complex{
+			[]*complexStruct{
 				nil,
 				{Test: &test{"test", 1}},
 			},
-			[]*complex{
+			[]*complexStruct{
 				{Test: &test{"test", 1}},
 			},
 		},
 		{
-			[]*complex{
+			[]*complexStruct{
 				nil,
 				{Test: &test{"test", 1}},
 			},
-			[]*complex{
+			[]*complexStruct{
 				{TestMap: &map[test]any{
 					{"test", 1}: &test{"test", 1},
 					{"test", 2}: float64(1),
@@ -74,7 +74,7 @@ func TestDeepHashObject_Map(t *testing.T) {
 		{
 			map[any]any{
 				"a": "b",
-				&test{"test", 1}: complex{
+				&test{"test", 1}: complexStruct{
 					Test: &test{"test", 1},
 					TestMap: &map[test]any{
 						{"test", 1}: &test{"test", 1},
@@ -108,14 +108,14 @@ func TestDeepHashObject_Map(t *testing.T) {
 			time.Now().UTC(),
 		},
 		{
-			complex{
+			complexStruct{
 				Test: &test{"test", 1},
 				TestMap: &map[test]any{
 					{"test", 1}: &test{"test", 1},
 					{"test", 2}: 1,
 				},
 			},
-			complex{
+			complexStruct{
 				Test: &test{"test", 1},
 				TestMap: &map[test]any{
 					{"test", 1}: &test{"test", 1},


### PR DESCRIPTION
This PR introduces an function DeepHashObject that prints an arbitrary structure into hasher. It uses github.com/davecgh/go-spew module to deep print the structure. 

### Why

This approach [is used in many places](https://github.com/search?q=repo%3Akubernetes%2Fkubernetes%20DeepHashObject&type=code) in kubernetes modules and offers a good alternative to manual calculation of the hash.

It does have some limitations:
- map keys must be either simple structs or basic types. Slices and maps as key of of a map will cause panic.
- there is no way to ignore order of elements in array. So, in the case of order agnostic hashes, the slices must be sorted.