### PR TITLE
Disallow matchers and object matchers in root route

### DIFF
--- a/definition/alertmanager_validation.go
+++ b/definition/alertmanager_validation.go
@@ -60,7 +60,7 @@ func (r *Route) Validate() error {
 	if len(r.Receiver) == 0 {
 		return fmt.Errorf("root route must specify a default receiver")
 	}
-	if len(r.Match) > 0 || len(r.MatchRE) > 0 {
+	if len(r.Match) > 0 || len(r.MatchRE) > 0 || len(r.Matchers) > 0 || len(r.ObjectMatchers) > 0 {
 		return fmt.Errorf("root route must not have any matchers")
 	}
 	if len(r.MuteTimeIntervals) > 0 {

--- a/definition/alertmanager_validation_test.go
+++ b/definition/alertmanager_validation_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 )
 
@@ -211,6 +212,36 @@ func TestValidateRoutes(t *testing.T) {
 					GroupByStr: []string{"..."},
 					Match: map[string]string{
 						"abc": "def",
+					},
+				},
+				expMsg: "must not have any matchers",
+			},
+			{
+				desc: "matchers present",
+				route: Route{
+					Receiver:   "foo",
+					GroupByStr: []string{"..."},
+					Matchers: []*labels.Matcher{
+						{
+							Type:  labels.MatchEqual,
+							Name:  "abc",
+							Value: "def",
+						},
+					},
+				},
+				expMsg: "must not have any matchers",
+			},
+			{
+				desc: "object matchers present",
+				route: Route{
+					Receiver:   "foo",
+					GroupByStr: []string{"..."},
+					ObjectMatchers: ObjectMatchers{
+						&labels.Matcher{
+							Type:  labels.MatchEqual,
+							Name:  "abc",
+							Value: "def",
+						},
 					},
 				},
 				expMsg: "must not have any matchers",


### PR DESCRIPTION
This is done in [upstream](https://github.com/prometheus/alertmanager/blob/17f42810382299639b34b56a01550243f2b2512a/config/config.go#L647), and we're doing the same for match and match regex, but we missed disallowing object matchers and matchers which replace them.
If we allow them very confusing behavior can happen, where notifications are dropped because the root route has matchers that don't match.

Note: This may cause issues where previously "valid" configurations are no longer valid. We will need to provide guidance on handling those cases, but basically in order to maintain the behavior the "correct" way of ignoring notifications is to use a null receiver.
