### PR TITLE
Disable keepalives in NewTLSClient

### DIFF
--- a/receivers/util.go
+++ b/receivers/util.go
@@ -88,6 +88,8 @@ func NewTLSClient(tlsConfig *tls.Config) *http.Client {
 					Timeout: 30 * time.Second,
 				}).Dial,
 				TLSHandshakeTimeout: 5 * time.Second,
+				// Disable keep alive since this is always used as a short lived client
+				DisableKeepAlives: true,
 			},
 		}
 	}


### PR DESCRIPTION
This client is only used in short lived contexts so we don't want to keep the connections it opens alive since they can't be reused.