### PR TITLE
alertmanager: add dispatch timer opts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/alertmanager v0.25.1
+	github.com/prometheus/alertmanager v0.28.2
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.64.0
 	github.com/stretchr/testify v1.10.0
@@ -150,7 +150,7 @@ require (
 )
 
 // Using a fork of the Alertmanager with Alerting Squad specific changes.
-replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604
+replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20251201201731-2a968e7da815
 
 replace github.com/Unknwon/com v1.0.1 => github.com/unknwon/com v1.0.1
 

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000 h1:/5LKSYgLm
 github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000/go.mod h1:/ZklAgE1i4f3Z8uriXwESmCr1VLF8lBGaJspuaGuf78=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604 h1:aXfUhVN/Ewfpbko2CCtL65cIiGgwStOo4lWH2b6gw2U=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604/go.mod h1:O/QP1BCm0HHIzbKvgMzqb5sSyH88rzkFk84F4TfJjBU=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20251201201731-2a968e7da815 h1:FgDwuudivx8AAa5obQQQh2h+GSF757F70kXVrwUHFJw=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20251201201731-2a968e7da815/go.mod h1:O/QP1BCm0HHIzbKvgMzqb5sSyH88rzkFk84F4TfJjBU=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=

--- a/notify/dispatch_timer.go
+++ b/notify/dispatch_timer.go
@@ -1,0 +1,33 @@
+package notify
+
+const (
+	// DispatchTimerDefault represents the default dispatch timer behavior (no sync).
+	DispatchTimerDefault DispatchTimer = iota
+	// DispatchTimerSync represents synchronized dispatch timer (using flush log).
+	DispatchTimerSync
+)
+
+// DispatchTimer represents the dispatch timer behavior.
+type DispatchTimer int
+
+// String returns the string representation of the DispatchTimer.
+func (t DispatchTimer) String() string {
+	switch t {
+	case DispatchTimerSync:
+		return "sync"
+	default:
+		return "default"
+	}
+}
+
+// FromString sets the DispatchTimer based on the provided string.
+func (t *DispatchTimer) FromString(s string) {
+	var v DispatchTimer
+	switch s {
+	case "sync":
+		v = DispatchTimerSync
+	default:
+		v = DispatchTimerDefault
+	}
+	(*t) = v
+}

--- a/notify/dispatch_timer_test.go
+++ b/notify/dispatch_timer_test.go
@@ -1,0 +1,70 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DispatchTimer_String(t *testing.T) {
+	tt := []struct {
+		name string
+		dt   DispatchTimer
+		exp  string
+	}{
+		{
+			name: "when default",
+			dt:   DispatchTimerDefault,
+			exp:  "default",
+		},
+		{
+			name: "when sync",
+			dt:   DispatchTimerSync,
+			exp:  "sync",
+		},
+		{
+			name: "when unknown",
+			dt:   DispatchTimer(999),
+			exp:  "default",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.exp, tc.dt.String())
+		})
+	}
+}
+
+func Test_DispatchTimer_FromString(t *testing.T) {
+	tt := []struct {
+		name string
+		s    string
+		exp  DispatchTimer
+	}{
+		{
+			name: "when default",
+			s:    "default",
+			exp:  DispatchTimerDefault,
+		},
+		{
+			name: "when sync",
+			s:    "sync",
+			exp:  DispatchTimerSync,
+		},
+		{
+			name: "when unknown",
+			s:    "default",
+			exp:  DispatchTimerDefault,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			dt := new(DispatchTimer)
+			dt.FromString(tc.s)
+
+			assert.Equal(t, tc.exp, *dt)
+		})
+	}
+}

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -198,10 +198,8 @@ func (c *GrafanaAlertmanagerOpts) Validate() error {
 	}
 
 	// only validate flush log options if using sync'ed dispatcher timer
