### PR TITLE
Add MS Teams V2 integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 )
 
 // Using a fork of the Alertmanager with Alerting Squad specific changes.
-replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250821192752-903ba9e90238
+replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604
 
 replace github.com/Unknwon/com v1.0.1 => github.com/unknwon/com v1.0.1
 

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/Oth
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250821192752-903ba9e90238 h1:0UYzSzpVFKCc4OhVB8dZai3lO0ANg7IIdSZhMiBhdOg=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250821192752-903ba9e90238/go.mod h1:O/QP1BCm0HHIzbKvgMzqb5sSyH88rzkFk84F4TfJjBU=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604 h1:aXfUhVN/Ewfpbko2CCtL65cIiGgwStOo4lWH2b6gw2U=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604/go.mod h1:O/QP1BCm0HHIzbKvgMzqb5sSyH88rzkFk84F4TfJjBU=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -16,7 +16,8 @@ import (
 
 	promDiscord "github.com/prometheus/alertmanager/notify/discord"
 	promEmail "github.com/prometheus/alertmanager/notify/email"
-	promMsteams "github.com/prometheus/alertmanager/notify/msteams"
+	promMSTeams "github.com/prometheus/alertmanager/notify/msteams"
+	promMSTeamsV2 "github.com/prometheus/alertmanager/notify/msteamsv2"
 	promOpsgenie "github.com/prometheus/alertmanager/notify/opsgenie"
 	promPagerduty "github.com/prometheus/alertmanager/notify/pagerduty"
 	promPushover "github.com/prometheus/alertmanager/notify/pushover"
@@ -291,7 +292,10 @@ func BuildPrometheusReceiverIntegrations(
 		add("webex", i, c, func(l log.Logger) (notify.Notifier, error) { return promWebex.New(c, tmpl, l, httpOps...) })
 	}
 	for i, c := range nc.MSTeamsConfigs {
-		add("msteams", i, c, func(l log.Logger) (notify.Notifier, error) { return promMsteams.New(c, tmpl, l, httpOps...) })
+		add("msteams", i, c, func(l log.Logger) (notify.Notifier, error) { return promMSTeams.New(c, tmpl, l, httpOps...) })
+	}
+	for i, c := range nc.MSTeamsV2Configs {
+		add("msteamsv2", i, c, func(l log.Logger) (notify.Notifier, error) { return promMSTeamsV2.New(c, tmpl, l, httpOps...) })
 	}
 	// If we add support for more integrations, we need to add them to validation as well. See validation.allowedIntegrationNames field.
 	if errs.Len() > 0 {


### PR DESCRIPTION
This PR updates the `grafana/prometheus-alertmanager` package to include https://github.com/grafana/prometheus-alertmanager/commit/5456b6e4560430a2761f3ae6b6117ba391252a23 and adds the `msteamsv2` integration as an option when building receivers.