### PR TITLE
Fix Alertmanager integration to not modify incoming alerts

### DIFF
--- a/receivers/alertmanager/v1/alertmanager.go
+++ b/receivers/alertmanager/v1/alertmanager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -37,17 +38,31 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return true, nil
 	}
 
+	// clone because it can be modified by the image provider
+	clones := make([]*types.Alert, 0, len(as))
+	for _, a := range as {
+		clone := &types.Alert{
+			Alert: model.Alert{
+				Labels:      maps.Clone(a.Labels),
+				Annotations: maps.Clone(a.Annotations),
+			},
+			UpdatedAt: a.UpdatedAt,
+			Timeout:   a.Timeout,
+		}
+		clones = append(clones, clone)
+	}
+
 	_ = images.WithStoredImages(ctx, l, n.images,
 		func(index int, image images.Image) error {
 			// If there is an image for this alert and the image has been uploaded
 			// to a public URL then include it as an annotation
 			if image.URL != "" {
-				as[index].Annotations["image"] = model.LabelValue(image.URL)
+				clones[index].Annotations["image"] = model.LabelValue(image.URL)
 			}
 			return nil
-		}, as...)
+		}, clones...)
 
-	body, err := json.Marshal(as)
+	body, err := json.Marshal(clones)
 	if err != nil {
 		return false, err
 	}

--- a/receivers/alertmanager/v1/alertmanager_test.go
+++ b/receivers/alertmanager/v1/alertmanager_test.go
@@ -151,7 +151,7 @@ func TestNotify(t *testing.T) {
 		ctx := notify.WithGroupKey(context.Background(), "alertname")
 		ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
 
-		_, err := sn.Notify(context.Background(), alerts...)
+		_, err := sn.Notify(ctx, alerts...)
 		require.NoError(t, err)
 		require.EqualValues(t, getAlerts(), alerts)
 	})

--- a/receivers/alertmanager/v1/alertmanager_test.go
+++ b/receivers/alertmanager/v1/alertmanager_test.go
@@ -48,17 +48,6 @@ func TestNotify(t *testing.T) {
 				},
 			},
 		}, {
-			name:     "Default config with one alert with image URL",
-			settings: singleURLConfig,
-			alerts: []*types.Alert{
-				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1"},
-						Annotations: model.LabelSet{"__alertImageToken__": "test-image-1"},
-					},
-				},
-			},
-		}, {
 			name:     "Default config with one alert with empty receiver name",
 			settings: singleURLConfig,
 			alerts: []*types.Alert{
@@ -121,7 +110,7 @@ func TestNotify(t *testing.T) {
 		})
 	}
 
-	t.Run("should not modify the original alerts", func(t *testing.T) {
+	t.Run("images should not modify the original alerts", func(t *testing.T) {
 		getAlerts := func() []*types.Alert {
 			return []*types.Alert{
 				{
@@ -144,7 +133,9 @@ func TestNotify(t *testing.T) {
 		t.Cleanup(func() {
 			receivers.SendHTTPRequest = origSendHTTPRequest
 		})
+		var body []byte
 		receivers.SendHTTPRequest = func(_ context.Context, _ *url.URL, cfg receivers.HTTPCfg, _ log.Logger) ([]byte, error) {
+			body = cfg.Body
 			return nil, nil
 		}
 
@@ -154,5 +145,10 @@ func TestNotify(t *testing.T) {
 		_, err := sn.Notify(ctx, alerts...)
 		require.NoError(t, err)
 		require.EqualValues(t, getAlerts(), alerts)
+		expectedAlerts := getAlerts()
+		expectedAlerts[0].Annotations["image"] = "https://www.example.com/test-image-1.jpg"
+		expectedBody, err := json.Marshal(expectedAlerts)
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedBody), string(body))
 	})
 }


### PR DESCRIPTION
When image provider is configured the incoming alerts are mutated, which can corrupt data in another integration in the case when a single receiver contains many integrations.

Fixes https://github.com/grafana/alerting/issues/408?reload=1?reload=1