### PR TITLE
Return CommonHTTPConfigUnsupported back

### DIFF
--- a/notify/notifytest/grafana_integrations.go
+++ b/notify/notifytest/grafana_integrations.go
@@ -58,10 +58,10 @@ import (
 
 var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 	alertmanager.Type: {
-		NotifierType: alertmanager.Type,
-		Version:      schema.V1,
-		Config:       alertmanagerv1.FullValidConfigForTesting,
-		Secrets:      alertmanagerv1.FullValidSecretsForTesting,
+		NotifierType:                alertmanager.Type,
+		Version:                     schema.V1,
+		Config:                      alertmanagerv1.FullValidConfigForTesting,
+		Secrets:                     alertmanagerv1.FullValidSecretsForTesting,
 		CommonHTTPConfigUnsupported: true,
 	},
 	dingding.Type: {
@@ -75,9 +75,9 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Config:       discordv1.FullValidConfigForTesting,
 	},
 	email.Type: {
-		NotifierType: email.Type,
-		Version:      schema.V1,
-		Config:       emailv1.FullValidConfigForTesting,
+		NotifierType:                email.Type,
+		Version:                     schema.V1,
+		Config:                      emailv1.FullValidConfigForTesting,
 		CommonHTTPConfigUnsupported: true,
 	},
 	googlechat.Type: {
@@ -105,10 +105,10 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Secrets:      linev1.FullValidSecretsForTesting,
 	},
 	mqtt.Type: {
-		NotifierType: mqtt.Type,
-		Version:      schema.V1,
-		Config:       mqttv1.FullValidConfigForTesting,
-		Secrets:      mqttv1.FullValidSecretsForTesting,
+		NotifierType:                mqtt.Type,
+		Version:                     schema.V1,
+		Config:                      mqttv1.FullValidConfigForTesting,
+		Secrets:                     mqttv1.FullValidSecretsForTesting,
 		CommonHTTPConfigUnsupported: true,
 	},
 	oncall.Type: {
@@ -142,16 +142,16 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Secrets:      sensugov1.FullValidSecretsForTesting,
 	},
 	slack.Type: {
-		NotifierType: slack.Type,
-		Version:      schema.V1,
-		Config:       slackv1.FullValidConfigForTesting,
-		Secrets:      slackv1.FullValidSecretsForTesting,
+		NotifierType:                slack.Type,
+		Version:                     schema.V1,
+		Config:                      slackv1.FullValidConfigForTesting,
+		Secrets:                     slackv1.FullValidSecretsForTesting,
 		CommonHTTPConfigUnsupported: true,
 	},
 	sns.Type: {
-		NotifierType: sns.Type,
-		Version:      schema.V1,
-		Config:       snsv1.FullValidConfigForTesting,
+		NotifierType:                sns.Type,
+		Version:                     schema.V1,
+		Config:                      snsv1.FullValidConfigForTesting,
 		CommonHTTPConfigUnsupported: true,
 	},
 	teams.Type: {

--- a/notify/notifytest/grafana_integrations.go
+++ b/notify/notifytest/grafana_integrations.go
@@ -62,6 +62,7 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Version:      schema.V1,
 		Config:       alertmanagerv1.FullValidConfigForTesting,
 		Secrets:      alertmanagerv1.FullValidSecretsForTesting,
+		CommonHTTPConfigUnsupported: true,
 	},
 	dingding.Type: {
 		NotifierType: dingding.Type,
@@ -77,6 +78,7 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		NotifierType: email.Type,
 		Version:      schema.V1,
 		Config:       emailv1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
 	},
 	googlechat.Type: {
 		NotifierType: googlechat.Type,
@@ -107,6 +109,7 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Version:      schema.V1,
 		Config:       mqttv1.FullValidConfigForTesting,
 		Secrets:      mqttv1.FullValidSecretsForTesting,
+		CommonHTTPConfigUnsupported: true,
 	},
 	oncall.Type: {
 		NotifierType: oncall.Type,
@@ -143,11 +146,13 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Version:      schema.V1,
 		Config:       slackv1.FullValidConfigForTesting,
 		Secrets:      slackv1.FullValidSecretsForTesting,
+		CommonHTTPConfigUnsupported: true,
 	},
 	sns.Type: {
 		NotifierType: sns.Type,
 		Version:      schema.V1,
 		Config:       snsv1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
 	},
 	teams.Type: {
 		NotifierType: teams.Type,


### PR DESCRIPTION
During migration to notifytest package in https://github.com/grafana/alerting/pull/389 the flag CommonHTTPConfigUnsupported was accidentally unset for test integrations, which broke some tests in Grafana. This PR returns it back 