### PR TITLE
fix(receivers/alertmanager): preserve generator URL and timestamps in cloned alerts

### DIFF
--- a/receivers/alertmanager/v1/alertmanager.go
+++ b/receivers/alertmanager/v1/alertmanager.go
@@ -43,8 +43,11 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	for _, a := range as {
 		clone := &types.Alert{
 			Alert: model.Alert{
-				Labels:      maps.Clone(a.Labels),
-				Annotations: maps.Clone(a.Annotations),
+				Labels:       maps.Clone(a.Labels),
+				Annotations:  maps.Clone(a.Annotations),
+				StartsAt:     a.StartsAt,
+				EndsAt:       a.EndsAt,
+				GeneratorURL: a.GeneratorURL,
 			},
 			UpdatedAt: a.UpdatedAt,
 			Timeout:   a.Timeout,


### PR DESCRIPTION
Introduced in #414, the cloned alerts should retain their original fields
