### PR TITLE
Oncall: Populate OnCall message with extra data if present in the context

### DIFF
--- a/receivers/oncall/v1/oncall.go
+++ b/receivers/oncall/v1/oncall.go
@@ -88,6 +88,16 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		},
 		as...)
 
+	// Augment extended Alert data with any extra data if provided
+	// If there is no extra data in the context or it is malformed,
+	// we simply continue without erroring
+	extraData, ok := receivers.GetExtraDataFromContext(ctx)
+	if ok && len(data.Alerts) == len(extraData) {
+		for i, ed := range extraData {
+			data.Alerts[i].ExtraData = ed
+		}
+	}
+
 	msg := &oncallMessage{
 		Version:         "1",
 		ExtendedData:    data,

--- a/receivers/oncall/v1/oncall_test.go
+++ b/receivers/oncall/v1/oncall_test.go
@@ -603,7 +603,7 @@ func TestNotify_ExtraData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that extra data is present in the alerts
-	require.Len(t, oncallMsg.ExtendedData.Alerts, 2)
+	require.Len(t, oncallMsg.Alerts, 2)
 
 	// Check first alert's extra data
 	require.JSONEq(t, string(extraData1), string(oncallMsg.ExtendedData.Alerts[0].ExtraData))

--- a/receivers/oncall/v1/oncall_test.go
+++ b/receivers/oncall/v1/oncall_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
 )
@@ -535,4 +536,78 @@ func TestNotify(t *testing.T) {
 			require.Equal(t, c.expHeaders, webhookSender.Webhook.HTTPHeader)
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	orgID := int64(1)
+
+	// Setup OnCall notifier
+	settings := Config{
+		URL:        "http://localhost/test",
+		HTTPMethod: http.MethodPost,
+		Title:      templates.DefaultMessageTitleEmbed,
+		Message:    templates.DefaultMessageEmbed,
+	}
+
+	webhookSender := receivers.MockNotificationService()
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images.UnavailableProvider{},
+		orgID:    orgID,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = notify.WithReceiverName(ctx, "my_receiver")
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Parse the oncall body to verify extra data was included
+	var oncallMsg oncallMessage
+	err = json.Unmarshal([]byte(webhookSender.Webhook.Body), &oncallMsg)
+	require.NoError(t, err)
+
+	// Verify that extra data is present in the alerts
+	require.Len(t, oncallMsg.ExtendedData.Alerts, 2)
+
+	// Check first alert's extra data
+	require.JSONEq(t, string(extraData1), string(oncallMsg.ExtendedData.Alerts[0].ExtraData))
+
+	// Check second alert's extra data
+	require.JSONEq(t, string(extraData2), string(oncallMsg.ExtendedData.Alerts[1].ExtraData))
 }

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -212,4 +213,15 @@ func TruncateInBytes(s string, n int) (string, bool) {
 	}
 
 	return string(truncatedRunes) + truncationMarker, true
+}
+
+type extraDataKey int
+
+const (
+	ExtraDataKey extraDataKey = iota
+)
+
+func GetExtraDataFromContext(ctx context.Context) ([]json.RawMessage, bool) {
+	v, ok := ctx.Value(ExtraDataKey).([]json.RawMessage)
+	return v, ok
 }

--- a/receivers/webhook/v1/webhook.go
+++ b/receivers/webhook/v1/webhook.go
@@ -56,12 +56,6 @@ type webhookMessage struct {
 	Message         string `json:"message"`
 }
 
-type extraDataKey int
-
-const (
-	ExtraDataKey extraDataKey = iota
-)
-
 // Notify implements the Notifier interface.
 func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	l := wn.GetLogger(ctx)
@@ -99,7 +93,7 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	// Augment extended Alert data with any extra data if provided
 	// If there is no extra data in the context or it is malformed,
 	// we simply continue without erroring
-	extraData, ok := getExtraDataFromContext(ctx)
+	extraData, ok := receivers.GetExtraDataFromContext(ctx)
 	if ok && len(data.Alerts) == len(extraData) {
 		for i, ed := range extraData {
 			data.Alerts[i].ExtraData = ed
@@ -187,11 +181,6 @@ func truncateAlerts(maxAlerts int, alerts []*types.Alert) ([]*types.Alert, int) 
 	}
 
 	return alerts, 0
-}
-
-func getExtraDataFromContext(ctx context.Context) ([]json.RawMessage, bool) {
-	v, ok := ctx.Value(ExtraDataKey).([]json.RawMessage)
-	return v, ok
 }
 
 func (wn *Notifier) SendResolved() bool {

--- a/receivers/webhook/v1/webhook_test.go
+++ b/receivers/webhook/v1/webhook_test.go
@@ -1130,7 +1130,7 @@ func TestNotify_ExtraData(t *testing.T) {
 	ctx := notify.WithGroupKey(context.Background(), "alertname")
 	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
 	ctx = notify.WithReceiverName(ctx, "my_receiver")
-	ctx = context.WithValue(ctx, ExtraDataKey, extraDataSlice)
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
 
 	// Call Notify
 	ok, err := pn.Notify(ctx, alerts...)

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -118,7 +118,7 @@ type ExtendedAlert struct {
 	ImageURL      string             `json:"imageURL,omitempty"`
 	EmbeddedImage string             `json:"embeddedImage,omitempty"`
 	OrgID         *int64             `json:"orgId,omitempty"`
-	ExtraData     json.RawMessage    `json:"extraData,omitempty"`
+	ExtraData     json.RawMessage    `json:"enrichments,omitempty"`
 }
 
 type ExtendedAlerts []ExtendedAlert


### PR DESCRIPTION
Similar to the `webhookMessage` - if there is any `extraData` present in the context for the alert, read the data and add it to the `ExtendedAlert` in the OnCall message.