### PR TITLE
Update dingding to read url from secure settings

### DIFF
--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -286,7 +286,7 @@ func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver 
 		}
 		result.AlertmanagerConfigs = append(result.AlertmanagerConfigs, notifierConfig)
 	case "dingding":
-		cfg, err := dingding.NewConfig(receiver.Settings)
+		cfg, err := dingding.NewConfig(receiver.Settings, decryptFn)
 		if err != nil {
 			return err
 		}

--- a/receivers/dingding/v1/config.go
+++ b/receivers/dingding/v1/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/templates"
 )
@@ -20,12 +21,13 @@ type Config struct {
 
 const defaultDingdingMsgType = "link"
 
-func NewConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
 	var settings Config
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
+	settings.URL = decryptFn("url", settings.URL)
 	if settings.URL == "" {
 		return Config{}, errors.New("could not find url property in settings")
 	}

--- a/receivers/dingding/v1/config_test.go
+++ b/receivers/dingding/v1/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -43,6 +44,19 @@ func TestNewConfig(t *testing.T) {
 			},
 		},
 		{
+			name:     "Minimal valid configuration from secure settings",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"url": []byte("http://localhost"),
+			},
+			expectedConfig: Config{
+				URL:         "http://localhost",
+				MessageType: defaultDingdingMsgType,
+				Title:       templates.DefaultMessageTitleEmbed,
+				Message:     templates.DefaultMessageEmbed,
+			},
+		},
+		{
 			name:     "All empty fields = minimal valid configuration",
 			settings: `{"url": "http://localhost", "message": "", "title": "", "msgType": ""}`,
 			expectedConfig: Config{
@@ -65,7 +79,7 @@ func TestNewConfig(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := NewConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)


### PR DESCRIPTION
Changes DingDing URL to read from secure setting. Grafana already does this but via a workaround https://github.com/grafana/grafana/issues/106710.
When it's merged, it can be deleted.