-	if c.DispatchTimer == DispatchTimerSync {
-		if c.FlushLog == nil {
-			return errors.New("flush log maintenance options must be present")
-		}
+	if c.DispatchTimer == DispatchTimerSync && c.FlushLog == nil {
+		return errors.New("flush log maintenance options must be present")
 	}
 
 	if c.EmailSender == nil {

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/featurecontrol"
+	"github.com/prometheus/alertmanager/flushlog"
 	"github.com/prometheus/alertmanager/inhibit"
 	"github.com/prometheus/alertmanager/matchers/compat"
 	"github.com/prometheus/alertmanager/nflog"
@@ -88,6 +89,7 @@ type GrafanaAlertmanager struct {
 	inhibitor       *inhibit.Inhibitor
 	silencer        *silence.Silencer
 	silences        *silence.Silences
+	flushLog        *flushlog.FlushLog
 
 	// timeIntervals is the set of all time_intervals and mute_time_intervals from
 	// the configuration.
@@ -158,6 +160,31 @@ type Limits struct {
 	MaxSilenceSizeBytes int
 }
 
+type DispatchTimer int
+
+func (t DispatchTimer) String() string {
+	switch t {
+	case DispatchTimerSync:
+		return "sync"
+	default:
+		return "default"
+	}
+}
+
+func (t *DispatchTimer) FromString(s string) {
+	var v DispatchTimer
+	switch s {
+	case "sync":
+		v = DispatchTimerSync
+	}
+	(*t) = v
+}
+
+const (
+	_ DispatchTimer = iota
+	DispatchTimerSync
+)
+
 type GrafanaAlertmanagerOpts struct {
 	ExternalURL        string
 	AlertStoreCallback mem.AlertStoreCallback
@@ -165,6 +192,7 @@ type GrafanaAlertmanagerOpts struct {
 
 	Silences MaintenanceOptions
 	Nflog    MaintenanceOptions
+	FlushLog MaintenanceOptions
 
 	Limits Limits
 
@@ -181,6 +209,8 @@ type GrafanaAlertmanagerOpts struct {
 	Metrics *GrafanaAlertmanagerMetrics
 
 	NotificationHistorian nfstatus.NotificationHistorian
+
+	DispatchTimer DispatchTimer
 }
 
 func (c *GrafanaAlertmanagerOpts) Validate() error {
@@ -190,6 +220,13 @@ func (c *GrafanaAlertmanagerOpts) Validate() error {
 
 	if c.Nflog == nil {
 		return errors.New("notification log maintenance options must be present")
+	}
+
+	// only validate flush log options if using sync'ed dispatcher timer
+	if c.DispatchTimer == DispatchTimerSync {
+		if c.FlushLog == nil {
+			return errors.New("flush log maintenance options must be present")
+		}
 	}
 
 	if c.EmailSender == nil {
@@ -297,6 +334,34 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 		am.wg.Done()
 	}()
 
+	// Initialize the flush log only if using sync'ed timer
+	if am.opts.DispatchTimer == DispatchTimerSync {
+		am.flushLog, err = flushlog.New(flushlog.Options{
+			SnapshotReader: strings.NewReader(opts.FlushLog.InitialState()),
+			Retention:      opts.FlushLog.Retention(),
+			Logger:         opts.Logger,
+			Metrics:        opts.Metrics.Registerer,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to initialize the flush log component of alerting: %w", err)
+		}
+		c = opts.Peer.AddState(fmt.Sprintf("flushlog:%d", opts.TenantID), am.flushLog, opts.Metrics.Registerer)
+		am.flushLog.SetBroadcast(c.Broadcast)
+
+		am.wg.Add(1)
+		go func() {
+			am.flushLog.Maintenance(opts.FlushLog.MaintenanceFrequency(), snapshotPlaceholder, am.stopc, func() (int64, error) {
+				if _, err := am.flushLog.GC(); err != nil {
+					level.Error(am.logger).Log("flush log garbage collection", "err", err)
+				}
+
+				return opts.FlushLog.MaintenanceFunc(am.flushLog)
+			})
+			am.wg.Done()
+		}()
+
+	}
+
 	// Initialize in-memory alerts
 	am.alerts, err = mem.NewAlerts(context.Background(), am.marker, memoryAlertsGCInterval, opts.AlertStoreCallback, am.logger, opts.Metrics.Registerer)
 	if err != nil {
@@ -317,6 +382,14 @@ func (am *GrafanaAlertmanager) MergeSilences(sil []byte) error {
 
 func (am *GrafanaAlertmanager) MergeNflog(nflog []byte) error {
 	return am.notificationLog.Merge(nflog)
+}
+
+func (am *GrafanaAlertmanager) MergeFlushLog(flushLog []byte) error {
+	// flushLog will only be initialized if using sync'ed dispatcher timer
+	if am.flushLog != nil {
+		return am.flushLog.Merge(flushLog)
+	}
+	return nil
 }
 
 func (am *GrafanaAlertmanager) TenantID() int64 {
@@ -733,7 +806,13 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 	silencingStage := notify.NewMuteStage(am.silencer, am.stageMetrics)
 
 	am.route = dispatch.NewRoute(cfg.RoutingTree, nil)
-	am.dispatcher = dispatch.NewDispatcher(am.alerts, am.route, routingStage, am.marker, am.timeoutFunc, cfg.DispatcherLimits, am.logger, am.dispatcherMetrics, nil)
+
+	var dispatchTimer dispatch.TimerFactory
+	if am.opts.DispatchTimer == DispatchTimerSync {
+		dispatchTimer = dispatch.NewSyncTimerFactory(am.flushLog, am.opts.Peer.Position)
+	}
+
+	am.dispatcher = dispatch.NewDispatcher(am.alerts, am.route, routingStage, am.marker, am.timeoutFunc, cfg.DispatcherLimits, am.logger, am.dispatcherMetrics, dispatchTimer)
 
 	// TODO: This has not been upstreamed yet. Should be aligned when https://github.com/prometheus/alertmanager/pull/3016 is merged.
 	var receivers []*nfstatus.Receiver

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -160,31 +160,6 @@ type Limits struct {
 	MaxSilenceSizeBytes int
 }
 
-type DispatchTimer int
-
-func (t DispatchTimer) String() string {
-	switch t {
-	case DispatchTimerSync:
-		return "sync"
-	default:
-		return "default"
-	}
-}
-
-func (t *DispatchTimer) FromString(s string) {
-	var v DispatchTimer
-	switch s {
-	case "sync":
-		v = DispatchTimerSync
-	}
-	(*t) = v
-}
-
-const (
-	_ DispatchTimer = iota
-	DispatchTimerSync
-)
-
 type GrafanaAlertmanagerOpts struct {
 	ExternalURL        string
 	AlertStoreCallback mem.AlertStoreCallback


### PR DESCRIPTION
## Context
- Adding support for sync timer so we can start rolling it out
- Sync timer synchronizes the flush times across HA nodes to decrease the chance of duplicate notifications
- If opt timer is set to sync timer, we initialize the flush log and set the sync timer factory when initializing the dispatcher

Related to https://github.com/grafana/grafana/pull/114602
