### PR TITLE
Convert config.Receiver to a slice of integration configs

### DIFF
--- a/notify/compat.go
+++ b/notify/compat.go
@@ -109,7 +109,13 @@ func ConfigReceiverToIntegrations(receiver ConfigReceiver) ([]MimirIntegrationCo
 		}
 		result = slices.Grow(result, len(result)+sliceVal.Len())
 		for j := 0; j < sliceVal.Len(); j++ {
-			elem := sliceVal.Index(j).Elem().Interface()
+			var elem any
+			item := sliceVal.Index(j)
+			if elemType.Kind() == reflect.Ptr {
+				elem = item.Elem().Interface()
+			} else {
+				elem = item.Interface()
+			}
 			result = append(result, MimirIntegrationConfig{
 				Schema: version,
 				Config: elem,

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -87,6 +87,10 @@ func ConfigReceiverToIntegrations(receiver ConfigReceiver) ([]MimirIntegrationCo
 			continue
 		}
 		iType, err := IntegrationTypeFromMimirTypeReflect(elemType)
+		if err != nil {
+			return nil, err
+		}
+
 		sch, ok := GetSchemaForIntegration(iType)
 		if !ok {
 			return nil, fmt.Errorf("cannot find schema by integration type %s", iType)
@@ -102,10 +106,6 @@ func ConfigReceiverToIntegrations(receiver ConfigReceiver) ([]MimirIntegrationCo
 			if !ok {
 				return nil, fmt.Errorf("cannot find schema version by integration type alias %s", iType)
 			}
-		}
-
-		if err != nil {
-			return nil, err
 		}
 		result = slices.Grow(result, len(result)+sliceVal.Len())
 		for j := 0; j < sliceVal.Len(); j++ {

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -70,8 +70,8 @@ func PostableAPITemplatesToTemplateDefinitions(ts []definition.PostableApiTempla
 	return defs
 }
 
-// ConfigReceiverToIntegrations converts a ConfigReceiver to a list of MimirIntegrationConfig
-func ConfigReceiverToIntegrations(receiver ConfigReceiver) ([]MimirIntegrationConfig, error) {
+// ConfigReceiverToMimirIntegrations converts a ConfigReceiver to a list of MimirIntegrationConfig
+func ConfigReceiverToMimirIntegrations(receiver ConfigReceiver) ([]MimirIntegrationConfig, error) {
 	result := make([]MimirIntegrationConfig, 0)
 	receiverVal := reflect.ValueOf(&receiver).Elem()
 	receiverType := receiverVal.Type()
@@ -107,7 +107,7 @@ func ConfigReceiverToIntegrations(receiver ConfigReceiver) ([]MimirIntegrationCo
 				return nil, fmt.Errorf("cannot find schema version by integration type alias %s", iType)
 			}
 		}
-		result = slices.Grow(result, len(result)+sliceVal.Len())
+		result = slices.Grow(result, sliceVal.Len())
 		for j := 0; j < sliceVal.Len(); j++ {
 			var elem any
 			item := sliceVal.Index(j)

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -142,10 +142,10 @@ func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
 	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[1]), actual[1])
 }
 
-func TestConfigReceiverToIntegrations(t *testing.T) {
+func TestConfigReceiverToMimirIntegrations(t *testing.T) {
 	r, err := notifytest.GetMimirReceiverWithAllIntegrations()
 	require.NoError(t, err)
-	actual, err := ConfigReceiverToIntegrations(r)
+	actual, err := ConfigReceiverToMimirIntegrations(r)
 	require.NoError(t, err)
 	require.Len(t, actual, len(notifytest.AllValidMimirConfigs))
 	idx := slices.IndexFunc(actual, func(e MimirIntegrationConfig) bool {
@@ -173,7 +173,7 @@ func TestConfigReceiverToIntegrations(t *testing.T) {
 		assert.Equal(t, 2, found, "expected 2 teams integrations")
 	})
 	t.Run("should not fail if empty", func(t *testing.T) {
-		actual, err = ConfigReceiverToIntegrations(ConfigReceiver{Name: "empty"})
+		actual, err = ConfigReceiverToMimirIntegrations(ConfigReceiver{Name: "empty"})
 		require.NoError(t, err)
 		require.Empty(t, actual)
 	})

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/prometheus/alertmanager/config"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/notify/notifytest"
+	"github.com/grafana/alerting/receivers/email"
 )
 
 func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
@@ -134,4 +137,16 @@ func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
 	require.Len(t, actual, 2)
 	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[0]), actual[0])
 	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[1]), actual[1])
+}
+
+func TestConfigReceiverToIntegrations(t *testing.T) {
+	r, err := notifytest.GetMimirReceiverWithAllIntegrations()
+	require.NoError(t, err)
+	actual, err := ConfigReceiverToIntegrations(r)
+	require.NoError(t, err)
+	require.Len(t, actual, len(notifytest.AllValidMimirConfigs))
+	idx := slices.IndexFunc(actual, func(e MimirIntegrationConfig) bool {
+		return e.Type == email.Type
+	})
+	require.IsType(t, config.EmailConfig{}, actual[idx].Config)
 }

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -15,8 +15,10 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/receivers/schema"
 
 	"github.com/grafana/alerting/receivers"
 	alertmanager "github.com/grafana/alerting/receivers/alertmanager/v1"
@@ -573,3 +575,25 @@ func (e IntegrationValidationError) Error() string {
 }
 
 func (e IntegrationValidationError) Unwrap() error { return e.Err }
+
+type MimirIntegrationConfig struct {
+	Type   schema.IntegrationType
+	Config any
+}
+
+func (c MimirIntegrationConfig) ConfigJSON() ([]byte, error) {
+	return definition.MarshalJSONWithSecrets(c.Config)
+}
+
+func (c MimirIntegrationConfig) ConfigMap() (map[string]any, error) {
+	data, err := c.ConfigJSON()
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -18,8 +18,6 @@ import (
 	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/models"
-	"github.com/grafana/alerting/receivers/schema"
-
 	"github.com/grafana/alerting/receivers"
 	alertmanager "github.com/grafana/alerting/receivers/alertmanager/v1"
 	dingding "github.com/grafana/alerting/receivers/dingding/v1"
@@ -34,6 +32,7 @@ import (
 	opsgenie "github.com/grafana/alerting/receivers/opsgenie/v1"
 	pagerduty "github.com/grafana/alerting/receivers/pagerduty/v1"
 	pushover "github.com/grafana/alerting/receivers/pushover/v1"
+	"github.com/grafana/alerting/receivers/schema"
 	sensugo "github.com/grafana/alerting/receivers/sensugo/v1"
 	slack "github.com/grafana/alerting/receivers/slack/v1"
 	sns "github.com/grafana/alerting/receivers/sns/v1"
@@ -577,10 +576,11 @@ func (e IntegrationValidationError) Error() string {
 func (e IntegrationValidationError) Unwrap() error { return e.Err }
 
 type MimirIntegrationConfig struct {
-	Type   schema.IntegrationType
+	Schema schema.IntegrationSchemaVersion
 	Config any
 }
 
+// ConfigJSON returns the JSON representation of the integration config with non-masked secrets.
 func (c MimirIntegrationConfig) ConfigJSON() ([]byte, error) {
 	return definition.MarshalJSONWithSecrets(c.Config)
 }

--- a/notify/schema.go
+++ b/notify/schema.go
@@ -220,6 +220,9 @@ func IntegrationTypeFromString(s string) (schema.IntegrationType, error) {
 	return "", fmt.Errorf("%w: %s", ErrUnknownIntegrationType, s)
 }
 
+// IntegrationTypeFromMimirType returns a valid integration type from a type.
+// The argument could be a slice of configurations, e.g. Receiver.EmailConfigs or a struct or a pointer of config type, e.g. config.EmailConfig
+// The returning type could be alias or original type.
 func IntegrationTypeFromMimirType(t any) (schema.IntegrationType, error) {
 	var configType = reflect.TypeOf(t)
 	return IntegrationTypeFromMimirTypeReflect(configType)

--- a/notify/schema.go
+++ b/notify/schema.go
@@ -1,7 +1,9 @@
 package notify
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -216,4 +218,27 @@ func IntegrationTypeFromString(s string) (schema.IntegrationType, error) {
 		}
 	}
 	return "", fmt.Errorf("%w: %s", ErrUnknownIntegrationType, s)
+}
+
+func IntegrationTypeFromMimirType(t any) (schema.IntegrationType, error) {
+	var configType = reflect.TypeOf(t)
+	return IntegrationTypeFromMimirTypeReflect(configType)
+}
+
+// IntegrationTypeFromMimirTypeReflect returns a valid integration type from a reflect.Type.
+// Can be type of ConfigReceiver fields, e.g EmailConfigs or type a particular configuration
+func IntegrationTypeFromMimirTypeReflect(t reflect.Type) (schema.IntegrationType, error) {
+	if t == nil {
+		return "", errors.New("nil type")
+	}
+	if t.Kind() == reflect.Struct {
+		return IntegrationTypeFromString(strings.ToLower(strings.TrimSuffix(t.Name(), "Config")))
+	}
+	if t.Kind() == reflect.Ptr {
+		return IntegrationTypeFromMimirTypeReflect(t.Elem())
+	}
+	if t.Kind() == reflect.Slice {
+		return IntegrationTypeFromMimirTypeReflect(t.Elem())
+	}
+	return "", errors.New("not a struct or slice")
 }

--- a/notify/schema_test.go
+++ b/notify/schema_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/grafana/alerting/receivers/slack"
 	"github.com/grafana/alerting/receivers/sns"
 	"github.com/grafana/alerting/receivers/teams"
+	teamsV0Mimir1 "github.com/grafana/alerting/receivers/teams/v0mimir1"
+	teamsV0Mimir2 "github.com/grafana/alerting/receivers/teams/v0mimir2"
 	"github.com/grafana/alerting/receivers/telegram"
 	"github.com/grafana/alerting/receivers/threema"
 	"github.com/grafana/alerting/receivers/victorops"
@@ -318,13 +320,13 @@ func TestIntegrationTypeFromMimirType(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, email.Type, actual)
 
-	actual, err = IntegrationTypeFromMimirType(config.WebexConfig{})
+	actual, err = IntegrationTypeFromMimirType(config.MSTeamsConfig{})
 	require.NoError(t, err)
-	require.Equal(t, webex.Type, actual)
+	require.Equal(t, teamsV0Mimir1.Schema.TypeAlias, actual)
 
-	actual, err = IntegrationTypeFromMimirType(&config.WebhookConfig{})
+	actual, err = IntegrationTypeFromMimirType(&config.MSTeamsV2Config{})
 	require.NoError(t, err)
-	require.Equal(t, webhook.Type, actual)
+	require.Equal(t, teamsV0Mimir2.Schema.TypeAlias, actual)
 
 	t.Run("error on unknown type", func(t *testing.T) {
 		_, err = IntegrationTypeFromMimirType(1)
@@ -343,7 +345,6 @@ func TestIntegrationTypeFromMimirType(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, schema.IntegrationType(expected), actual)
 	})
-
 }
 
 func unique(slice []string) []string {


### PR DESCRIPTION
1. Adds a functions to resolve v0 integration types from struct field types
`IntegrationTypeFromMimirType` and `IntegrationTypeFromMimirTypeReflect`. They help convert a field into `schema.IntegrationType`.

2. Adds a adapter function to convert Alertmanager's Reciever into a generic struct `MimirIntegrationConfig` that holds information about type and version along with configuration. 

This will help us convert v0 configurations to models we can work in a generic manner