### PR TITLE
Move common structs from notify to models package

### DIFF
--- a/models/integration.go
+++ b/models/integration.go
@@ -10,3 +10,7 @@ type IntegrationConfig struct {
 	Settings              json.RawMessage   `json:"settings" yaml:"settings"`
 	SecureSettings        map[string]string `json:"secureSettings" yaml:"secureSettings"`
 }
+
+type ReceiverConfig struct {
+	Integrations []*IntegrationConfig `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
+}

--- a/models/integration.go
+++ b/models/integration.go
@@ -1,0 +1,12 @@
+package models
+
+import "encoding/json"
+
+type IntegrationConfig struct {
+	UID                   string            `json:"uid" yaml:"uid"`
+	Name                  string            `json:"name" yaml:"name"`
+	Type                  string            `json:"type" yaml:"type"`
+	DisableResolveMessage bool              `json:"disableResolveMessage" yaml:"disableResolveMessage"`
+	Settings              json.RawMessage   `json:"settings" yaml:"settings"`
+	SecureSettings        map[string]string `json:"secureSettings" yaml:"secureSettings"`
+}

--- a/models/receivers.go
+++ b/models/receivers.go
@@ -6,18 +6,18 @@ import (
 
 // Type definitions for the Grafana extended version of the /receivers API.
 
-type Receiver struct {
+type ReceiverStatus struct {
 	// Whether the receiver is used in a route or not.
 	Active bool `json:"active"`
 
 	// Integrations configured for this receiver.
-	Integrations []Integration `json:"integrations"`
+	Integrations []IntegrationStatus `json:"integrations"`
 
 	// Name of the receiver.
 	Name string `json:"name"`
 }
 
-type Integration struct {
+type IntegrationStatus struct {
 	// A timestamp indicating the last attempt to deliver a notification regardless of the outcome.
 	// Format: date-time
 	LastNotifyAttempt strfmt.DateTime `json:"lastNotifyAttempt,omitempty"`

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -4,15 +4,16 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/alerting/definition"
+	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/templates"
 )
 
 func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) *APIReceiver {
 	integrations := GrafanaIntegrations{
-		Integrations: make([]*GrafanaIntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
+		Integrations: make([]*models.IntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
 	}
 	for _, p := range r.GrafanaManagedReceivers {
-		integrations.Integrations = append(integrations.Integrations, &GrafanaIntegrationConfig{
+		integrations.Integrations = append(integrations.Integrations, &models.IntegrationConfig{
 			UID:                   p.UID,
 			Name:                  p.Name,
 			Type:                  p.Type,

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -8,24 +8,36 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
+func PostableAPIReceiversToAPIReceivers(r []*definition.PostableApiReceiver) []*APIReceiver {
+	result := make([]*APIReceiver, 0, len(r))
+	for _, receiver := range r {
+		result = append(result, PostableAPIReceiverToAPIReceiver(receiver))
+	}
+	return result
+}
+
 func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) *APIReceiver {
 	integrations := models.ReceiverConfig{
 		Integrations: make([]*models.IntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
 	}
 	for _, p := range r.GrafanaManagedReceivers {
-		integrations.Integrations = append(integrations.Integrations, &models.IntegrationConfig{
-			UID:                   p.UID,
-			Name:                  p.Name,
-			Type:                  p.Type,
-			DisableResolveMessage: p.DisableResolveMessage,
-			Settings:              json.RawMessage(p.Settings),
-			SecureSettings:        p.SecureSettings,
-		})
+		integrations.Integrations = append(integrations.Integrations, PostableGrafanaReceiverToIntegrationConfig(p))
 	}
 
 	return &APIReceiver{
 		ConfigReceiver: r.Receiver,
 		ReceiverConfig: integrations,
+	}
+}
+
+func PostableGrafanaReceiverToIntegrationConfig(r *definition.PostableGrafanaReceiver) *models.IntegrationConfig {
+	return &models.IntegrationConfig{
+		UID:                   r.UID,
+		Name:                  r.Name,
+		Type:                  r.Type,
+		DisableResolveMessage: r.DisableResolveMessage,
+		Settings:              json.RawMessage(r.Settings),
+		SecureSettings:        r.SecureSettings,
 	}
 }
 

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -9,7 +9,7 @@ import (
 )
 
 func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) *APIReceiver {
-	integrations := GrafanaIntegrations{
+	integrations := models.ReceiverConfig{
 		Integrations: make([]*models.IntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
 	}
 	for _, p := range r.GrafanaManagedReceivers {
@@ -24,8 +24,8 @@ func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) *APIRec
 	}
 
 	return &APIReceiver{
-		ConfigReceiver:      r.Receiver,
-		GrafanaIntegrations: integrations,
+		ConfigReceiver: r.Receiver,
+		ReceiverConfig: integrations,
 	}
 }
 

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -8,34 +8,130 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/definition"
+	"github.com/grafana/alerting/models"
 )
 
-func TestPostableApiReceiverToApiReceiver(t *testing.T) {
-	postableReceiver := &definition.PostableApiReceiver{
-		Receiver: config.Receiver{
-			Name: "test",
-		},
-		PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
-			GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{{
-				UID:                   "abc",
-				Name:                  "test",
-				Type:                  "slack",
-				DisableResolveMessage: true,
-				Settings:              definition.RawMessage{'b', 'y', 't', 'e', 's'},
-				SecureSettings:        map[string]string{"key": "value"},
-			}},
+func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
+	t.Run("returns empty when no receivers", func(t *testing.T) {
+		r := &definition.PostableApiReceiver{
+			Receiver: config.Receiver{
+				Name: "test-receiver",
+			},
+		}
+		actual := PostableAPIReceiverToAPIReceiver(r)
+		require.Empty(t, actual.Integrations)
+		require.Equal(t, r.Receiver, actual.ConfigReceiver)
+	})
+	t.Run("converts receivers", func(t *testing.T) {
+		r := &definition.PostableApiReceiver{
+			Receiver: config.Receiver{
+				Name: "test-receiver",
+			},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+					{
+						UID:                   "test-uid",
+						Name:                  "test-name",
+						Type:                  "slack",
+						DisableResolveMessage: false,
+						Settings:              definition.RawMessage(`{ "data" : "test" }`),
+						SecureSettings: map[string]string{
+							"test": "data",
+						},
+					},
+					{
+						UID:                   "test-uid2",
+						Name:                  "test-name2",
+						Type:                  "webhook",
+						DisableResolveMessage: false,
+						Settings:              definition.RawMessage(`{ "data2" : "test2" }`),
+						SecureSettings: map[string]string{
+							"test2": "data2",
+						},
+					},
+				},
+			},
+		}
+		actual := PostableAPIReceiverToAPIReceiver(r)
+		require.Len(t, actual.Integrations, 2)
+		require.Equal(t, r.Receiver, actual.ConfigReceiver)
+		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[0]), *actual.Integrations[0])
+		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[1]), *actual.Integrations[1])
+	})
+}
+
+func TestPostableGrafanaReceiverToGrafanaIntegrationConfig(t *testing.T) {
+	r := &definition.PostableGrafanaReceiver{
+		UID:                   "test-uid",
+		Name:                  "test-name",
+		Type:                  "slack",
+		DisableResolveMessage: false,
+		Settings:              definition.RawMessage(`{ "data" : "test" }`),
+		SecureSettings: map[string]string{
+			"test": "data",
 		},
 	}
-	receiver := PostableAPIReceiverToAPIReceiver(postableReceiver)
+	actual := PostableGrafanaReceiverToIntegrationConfig(r)
+	require.Equal(t, models.IntegrationConfig{
+		UID:                   "test-uid",
+		Name:                  "test-name",
+		Type:                  "slack",
+		DisableResolveMessage: false,
+		Settings:              json.RawMessage(`{ "data" : "test" }`),
+		SecureSettings: map[string]string{
+			"test": "data",
+		},
+	}, *actual)
+}
 
-	require.Equal(t, "test", receiver.Name)
-	require.Equal(t, 1, len(receiver.ReceiverConfig.Integrations))
+func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
+	t.Run("returns empty when no receivers", func(t *testing.T) {
+		actual := PostableAPIReceiversToAPIReceivers(nil)
+		require.Empty(t, actual)
+	})
+	receivers := []*definition.PostableApiReceiver{
+		{
+			Receiver: config.Receiver{
+				Name: "test-receiver",
+			},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+					{
+						UID:                   "test-uid",
+						Name:                  "test-name",
+						Type:                  "slack",
+						DisableResolveMessage: false,
+						Settings:              definition.RawMessage(`{ "data" : "test" }`),
+						SecureSettings: map[string]string{
+							"test": "data",
+						},
+					},
+				},
+			},
+		},
+		{
+			Receiver: config.Receiver{
+				Name: "test-receiver2",
+			},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+					{
+						UID:                   "test-uid2",
+						Name:                  "test-name1",
+						Type:                  "slack",
+						DisableResolveMessage: false,
+						Settings:              definition.RawMessage(`{ "data" : "test" }`),
+						SecureSettings: map[string]string{
+							"test": "data",
+						},
+					},
+				},
+			},
+		},
+	}
+	actual := PostableAPIReceiversToAPIReceivers(receivers)
 
-	i := receiver.ReceiverConfig.Integrations[0]
-	require.Equal(t, "abc", i.UID)
-	require.Equal(t, "test", i.Name)
-	require.Equal(t, "slack", i.Type)
-	require.Equal(t, true, i.DisableResolveMessage)
-	require.Equal(t, json.RawMessage{'b', 'y', 't', 'e', 's'}, i.Settings)
-	require.Equal(t, map[string]string{"key": "value"}, i.SecureSettings)
+	require.Len(t, actual, 2)
+	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[0]), actual[0])
+	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[1]), actual[1])
 }

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/definition"
 )
 
 func TestPostableApiReceiverToApiReceiver(t *testing.T) {
@@ -28,9 +29,9 @@ func TestPostableApiReceiverToApiReceiver(t *testing.T) {
 	receiver := PostableAPIReceiverToAPIReceiver(postableReceiver)
 
 	require.Equal(t, "test", receiver.Name)
-	require.Equal(t, 1, len(receiver.GrafanaIntegrations.Integrations))
+	require.Equal(t, 1, len(receiver.ReceiverConfig.Integrations))
 
-	i := receiver.GrafanaIntegrations.Integrations[0]
+	i := receiver.ReceiverConfig.Integrations[0]
 	require.Equal(t, "abc", i.UID)
 	require.Equal(t, "test", i.Name)
 	require.Equal(t, "slack", i.Type)

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -325,8 +325,8 @@ func BuildReceiversIntegrations(
 	nameToReceiver := make(map[string]*APIReceiver, len(apiReceivers))
 	for _, receiver := range apiReceivers {
 		if existing, ok := nameToReceiver[receiver.Name]; ok {
-			itypes := make([]string, 0, len(existing.GrafanaIntegrations.Integrations))
-			for _, i := range existing.GrafanaIntegrations.Integrations {
+			itypes := make([]string, 0, len(existing.ReceiverConfig.Integrations))
+			for _, i := range existing.ReceiverConfig.Integrations {
 				itypes = append(itypes, i.Type)
 			}
 			level.Warn(logger).Log("msg", "receiver with same name is defined multiple times. Only the last one will be used", "receiver_name", receiver.Name, "overwritten_integrations", itypes)

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -150,7 +150,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "test2",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test2"),
 					},
@@ -187,7 +187,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "test",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test"),
 					},
@@ -197,7 +197,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "test",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						notifytest.AllKnownV1ConfigsForTesting["webhook"].GetRawNotifierConfig("test"),
 					},

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
@@ -40,7 +41,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	getFullConfig := func(t *testing.T) (GrafanaReceiverConfig, int) {
 		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
-			recCfg.Integrations = append(recCfg.Integrations, GetRawNotifierConfig(cfg, ""))
+			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, GetDecryptedValueFnForTesting)
 		require.NoError(t, err)
@@ -150,8 +151,8 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 					Name: "test2",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
-						GetRawNotifierConfig(notifytest.AllKnownV1ConfigsForTesting["email"], "test2"),
+					Integrations: []*models.IntegrationConfig{
+						notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test2"),
 					},
 				},
 			},
@@ -187,8 +188,8 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 					Name: "test",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
-						GetRawNotifierConfig(notifytest.AllKnownV1ConfigsForTesting["email"], "test"),
+					Integrations: []*models.IntegrationConfig{
+						notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test"),
 					},
 				},
 			},
@@ -197,8 +198,8 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 					Name: "test",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
-						GetRawNotifierConfig(notifytest.AllKnownV1ConfigsForTesting["webhook"], "test"),
+					Integrations: []*models.IntegrationConfig{
+						notifytest.AllKnownV1ConfigsForTesting["webhook"].GetRawNotifierConfig("test"),
 					},
 				},
 			},

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -353,9 +353,9 @@ func (am *GrafanaAlertmanager) StopAndWait() {
 	am.wg.Wait()
 }
 
-// GetReceivers returns the receivers configured as part of the current configuration.
+// GetReceiversStatus returns the status of receivers configured as part of the current configuration.
 // It is safe to call concurrently.
-func (am *GrafanaAlertmanager) GetReceivers() []models.Receiver {
+func (am *GrafanaAlertmanager) GetReceiversStatus() []models.ReceiverStatus {
 	am.reloadConfigMtx.RLock()
 	receivers := am.receivers
 	am.reloadConfigMtx.RUnlock()
@@ -364,14 +364,14 @@ func (am *GrafanaAlertmanager) GetReceivers() []models.Receiver {
 }
 
 // GetReceivers converts the internal receiver status into the API response.
-func GetReceivers(receivers []*nfstatus.Receiver) []models.Receiver {
-	apiReceivers := make([]models.Receiver, 0, len(receivers))
+func GetReceivers(receivers []*nfstatus.Receiver) []models.ReceiverStatus {
+	apiReceivers := make([]models.ReceiverStatus, 0, len(receivers))
 	for _, rcv := range receivers {
 		// Build integrations slice for each receiver.
-		integrations := make([]models.Integration, 0, len(rcv.Integrations()))
+		integrations := make([]models.IntegrationStatus, 0, len(rcv.Integrations()))
 		for _, integration := range rcv.Integrations() {
 			ts, d, err := integration.GetReport()
-			integrations = append(integrations, models.Integration{
+			integrations = append(integrations, models.IntegrationStatus{
 				Name:                      integration.Name(),
 				SendResolved:              integration.SendResolved(),
 				LastNotifyAttempt:         strfmt.DateTime(ts),
@@ -385,7 +385,7 @@ func GetReceivers(receivers []*nfstatus.Receiver) []models.Receiver {
 			})
 		}
 
-		apiReceivers = append(apiReceivers, models.Receiver{
+		apiReceivers = append(apiReceivers, models.ReceiverStatus{
 			Active:       rcv.Active(),
 			Integrations: integrations,
 			Name:         rcv.Name(),

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -397,14 +397,14 @@ func GetReceivers(receivers []*nfstatus.Receiver) []models.Receiver {
 
 // job contains all metadata required to test a receiver
 type job struct {
-	Config       *GrafanaIntegrationConfig
+	Config       *models.IntegrationConfig
 	ReceiverName string
 	Notifier     notify.Notifier
 }
 
 // result contains the receiver that was tested and a non-nil error if the test failed
 type result struct {
-	Config       *GrafanaIntegrationConfig
+	Config       *models.IntegrationConfig
 	ReceiverName string
 	Error        error
 }
@@ -503,7 +503,7 @@ func TestReceivers(
 			// can identify invalid receiver integration configs
 			singleIntReceiver := &APIReceiver{
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{intg},
+					Integrations: []*models.IntegrationConfig{intg},
 				},
 			}
 			integrations, err := buildIntegrationsFunc(singleIntReceiver, tmplProvider)

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -502,7 +502,7 @@ func TestReceivers(
 			// Create an APIReceiver with a single integration so we
 			// can identify invalid receiver integration configs
 			singleIntReceiver := &APIReceiver{
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{intg},
 				},
 			}

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -714,7 +714,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 1",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
@@ -724,7 +724,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 2",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
@@ -757,7 +757,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 1",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
@@ -767,7 +767,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 2",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
@@ -800,7 +800,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 1",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
@@ -810,7 +810,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 2",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
@@ -835,7 +835,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 1",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
@@ -845,7 +845,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ConfigReceiver: ConfigReceiver{
 					Name: "receiver 2",
 				},
-				GrafanaIntegrations: GrafanaIntegrations{
+				ReceiverConfig: models.ReceiverConfig{
 					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/receivers"
 )
@@ -694,17 +695,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 		_, status := newTestReceiversResult(types.Alert{}, []result{
 			{
 				ReceiverName: "receiver 1",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 1"},
+				Config:       &models.IntegrationConfig{Name: "integration 1"},
 				Error: IntegrationValidationError{
-					Integration: &GrafanaIntegrationConfig{Name: "integration 1"},
+					Integration: &models.IntegrationConfig{Name: "integration 1"},
 					Err:         errors.New("error 1"),
 				},
 			},
 			{
 				ReceiverName: "receiver 2",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 2"},
+				Config:       &models.IntegrationConfig{Name: "integration 2"},
 				Error: IntegrationValidationError{
-					Integration: &GrafanaIntegrationConfig{Name: "integration 2"},
+					Integration: &models.IntegrationConfig{Name: "integration 2"},
 					Err:         errors.New("error 2"),
 				},
 			},
@@ -714,7 +715,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 1",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
 				},
@@ -724,7 +725,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 2",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
 				},
@@ -737,17 +738,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 		_, status := newTestReceiversResult(types.Alert{}, []result{
 			{
 				ReceiverName: "receiver 1",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 1"},
+				Config:       &models.IntegrationConfig{Name: "integration 1"},
 				Error: IntegrationTimeoutError{
-					Integration: &GrafanaIntegrationConfig{Name: "integration 1"},
+					Integration: &models.IntegrationConfig{Name: "integration 1"},
 					Err:         errors.New("error 1"),
 				},
 			},
 			{
 				ReceiverName: "receiver 2",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 2"},
+				Config:       &models.IntegrationConfig{Name: "integration 2"},
 				Error: IntegrationTimeoutError{
-					Integration: &GrafanaIntegrationConfig{Name: "integration 2"},
+					Integration: &models.IntegrationConfig{Name: "integration 2"},
 					Err:         errors.New("error 2"),
 				},
 			},
@@ -757,7 +758,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 1",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
 				},
@@ -767,7 +768,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 2",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
 				},
@@ -780,17 +781,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 		_, status := newTestReceiversResult(types.Alert{}, []result{
 			{
 				ReceiverName: "receiver 1",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 1"},
+				Config:       &models.IntegrationConfig{Name: "integration 1"},
 				Error: IntegrationValidationError{
-					Integration: &GrafanaIntegrationConfig{Name: "integration 1"},
+					Integration: &models.IntegrationConfig{Name: "integration 1"},
 					Err:         errors.New("error 1"),
 				},
 			},
 			{
 				ReceiverName: "receiver 2",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 2"},
+				Config:       &models.IntegrationConfig{Name: "integration 2"},
 				Error: IntegrationTimeoutError{
-					Integration: &GrafanaIntegrationConfig{Name: "integration 2"},
+					Integration: &models.IntegrationConfig{Name: "integration 2"},
 					Err:         errors.New("error 2"),
 				},
 			},
@@ -800,7 +801,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 1",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
 				},
@@ -810,7 +811,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 2",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
 				},
@@ -823,11 +824,11 @@ func TestStatusForTestReceivers(t *testing.T) {
 		_, status := newTestReceiversResult(types.Alert{}, []result{
 			{
 				ReceiverName: "receiver 1",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 1"},
+				Config:       &models.IntegrationConfig{Name: "integration 1"},
 			},
 			{
 				ReceiverName: "receiver 2",
-				Config:       &GrafanaIntegrationConfig{Name: "integration 2"},
+				Config:       &models.IntegrationConfig{Name: "integration 2"},
 			},
 		}, []*APIReceiver{
 			{
@@ -835,7 +836,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 1",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 1"},
 					},
 				},
@@ -845,7 +846,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Name: "receiver 2",
 				},
 				GrafanaIntegrations: GrafanaIntegrations{
-					Integrations: []*GrafanaIntegrationConfig{
+					Integrations: []*models.IntegrationConfig{
 						{Name: "integration 2"},
 					},
 				},

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -73,12 +73,8 @@ type TestIntegrationConfigResult struct {
 type ConfigReceiver = config.Receiver
 
 type APIReceiver struct {
-	ConfigReceiver      `yaml:",inline"`
-	GrafanaIntegrations `yaml:",inline"`
-}
-
-type GrafanaIntegrations struct {
-	Integrations []*models.IntegrationConfig `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
+	ConfigReceiver        `yaml:",inline"`
+	models.ReceiverConfig `yaml:",inline"`
 }
 
 type TestReceiversConfigBodyParams struct {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/http"
+	"github.com/grafana/alerting/models"
 
 	"github.com/grafana/alerting/receivers"
 	alertmanager "github.com/grafana/alerting/receivers/alertmanager/v1"
@@ -69,15 +70,6 @@ type TestIntegrationConfigResult struct {
 	Error  string `json:"error"`
 }
 
-type GrafanaIntegrationConfig struct {
-	UID                   string            `json:"uid" yaml:"uid"`
-	Name                  string            `json:"name" yaml:"name"`
-	Type                  string            `json:"type" yaml:"type"`
-	DisableResolveMessage bool              `json:"disableResolveMessage" yaml:"disableResolveMessage"`
-	Settings              json.RawMessage   `json:"settings" yaml:"settings"`
-	SecureSettings        map[string]string `json:"secureSettings" yaml:"secureSettings"`
-}
-
 type ConfigReceiver = config.Receiver
 
 type APIReceiver struct {
@@ -86,7 +78,7 @@ type APIReceiver struct {
 }
 
 type GrafanaIntegrations struct {
-	Integrations []*GrafanaIntegrationConfig `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
+	Integrations []*models.IntegrationConfig `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
 }
 
 type TestReceiversConfigBodyParams struct {
@@ -100,7 +92,7 @@ type TestReceiversConfigAlertParams struct {
 }
 
 type IntegrationTimeoutError struct {
-	Integration *GrafanaIntegrationConfig
+	Integration *models.IntegrationConfig
 	Err         error
 }
 
@@ -153,7 +145,7 @@ func newTestAlert(c TestReceiversConfigBodyParams, startsAt, updatedAt time.Time
 	return alert
 }
 
-func ProcessIntegrationError(config *GrafanaIntegrationConfig, err error) error {
+func ProcessIntegrationError(config *models.IntegrationConfig, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -206,7 +198,7 @@ type GrafanaReceiverConfig struct {
 	WebexConfigs        []*NotifierConfig[webex.Config]
 }
 
-// NotifierConfig represents parsed GrafanaIntegrationConfig.
+// NotifierConfig represents parsed IntegrationConfig.
 type NotifierConfig[T interface{}] struct {
 	receivers.Metadata
 	Settings         T
@@ -275,7 +267,7 @@ func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decode De
 }
 
 // parseNotifier parses receivers and populates the corresponding field in GrafanaReceiverConfig. Returns an error if the configuration cannot be parsed.
-func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver *GrafanaIntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn, idx int) error {
+func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver *models.IntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn, idx int) error {
 	secureSettings, err := decode(receiver.SecureSettings)
 	if err != nil {
 		return err
@@ -533,7 +525,7 @@ func GetActiveReceiversMap(r *dispatch.Route) map[string]struct{} {
 	return receiversMap
 }
 
-func parseHTTPConfig(integration *GrafanaIntegrationConfig, decryptFn func(key string, fallback string) string) (*http.HTTPClientConfig, error) {
+func parseHTTPConfig(integration *models.IntegrationConfig, decryptFn func(key string, fallback string) string) (*http.HTTPClientConfig, error) {
 	httpConfigSettings := struct {
 		HTTPConfig *http.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	}{}
@@ -552,7 +544,7 @@ func parseHTTPConfig(integration *GrafanaIntegrationConfig, decryptFn func(key s
 	return httpConfigSettings.HTTPConfig, nil
 }
 
-func newNotifierConfig[T interface{}](integration *GrafanaIntegrationConfig, idx int, settings T, decryptFn func(key string, fallback string) string) (*NotifierConfig[T], error) {
+func newNotifierConfig[T interface{}](integration *models.IntegrationConfig, idx int, settings T, decryptFn func(key string, fallback string) string) (*NotifierConfig[T], error) {
 	httpClientConfig, err := parseHTTPConfig(integration, decryptFn)
 	if err != nil {
 		return nil, err
@@ -572,7 +564,7 @@ func newNotifierConfig[T interface{}](integration *GrafanaIntegrationConfig, idx
 
 type IntegrationValidationError struct {
 	Err         error
-	Integration *GrafanaIntegrationConfig
+	Integration *models.IntegrationConfig
 }
 
 func (e IntegrationValidationError) Error() string {

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -173,7 +173,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, NoopDecode, NoopDecrypt)
 		require.NoError(t, err)
 		require.Equal(t, recCfg.Name, parsed.Name)
-		for _, notifier := range recCfg.GrafanaIntegrations.Integrations {
+		for _, notifier := range recCfg.ReceiverConfig.Integrations {
 			if notifier.Type == "prometheus-alertmanager" {
 				require.Equal(t, notifier.SecureSettings["basicAuthPassword"], parsed.AlertmanagerConfigs[0].Settings.Password)
 			}
@@ -212,7 +212,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.Equal(t, recCfg.Name, parsed.Name)
 
 		expectedNotifiers := make(map[string]struct{})
-		for _, notifier := range recCfg.GrafanaIntegrations.Integrations {
+		for _, notifier := range recCfg.ReceiverConfig.Integrations {
 			expectedNotifiers[notifier.Type] = struct{}{}
 		}
 
@@ -257,7 +257,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedNotifiers := make(map[string]struct{})
-		for _, notifier := range recCfg.GrafanaIntegrations.Integrations {
+		for _, notifier := range recCfg.ReceiverConfig.Integrations {
 			expectedNotifiers[notifier.Type] = struct{}{}
 		}
 
@@ -297,7 +297,7 @@ func TestHTTPConfig(t *testing.T) {
 
 				recCfg := &APIReceiver{
 					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-					GrafanaIntegrations: GrafanaIntegrations{
+					ReceiverConfig: models.ReceiverConfig{
 						[]*models.IntegrationConfig{
 							config,
 						},
@@ -482,7 +482,7 @@ func TestHTTPConfig(t *testing.T) {
 
 				recCfg := &APIReceiver{
 					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-					GrafanaIntegrations: GrafanaIntegrations{
+					ReceiverConfig: models.ReceiverConfig{
 						[]*models.IntegrationConfig{
 							config,
 						},

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -298,7 +298,7 @@ func TestHTTPConfig(t *testing.T) {
 				recCfg := &APIReceiver{
 					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
 					ReceiverConfig: models.ReceiverConfig{
-						[]*models.IntegrationConfig{
+						Integrations: []*models.IntegrationConfig{
 							config,
 						},
 					},
@@ -483,7 +483,7 @@ func TestHTTPConfig(t *testing.T) {
 				recCfg := &APIReceiver{
 					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
 					ReceiverConfig: models.ReceiverConfig{
-						[]*models.IntegrationConfig{
+						Integrations: []*models.IntegrationConfig{
 							config,
 						},
 					},

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -2,15 +2,12 @@ package notify
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/prometheus/alertmanager/types"
 
-	"github.com/grafana/alerting/notify/notifytest"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -117,38 +114,4 @@ func MergeSettings(a []byte, b []byte) ([]byte, error) {
 	}
 
 	return json.Marshal(origSettings)
-}
-
-func GetRawNotifierConfig(n notifytest.NotifierConfigTest, name string) *GrafanaIntegrationConfig {
-	if name == "" {
-		name = string(n.NotifierType)
-	}
-	secrets := make(map[string]string)
-	if n.Secrets != "" {
-		err := json.Unmarshal([]byte(n.Secrets), &secrets)
-		if err != nil {
-			panic(err)
-		}
-		for key, value := range secrets {
-			secrets[key] = base64.StdEncoding.EncodeToString([]byte(value))
-		}
-	}
-
-	config := []byte(n.Config)
-	if !n.CommonHTTPConfigUnsupported {
-		var err error
-		config, err = MergeSettings([]byte(n.Config), []byte(notifytest.FullValidHTTPConfigForTesting))
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	return &GrafanaIntegrationConfig{
-		UID:                   fmt.Sprintf("%s-uid", name),
-		Name:                  name,
-		Type:                  string(n.NotifierType),
-		DisableResolveMessage: true,
-		Settings:              config,
-		SecureSettings:        secrets,
-	}
 }


### PR DESCRIPTION
This PR is a minor refactoring:
- Moves `notify.GrafanaIntegrationConfig` to `models.IntegrationConfig`
- Moves `notify.GrafanaIntegrations` to `models.ReceiverConfig`
- Moves compat functions [from Grafana ](https://github.com/grafana/grafana/blob/5520f481538f5dd4660a05127fb7b25ba0d96c9b/pkg/services/ngalert/notifier/compat.go#L12-L43) to notify
- Renames models.Receiver and models.Integration to ReceiverStatus and IntegrationStatus to better reflect thier purpose.


This will make it reusable and avoid some circular dependencies