### PR TITLE
feat: make some widgets optional for google chat

### DIFF
--- a/receivers/googlechat/v1/config.go
+++ b/receivers/googlechat/v1/config.go
@@ -13,9 +13,11 @@ import (
 const Version = schema.V1
 
 type Config struct {
-	URL     string `json:"url,omitempty" yaml:"url,omitempty"`
-	Title   string `json:"title,omitempty" yaml:"title,omitempty"`
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	URL             string `json:"url,omitempty" yaml:"url,omitempty"`
+	Title           string `json:"title,omitempty" yaml:"title,omitempty"`
+	Message         string `json:"message,omitempty" yaml:"message,omitempty"`
+	HideOpenButton  bool   `json:"hide_open_button,omitempty" yaml:"hide_open_button,omitempty"`
+	HideVersionInfo bool   `json:"hide_version_info,omitempty" yaml:"hide_version_info,omitempty"`
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
@@ -64,6 +66,18 @@ var Schema = schema.IntegrationSchemaVersion{
 			Element:      schema.ElementTypeTextArea,
 			Placeholder:  templates.DefaultMessageEmbed,
 			PropertyName: "message",
+		},
+		{
+			Label:        "HideOpenButton",
+			Description:  "Hide open URL button",
+			Element:      schema.ElementTypeCheckbox,
+			PropertyName: "hide_open_button",
+		},
+		{
+			Label:        "HideVersionInfo",
+			Description:  "Hide version info",
+			Element:      schema.ElementTypeCheckbox,
+			PropertyName: "hide_version_info",
 		},
 	},
 }

--- a/receivers/googlechat/v1/config_test.go
+++ b/receivers/googlechat/v1/config_test.go
@@ -39,9 +39,11 @@ func TestNewConfig(t *testing.T) {
 			settings: `{ "url": "http://localhost" }`,
 			secrets:  map[string][]byte{},
 			expectedConfig: Config{
-				Title:   templates.DefaultMessageTitleEmbed,
-				Message: templates.DefaultMessageEmbed,
-				URL:     "http://localhost",
+				Title:           templates.DefaultMessageTitleEmbed,
+				Message:         templates.DefaultMessageEmbed,
+				URL:             "http://localhost",
+				HideOpenButton:  false,
+				HideVersionInfo: false,
 			},
 		},
 		{
@@ -51,9 +53,11 @@ func TestNewConfig(t *testing.T) {
 				"url": []byte("http://localhost"),
 			},
 			expectedConfig: Config{
-				Title:   templates.DefaultMessageTitleEmbed,
-				Message: templates.DefaultMessageEmbed,
-				URL:     "http://localhost",
+				Title:           templates.DefaultMessageTitleEmbed,
+				Message:         templates.DefaultMessageEmbed,
+				URL:             "http://localhost",
+				HideOpenButton:  false,
+				HideVersionInfo: false,
 			},
 		},
 		{
@@ -63,18 +67,22 @@ func TestNewConfig(t *testing.T) {
 				"url": []byte("http://test"),
 			},
 			expectedConfig: Config{
-				Title:   templates.DefaultMessageTitleEmbed,
-				Message: templates.DefaultMessageEmbed,
-				URL:     "http://test",
+				Title:           templates.DefaultMessageTitleEmbed,
+				Message:         templates.DefaultMessageEmbed,
+				URL:             "http://test",
+				HideOpenButton:  false,
+				HideVersionInfo: false,
 			},
 		},
 		{
 			name:     "All empty fields = minimal valid configuration",
 			settings: `{"url": "http://localhost", "title": "", "message": "", "avatar_url" : "", "use_discord_username": null}`,
 			expectedConfig: Config{
-				Title:   templates.DefaultMessageTitleEmbed,
-				Message: templates.DefaultMessageEmbed,
-				URL:     "http://localhost",
+				Title:           templates.DefaultMessageTitleEmbed,
+				Message:         templates.DefaultMessageEmbed,
+				URL:             "http://localhost",
+				HideOpenButton:  false,
+				HideVersionInfo: false,
 			},
 		},
 		{
@@ -82,9 +90,11 @@ func TestNewConfig(t *testing.T) {
 			settings: FullValidConfigForTesting,
 			secrets:  receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
 			expectedConfig: Config{
-				Title:   "test-title",
-				Message: "test-message",
-				URL:     "http://localhost/url-secret",
+				Title:           "test-title",
+				Message:         "test-message",
+				URL:             "http://localhost/url-secret",
+				HideOpenButton:  true,
+				HideVersionInfo: true,
 			},
 		},
 	}

--- a/receivers/googlechat/v1/googlechat_test.go
+++ b/receivers/googlechat/v1/googlechat_test.go
@@ -485,6 +485,94 @@ func TestNotify(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Hide open button",
+			settings: Config{
+				Title:          templates.DefaultMessageTitleEmbed,
+				Message:        templates.DefaultMessageEmbed,
+				URL:            "http://localhost",
+				HideOpenButton: true,
+			}, // URL in settings = googlechat url
+			externalURL: "", // external URL = URL of grafana from configuration
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+					},
+				},
+			},
+			expMsg: &outerStruct{
+				PreviewText:  "[FIRING:1]  (val1)",
+				FallbackText: "[FIRING:1]  (val1)",
+				Cards: []card{
+					{
+						Header: header{
+							Title: "[FIRING:1]  (val1)",
+						},
+						Sections: []section{
+							{
+								Widgets: []widget{
+									textParagraphWidget{
+										Text: text{
+											Text: "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\n",
+										},
+									},
+
+									textParagraphWidget{
+										Text: text{
+											// RFC822 only has the minute, hence it works in most cases.
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Hide version info",
+			settings: Config{
+				Title:           templates.DefaultMessageTitleEmbed,
+				Message:         templates.DefaultMessageEmbed,
+				URL:             "http://localhost",
+				HideOpenButton:  true,
+				HideVersionInfo: true,
+			}, // URL in settings = googlechat url
+			externalURL: "", // external URL = URL of grafana from configuration
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+					},
+				},
+			},
+			expMsg: &outerStruct{
+				PreviewText:  "[FIRING:1]  (val1)",
+				FallbackText: "[FIRING:1]  (val1)",
+				Cards: []card{
+					{
+						Header: header{
+							Title: "[FIRING:1]  (val1)",
+						},
+						Sections: []section{
+							{
+								Widgets: []widget{
+									textParagraphWidget{
+										Text: text{
+											Text: "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\n",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/receivers/googlechat/v1/testing.go
+++ b/receivers/googlechat/v1/testing.go
@@ -4,7 +4,9 @@ package v1
 const FullValidConfigForTesting = `{
 	"url": "http://localhost", 
 	"title": "test-title", 
-	"message": "test-message"
+	"message": "test-message",
+	"hide_open_button": true,
+	"hide_version_info": true
 }`
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets.


### PR DESCRIPTION
Since making the widget customisable via templating is complicated and the open URL button and version info are irrelevant in most use cases (see https://github.com/grafana/alerting/issues/209), this PR makes it optional.

By default, both version info and the open URL are still displayed to avoid introducing a breaking change.