### PR TITLE
Move Jira search to a new endpoint

### DIFF
--- a/receivers/jira/jira_test.go
+++ b/receivers/jira/jira_test.go
@@ -426,7 +426,7 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search":
+				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{}), 200)
 				case baseURL + "/issue":
 					return cmd.Validation(nil, 201)
@@ -446,7 +446,7 @@ func TestNotify(t *testing.T) {
 			assert.Equal(t, cfg.User, searchRequest.User)
 			assert.Equal(t, cfg.Password, searchRequest.Password)
 			assert.JSONEq(t, string(mustMarshal(getSearchJql(cfg, groupKey.Hash(), true))), searchRequest.Body)
-			assert.Equal(t, baseURL+"/search", searchRequest.URL)
+			assert.Equal(t, baseURL+"/search/jql", searchRequest.URL)
 			assert.Equal(t, "POST", searchRequest.HTTPMethod)
 
 			submitRequest := mock.Calls[1].Args[2].(*receivers.SendWebhookSettings)
@@ -462,7 +462,7 @@ func TestNotify(t *testing.T) {
 			issueKey := "TEST-1"
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search":
+				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
 						Total: 1,
 						Issues: []issue{
@@ -520,7 +520,7 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search":
+				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
 						Total: 1,
 						Issues: []issue{
@@ -646,7 +646,7 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search":
+				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{}), 200)
 				default:
 					t.Fatalf("unexpected url: %s", cmd.URL)
@@ -673,7 +673,7 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search":
+				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
 						Total: 1,
 						Issues: []issue{
@@ -725,7 +725,7 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search":
+				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
 						Total: 1,
 						Issues: []issue{

--- a/receivers/jira/jira_test.go
+++ b/receivers/jira/jira_test.go
@@ -464,7 +464,6 @@ func TestNotify(t *testing.T) {
 				switch cmd.URL {
 				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
-						Total: 1,
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -522,7 +521,6 @@ func TestNotify(t *testing.T) {
 				switch cmd.URL {
 				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
-						Total: 1,
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -675,7 +673,6 @@ func TestNotify(t *testing.T) {
 				switch cmd.URL {
 				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
-						Total: 1,
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -727,7 +724,6 @@ func TestNotify(t *testing.T) {
 				switch cmd.URL {
 				case baseURL + "/search/jql":
 					return cmd.Validation(mustMarshal(issueSearchResult{
-						Total: 1,
 						Issues: []issue{
 							{
 								Key: issueKey,

--- a/receivers/jira/types.go
+++ b/receivers/jira/types.go
@@ -39,16 +39,16 @@ type issueStatus struct {
 	StatusCategory keyValue `json:"statusCategory"`
 }
 
+// See https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post-request-body for all fields
 type issueSearch struct {
-	Expand     []string `json:"expand"`
+	Expand     string   `json:"expand"`
 	Fields     []string `json:"fields"`
 	JQL        string   `json:"jql"`
 	MaxResults int      `json:"maxResults"`
-	StartAt    int      `json:"startAt"`
 }
 
+// see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post-response
 type issueSearchResult struct {
-	Total  int     `json:"total"`
 	Issues []issue `json:"issues"`
 }
 


### PR DESCRIPTION
This PR changes the JIRA integration to use a different search endpoint. 
The current `/search` endpoint got deprecated (see https://developer.atlassian.com/changelog/#CHANGE-2046 ). Instead, this PR proposes to use `/search/jql` (see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post), which mostly compatible with the old one except a few fields.