### PR TITLE
Update ExtendedAlert field with ExtraData

### DIFF
--- a/receivers/webhook/v1/webhook_test.go
+++ b/receivers/webhook/v1/webhook_test.go
@@ -900,7 +900,7 @@ func TestNotify_CustomPayload(t *testing.T) {
 				Payload: CustomPayload{
 					Template: `{{- $alerts := coll.Slice -}}
   {{- range .Alerts -}}
-    {{- $alerts = coll.Append (coll.Dict 
+    {{- $alerts = coll.Append (coll.Dict
     "labels" .Labels
     "annotations" .Annotations
     "startsAt" .StartsAt
@@ -1074,4 +1074,80 @@ func TestNotify_CustomPayload(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	orgID := int64(1)
+
+	// Setup webhook notifier
+	settings := Config{
+		URL:        "http://localhost/test",
+		HTTPMethod: http.MethodPost,
+		Title:      templates.DefaultMessageTitleEmbed,
+		Message:    templates.DefaultMessageEmbed,
+	}
+
+	webhookSender := receivers.MockNotificationService()
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images.UnavailableProvider{},
+		orgID:    orgID,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				GeneratorURL: "http://localhost/test",
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
+			},
+		},
+		{
+			Alert: model.Alert{
+				GeneratorURL: "http://localhost/test",
+				Labels:       model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations:  model.LabelSet{"ann1": "annv2", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = notify.WithReceiverName(ctx, "my_receiver")
+	ctx = context.WithValue(ctx, ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Parse the webhook body to verify extra data was included
+	var webhookMsg webhookMessage
+	err = json.Unmarshal([]byte(webhookSender.Webhook.Body), &webhookMsg)
+	require.NoError(t, err)
+
+	// Verify that extra data is present in the alerts
+	require.Len(t, webhookMsg.ExtendedData.Alerts, 2)
+
+	// Check first alert's extra data
+	require.JSONEq(t, string(extraData1), string(webhookMsg.ExtendedData.Alerts[0].ExtraData))
+
+	// Check second alert's extra data
+	require.JSONEq(t, string(extraData2), string(webhookMsg.ExtendedData.Alerts[1].ExtraData))
 }

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -142,8 +142,6 @@ type ExtendedData struct {
 
 	// Optional variables for templating, currently only used for webhook custom payloads.
 	Vars map[string]string `json:"-"`
-
-	ExtraData json.RawMessage `json:"extraData,omitempty"`
 }
 
 // addFuncs is a template.Option that adds functions to the function map fo the given templates.

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -118,6 +118,7 @@ type ExtendedAlert struct {
 	ImageURL      string             `json:"imageURL,omitempty"`
 	EmbeddedImage string             `json:"embeddedImage,omitempty"`
 	OrgID         *int64             `json:"orgId,omitempty"`
+	ExtraData     json.RawMessage    `json:"extraData,omitempty"`
 }
 
 type ExtendedAlerts []ExtendedAlert
@@ -141,6 +142,8 @@ type ExtendedData struct {
 
 	// Optional variables for templating, currently only used for webhook custom payloads.
 	Vars map[string]string `json:"-"`
+
+	ExtraData json.RawMessage `json:"extraData,omitempty"`
 }
 
 // addFuncs is a template.Option that adds functions to the function map fo the given templates.


### PR DESCRIPTION
Updated the `ExtendedAlert` with a new field, `ExtraData` that contains a `json.RawMessage` - this can be any additional data that is passed down from the Alertmanager which will be forwarded on in the webhook message