### PR TITLE
Disable keepalives in NewTLSClient

### DIFF
--- a/http/tls.go
+++ b/http/tls.go
@@ -19,6 +19,8 @@ func NewTLSClient(tlsConfig *tls.Config) *http.Client {
 					Timeout: 30 * time.Second,
 				}).Dial,
 				TLSHandshakeTimeout: 5 * time.Second,
+				// Disable keep alive since this is always used as a short lived client
+				DisableKeepAlives: true,
 			},
 		}
 	}


### PR DESCRIPTION
This client is only used in short lived contexts so we don't want to keep the connections it opens alive since they can't be reused.