### PR TITLE
Add ability to omit some templates from builtin definition

### DIFF
--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -1,8 +1,12 @@
 package templates
 
 import (
+	"fmt"
 	"net/url"
+	"slices"
+	"strings"
 	"testing"
+	tmpltext "text/template"
 
 	"github.com/stretchr/testify/require"
 )
@@ -206,4 +210,51 @@ func ForTests(t *testing.T) *Template {
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
 	return tmpl
+}
+
+var DefaultTemplateName = "__default__"
+
+// DefaultTemplate returns a new Template with all default templates parsed.
+func DefaultTemplate() (TemplateDefinition, error) {
+	// We cannot simply append the text of each default file together as there can be (and are) duplicate template
+	// names. Duplicate templates should override when parsed from separate files but will fail to parse if both are in
+	// the same file.
+	// So, instead we allow tmpltext to combine the templates and then convert it to a string afterwards.
+	// The underlying template is not accessible, so we capture it via template.Option.
+
+	// Call fromContent without any user-provided templates to get the combined default template.
+	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind, "grafana")...)
+	if err != nil {
+		return TemplateDefinition{}, err
+	}
+
+	var combinedTemplate strings.Builder
+	txt, err := tmpl.Text()
+	if err != nil {
+		return TemplateDefinition{}, err
+	}
+	tmpls := txt.Templates()
+	// Sort for a consistent order.
+	slices.SortFunc(tmpls, func(a, b *tmpltext.Template) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+
+	// Recreate the "define" blocks for all templates. Would be nice to have a more direct way to do this.
+	for _, tmpl := range tmpls {
+		if tmpl.Name() != "" {
+			def := tmpl.Tree.Root.String()
+			if tmpl.Name() == "__text_values_list" {
+				// Temporary fix for https://github.com/golang/go/commit/6fea4094242fe4e7be8bd7ec0b55df9f6df3f025.
+				// TODO: Can remove with GO v1.24.
+				def = strings.Replace(def, "$first := false", "$first = false", 1)
+			}
+
+			combinedTemplate.WriteString(fmt.Sprintf("{{ define \"%s\" }}%s{{ end }}\n\n", tmpl.Name(), def))
+		}
+	}
+	return TemplateDefinition{
+		Name:     DefaultTemplateName,
+		Template: combinedTemplate.String(),
+		Kind:     GrafanaKind,
+	}, nil
 }

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -355,6 +355,7 @@ Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&mat
 
 	t.Run("should omit templates", func(t *testing.T) {
 		def, err := DefaultTemplate(nil)
+		require.NoError(t, err)
 		defOmit, err := DefaultTemplate(DefaultTemplatesToOmit)
 		require.NoError(t, err)
 		for _, tmpl := range DefaultTemplatesToOmit {

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/template"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/types"
@@ -141,7 +142,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	l := log.NewNopLogger()
 	expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
 
-	tmplDef, err := DefaultTemplate()
+	tmplDef, err := DefaultTemplate(nil)
 	require.NoError(t, err)
 
 	tmplFromDefinition, err := template.New(defaultOptionsPerKind(GrafanaKind, "grafana")...)
@@ -351,6 +352,16 @@ Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&mat
 	}
 	require.NoError(t, tmplErr)
 	require.NoError(t, tmplDefErr)
+
+	t.Run("should omit templates", func(t *testing.T) {
+		def, err := DefaultTemplate(nil)
+		defOmit, err := DefaultTemplate(DefaultTemplatesToOmit)
+		require.NoError(t, err)
+		for _, tmpl := range DefaultTemplatesToOmit {
+			assert.Contains(t, def.Template, tmpl)
+			assert.NotContains(t, defOmit.Template, tmpl)
+		}
+	})
 }
 
 // resetTimeNow resets the global variable timeNow to the default value, which is time.Now

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -8,7 +8,6 @@ import (
 	tmplhtml "html/template"
 	"net/url"
 	"path"
-	"slices"
 	"strconv"
 	"strings"
 	tmpltext "text/template"
@@ -142,53 +141,6 @@ type ExtendedData struct {
 
 	// Optional variables for templating, currently only used for webhook custom payloads.
 	Vars map[string]string `json:"-"`
-}
-
-var DefaultTemplateName = "__default__"
-
-// DefaultTemplate returns a new Template with all default templates parsed.
-func DefaultTemplate() (TemplateDefinition, error) {
-	// We cannot simply append the text of each default file together as there can be (and are) duplicate template
-	// names. Duplicate templates should override when parsed from separate files but will fail to parse if both are in
-	// the same file.
-	// So, instead we allow tmpltext to combine the templates and then convert it to a string afterwards.
-	// The underlying template is not accessible, so we capture it via template.Option.
-
-	// Call fromContent without any user-provided templates to get the combined default template.
-	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind, "grafana")...)
-	if err != nil {
-		return TemplateDefinition{}, err
-	}
-
-	var combinedTemplate strings.Builder
-	txt, err := tmpl.Text()
-	if err != nil {
-		return TemplateDefinition{}, err
-	}
-	tmpls := txt.Templates()
-	// Sort for a consistent order.
-	slices.SortFunc(tmpls, func(a, b *tmpltext.Template) int {
-		return strings.Compare(a.Name(), b.Name())
-	})
-
-	// Recreate the "define" blocks for all templates. Would be nice to have a more direct way to do this.
-	for _, tmpl := range tmpls {
-		if tmpl.Name() != "" {
-			def := tmpl.Tree.Root.String()
-			if tmpl.Name() == "__text_values_list" {
-				// Temporary fix for https://github.com/golang/go/commit/6fea4094242fe4e7be8bd7ec0b55df9f6df3f025.
-				// TODO: Can remove with GO v1.24.
-				def = strings.Replace(def, "$first := false", "$first = false", 1)
-			}
-
-			combinedTemplate.WriteString(fmt.Sprintf("{{ define \"%s\" }}%s{{ end }}\n\n", tmpl.Name(), def))
-		}
-	}
-	return TemplateDefinition{
-		Name:     DefaultTemplateName,
-		Template: combinedTemplate.String(),
-		Kind:     GrafanaKind,
-	}, nil
 }
 
 // addFuncs is a template.Option that adds functions to the function map fo the given templates.

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -73,7 +73,7 @@ func ValidateKind(kind Kind) error {
 }
 
 const (
-	kindUnknown Kind = iota
+	_ Kind = iota
 	GrafanaKind
 	MimirKind
 )

--- a/templates/util.go
+++ b/templates/util.go
@@ -107,6 +107,8 @@ func checkNode(node parse.Node, executedTmpls map[string]struct{}) {
 	case parse.NodeWith:
 		n := node.(*parse.WithNode)
 		checkBranchNode(&n.BranchNode, executedTmpls)
+	default:
+		// do nothing
 	}
 }
 


### PR DESCRIPTION
The built-in template definition contains email templates that in fact are not used in Grafana. Instead, they confuse users by showing up in the drop down of field templates, and when they try to use it, the resulting notification arrives with broken formatting, which makes users think this is a bug.

I chose to make it as parameter, so it will be clearer on the Grafana side that the resulting definition is not full.