### PR TITLE
fix(receivers/jira): re-add support for Jira V2 API

### DIFF
--- a/receivers/jira/v1/jira.go
+++ b/receivers/jira/v1/jira.go
@@ -208,31 +208,52 @@ func (n *Notifier) prepareDescription(desc string, logger log.Logger) any {
 }
 
 func (n *Notifier) searchExistingIssue(ctx context.Context, logger log.Logger, groupID string, firing bool) (*issue, bool, error) {
+	issues, shouldRetry, err := n.searchIssues(ctx, logger, groupID, firing)
+	if err != nil {
+		return nil, shouldRetry, err
+	}
+	if len(issues) == 0 {
+		level.Debug(logger).Log("msg", "found no existing issue")
+		return nil, false, nil
+	}
+	if len(issues) > 1 {
+		level.Warn(logger).Log("msg", "more than one issue matched, selecting the most recently resolved", "selected_issue", issues[0].Key)
+	}
+	return &issues[0], false, nil
+}
+
+// searchIssues performs a version-aware search request against Jira and returns the list of matched issues.
+// It abstracts the differences between v2 (/search) and v3 (/search/jql) endpoints and response shapes.
+func (n *Notifier) searchIssues(ctx context.Context, logger log.Logger, groupID string, firing bool) ([]issue, bool, error) {
 	requestBody := getSearchJql(n.conf, groupID, firing)
 
 	level.Debug(logger).Log("msg", "search for recent issues", "jql", requestBody.JQL)
 
-	responseBody, shouldRetry, err := n.doAPIRequest(ctx, http.MethodPost, "search/jql", requestBody, logger)
+	// Determine API version by the configured base URL and choose the appropriate endpoint path.
+	isV3 := strings.HasSuffix(strings.TrimRight(n.conf.URL.Path, "/"), "/3")
+	path := "search"
+	if isV3 {
+		path = "search/jql"
+	}
+
+	responseBody, shouldRetry, err := n.doAPIRequest(ctx, http.MethodPost, path, requestBody, logger)
 	if err != nil {
 		return nil, shouldRetry, fmt.Errorf("HTTP request to JIRA API: %w", err)
 	}
 
-	var issueSearchResult issueSearchResult
-	err = json.Unmarshal(responseBody, &issueSearchResult)
-	if err != nil {
+	if isV3 {
+		var res issueSearchResultV3
+		if err := json.Unmarshal(responseBody, &res); err != nil {
+			return nil, false, err
+		}
+		return res.Issues, false, nil
+	}
+
+	var res issueSearchResultV2
+	if err := json.Unmarshal(responseBody, &res); err != nil {
 		return nil, false, err
 	}
-
-	if len(issueSearchResult.Issues) == 0 {
-		level.Debug(logger).Log("msg", "found no existing issue")
-		return nil, false, nil
-	}
-
-	if len(issueSearchResult.Issues) > 1 {
-		level.Warn(logger).Log("msg", "more than one issue matched, selecting the most recently resolved", "selected_issue", issueSearchResult.Issues[0].Key)
-	}
-
-	return &issueSearchResult.Issues[0], false, nil
+	return res.Issues, false, nil
 }
 
 func getSearchJql(conf Config, groupID string, firing bool) issueSearch {

--- a/receivers/jira/v1/types.go
+++ b/receivers/jira/v1/types.go
@@ -48,8 +48,20 @@ type issueSearch struct {
 }
 
 // see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post-response
-type issueSearchResult struct {
-	Issues []issue `json:"issues"`
+// v2 search results (legacy /search endpoints)
+type issueSearchResultV2 struct {
+	Expand     string  `json:"expand,omitempty"`
+	StartAt    int     `json:"startAt,omitempty"`
+	MaxResults int     `json:"maxResults,omitempty"`
+	Total      int     `json:"total,omitempty"`
+	Issues     []issue `json:"issues"`
+}
+
+// v3 search results (enhanced /search/jql endpoints)
+type issueSearchResultV3 struct {
+	IsLast        bool    `json:"isLast"`
+	NextPageToken string  `json:"nextPageToken,omitempty"`
+	Issues        []issue `json:"issues"`
 }
 
 type issueTransitions struct {


### PR DESCRIPTION
JIRA cloud removed support for the v2 API, but some self-hosted instances still support it.

Relates to https://github.com/grafana/grafana/issues/112921
