### PR TITLE
Add MS Teams V2 validation and testing

### DIFF
--- a/definition/mimir_validation.go
+++ b/definition/mimir_validation.go
@@ -104,6 +104,11 @@ func ValidateAlertmanagerConfig(cfg any) error {
 			return err
 		}
 
+	case reflect.TypeOf(config.MSTeamsV2Config{}):
+		if err := validateMSTeamsV2Config(v.Interface().(config.MSTeamsV2Config)); err != nil {
+			return err
+		}
+
 	case reflect.TypeOf(config.TelegramConfig{}):
 		if err := validateTelegramConfig(v.Interface().(config.TelegramConfig)); err != nil {
 			return err
@@ -288,6 +293,15 @@ func validatePushoverConfig(cfg config.PushoverConfig) error {
 // validateMSTeamsConfig validates the Microsoft Teams config and returns an error if it
 // contains settings not allowed by Mimir.
 func validateMSTeamsConfig(cfg config.MSTeamsConfig) error {
+	if cfg.WebhookURLFile != "" {
+		return errWebhookURLFileNotAllowed
+	}
+	return nil
+}
+
+// validateMSTeamsV2Config validates the Microsoft Teams config and returns an error if it
+// contains settings not allowed by Mimir.
+func validateMSTeamsV2Config(cfg config.MSTeamsV2Config) error {
 	if cfg.WebhookURLFile != "" {
 		return errWebhookURLFileNotAllowed
 	}

--- a/definition/mimir_validation.go
+++ b/definition/mimir_validation.go
@@ -299,7 +299,7 @@ func validateMSTeamsConfig(cfg config.MSTeamsConfig) error {
 	return nil
 }
 
-// validateMSTeamsV2Config validates the Microsoft Teams config and returns an error if it
+// validateMSTeamsV2Config validates the Microsoft Teams V2 config and returns an error if it
 // contains settings not allowed by Mimir.
 func validateMSTeamsV2Config(cfg config.MSTeamsV2Config) error {
 	if cfg.WebhookURLFile != "" {

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -237,5 +237,5 @@ func TestBuildPrometheusReceiverIntegrations(t *testing.T) {
 	require.NoError(t, err)
 	integrations, err := BuildPrometheusReceiverIntegrations(receiver, tmpl, nil, log.NewNopLogger(), NoWrap, nil)
 	require.NoError(t, err)
-	require.Len(t, integrations, 13)
+	require.Len(t, integrations, 14)
 }

--- a/notify/notifytest/mimir_integrations.go
+++ b/notify/notifytest/mimir_integrations.go
@@ -462,6 +462,13 @@ var ValidMimirConfigs = map[reflect.Type]string{
 			"summary": "test summary",
 			"text": "test text"
         }`,
+	reflect.TypeOf(promCfg.MSTeamsV2Config{}): `{
+			"send_resolved": true,
+			"webhook_url": "http://localhost",
+			"http_config": {},
+			"title": "test title",
+			"text": "test text"
+        }`,
 	reflect.TypeOf(promCfg.JiraConfig{}): `{
 			"api_url": "http://localhost",
 			"project": "PROJ",


### PR DESCRIPTION
This PR adds validation for the MS Teams v2 integration and adds a default test config.
MS Teams V2 config for reference -> https://prometheus.io/docs/alerting/latest/configuration/#msteamsv2_config