### PR TITLE
Fix Merge function to copy routes before modifying

### DIFF
--- a/definition/merge.go
+++ b/definition/merge.go
@@ -154,7 +154,13 @@ func Merge(a, b PostableApiAlertingConfig, opts MergeOpts) (MergeResult, error) 
 
 	renameReceiversInRoutes([]*Route{b.Route}, renamedReceivers, renamedTimeIntervals)
 
-	route := mergeRoutes(a.Route, b.Route, opts.SubtreeMatchers)
+	if a.Route == nil {
+		return MergeResult{}, fmt.Errorf("cannot merge into undefined routing tree")
+	}
+	if b.Route == nil {
+		return MergeResult{}, fmt.Errorf("cannot merge undefined routing tree")
+	}
+	route := mergeRoutes(*a.Route, *b.Route, opts.SubtreeMatchers)
 
 	inhibitRules := mergeInhibitRules(a.InhibitRules, b.InhibitRules, opts.SubtreeMatchers)
 
@@ -203,7 +209,8 @@ func mergeTimeIntervals(amt []config.MuteTimeInterval, ati []config.TimeInterval
 	return amt, ati, renamed
 }
 
-func mergeRoutes(a, b *Route, matcher config.Matchers) *Route {
+func mergeRoutes(a, b Route, matcher config.Matchers) *Route {
+	// get a and b by value so we get shallow copies of the top level routes, which we can modify.
 	// make sure "b" route has all defaults set explicitly to avoid inheriting "a"'s default route settings.
 	defaultOpts := dispatch.DefaultRouteOpts
 	if b.GroupWait == nil {
@@ -219,8 +226,8 @@ func mergeRoutes(a, b *Route, matcher config.Matchers) *Route {
 		b.RepeatInterval = &ri
 	}
 	b.Matchers = append(b.Matchers, matcher...)
-	a.Routes = append([]*Route{b}, a.Routes...)
-	return a
+	a.Routes = append([]*Route{&b}, a.Routes...)
+	return &a
 }
 
 func checkIfMatchersUsed(matchers config.Matchers, routes []*Route) (bool, error) {

--- a/definition/merge_test.go
+++ b/definition/merge_test.go
@@ -351,6 +351,15 @@ func TestMerge(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("should not modify existing config", func(t *testing.T) {
+		g := load(t, fullGrafanaConfig)
+		m := load(t, fullMimirConfig)
+		_, err := Merge(*g, *m, opts)
+		require.NoError(t, err)
+		assert.Equal(t, load(t, fullGrafanaConfig), g)
+		assert.Equal(t, load(t, fullMimirConfig), m)
+	})
 }
 
 func TestCheckIfMatchersUsed(t *testing.T) {


### PR DESCRIPTION
This fixes a bug when execution of Merge functions modifies the incoming configurations.