### PR TITLE
12.1.x: Disable keepalives in NewTLSClient

### DIFF
--- a/http/tls.go
+++ b/http/tls.go
@@ -29,6 +29,8 @@ func NewTLSClient(tlsConfig *tls.Config, dialContextfunc func(context.Context, s
 			Proxy:               http.ProxyFromEnvironment,
 			DialContext:         dialContextfunc,
 			TLSHandshakeTimeout: 5 * time.Second,
+			// Disable keep alive since this is always used as a short lived client
+			DisableKeepAlives: true,
 		},
 	}
 }


### PR DESCRIPTION
This client is only used in short lived contexts so we don't want to keep the connections it opens alive since they can't be reused.