### PR TITLE
fix(receivers/jira): re-add support for Jira V2 API (#415)

### DIFF
--- a/receivers/jira/jira.go
+++ b/receivers/jira/jira.go
@@ -207,31 +207,52 @@ func (n *Notifier) prepareDescription(desc string, logger logging.Logger) any {
 }
 
 func (n *Notifier) searchExistingIssue(ctx context.Context, logger logging.Logger, groupID string, firing bool) (*issue, bool, error) {
+	issues, shouldRetry, err := n.searchIssues(ctx, logger, groupID, firing)
+	if err != nil {
+		return nil, shouldRetry, err
+	}
+	if len(issues) == 0 {
+		logger.Debug("found no existing issue")
+		return nil, false, nil
+	}
+	if len(issues) > 1 {
+		logger.Warn("more than one issue matched, selecting the most recently resolved", "selected_issue", issues[0].Key)
+	}
+	return &issues[0], false, nil
+}
+
+// searchIssues performs a version-aware search request against Jira and returns the list of matched issues.
+// It abstracts the differences between v2 (/search) and v3 (/search/jql) endpoints and response shapes.
+func (n *Notifier) searchIssues(ctx context.Context, logger logging.Logger, groupID string, firing bool) ([]issue, bool, error) {
 	requestBody := getSearchJql(n.conf, groupID, firing)
 
 	logger.Debug("search for recent issues", "jql", requestBody.JQL)
 
-	responseBody, shouldRetry, err := n.doAPIRequest(ctx, http.MethodPost, "search/jql", requestBody)
+	// Determine API version by the configured base URL and choose the appropriate endpoint path.
+	isV3 := strings.HasSuffix(strings.TrimRight(n.conf.URL.Path, "/"), "/3")
+	path := "search"
+	if isV3 {
+		path = "search/jql"
+	}
+
+	responseBody, shouldRetry, err := n.doAPIRequest(ctx, http.MethodPost, path, requestBody)
 	if err != nil {
 		return nil, shouldRetry, fmt.Errorf("HTTP request to JIRA API: %w", err)
 	}
 
-	var issueSearchResult issueSearchResult
-	err = json.Unmarshal(responseBody, &issueSearchResult)
-	if err != nil {
+	if isV3 {
+		var res issueSearchResultV3
+		if err := json.Unmarshal(responseBody, &res); err != nil {
+			return nil, false, err
+		}
+		return res.Issues, false, nil
+	}
+
+	var res issueSearchResultV2
+	if err := json.Unmarshal(responseBody, &res); err != nil {
 		return nil, false, err
 	}
-
-	if len(issueSearchResult.Issues) == 0 {
-		logger.Debug("found no existing issue")
-		return nil, false, nil
-	}
-
-	if len(issueSearchResult.Issues) > 1 {
-		logger.Warn("more than one issue matched, selecting the most recently resolved", "selected_issue", issueSearchResult.Issues[0].Key)
-	}
-
-	return &issueSearchResult.Issues[0], false, nil
+	return res.Issues, false, nil
 }
 
 func getSearchJql(conf Config, groupID string, firing bool) issueSearch {

--- a/receivers/jira/jira_test.go
+++ b/receivers/jira/jira_test.go
@@ -397,6 +397,7 @@ func TestNotify(t *testing.T) {
 	groupKey, _ := notify.ExtractGroupKey(ctx)
 	tmpl := templates.ForTests(t)
 	baseURL := "https://jira.example.com/2"
+	baseURLv3 := "https://jira.example.com/3"
 
 	t.Run("when firing", func(t *testing.T) {
 		alert := &types.Alert{
@@ -427,8 +428,8 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search/jql":
-					return cmd.Validation(mustMarshal(issueSearchResult{}), 200)
+				case baseURL + "/search":
+					return cmd.Validation(mustMarshal(issueSearchResultV2{}), 200)
 				case baseURL + "/issue":
 					return cmd.Validation(nil, 201)
 				default:
@@ -447,7 +448,7 @@ func TestNotify(t *testing.T) {
 			assert.Equal(t, cfg.User, searchRequest.User)
 			assert.Equal(t, cfg.Password, searchRequest.Password)
 			assert.JSONEq(t, string(mustMarshal(getSearchJql(cfg, groupKey.Hash(), true))), searchRequest.Body)
-			assert.Equal(t, baseURL+"/search/jql", searchRequest.URL)
+			assert.Equal(t, baseURL+"/search", searchRequest.URL)
 			assert.Equal(t, "POST", searchRequest.HTTPMethod)
 
 			submitRequest := mock.Calls[1].Args[1].(*receivers.SendWebhookSettings)
@@ -463,8 +464,8 @@ func TestNotify(t *testing.T) {
 			issueKey := "TEST-1"
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search/jql":
-					return cmd.Validation(mustMarshal(issueSearchResult{
+				case baseURL + "/search":
+					return cmd.Validation(mustMarshal(issueSearchResultV2{
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -501,6 +502,74 @@ func TestNotify(t *testing.T) {
 			assert.Equal(t, "PUT", submitRequest.HTTPMethod)
 		})
 
+		// v3 variants
+		t.Run("v3: creates a new issue if no existing (uses /search/jql)", func(t *testing.T) {
+			u3, _ := url.Parse(baseURLv3)
+			cfg3 := cfg
+			cfg3.URL = u3
+
+			mock := receivers.NewMockWebhookSender()
+			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
+				switch cmd.URL {
+				case baseURLv3 + "/search/jql":
+					// v3 response shape
+					return cmd.Validation(mustMarshal(issueSearchResultV3{}), 200)
+				case baseURLv3 + "/issue":
+					return cmd.Validation(nil, 201)
+				default:
+					t.Fatalf("unexpected url: %s", cmd.URL)
+					return nil
+				}
+			}
+
+			n := New(cfg3, receivers.Metadata{}, tmpl, mock, logging.FakeLogger{})
+			retry, err := n.Notify(ctx, alert)
+			require.NoError(t, err)
+			require.False(t, retry)
+			require.Len(t, mock.Calls, 2)
+
+			searchRequest := mock.Calls[0].Args[1].(*receivers.SendWebhookSettings)
+			assert.Equal(t, baseURLv3+"/search/jql", searchRequest.URL)
+			assert.Equal(t, "POST", searchRequest.HTTPMethod)
+
+			submitRequest := mock.Calls[1].Args[1].(*receivers.SendWebhookSettings)
+			assert.Equal(t, baseURLv3+"/issue", submitRequest.URL)
+			assert.Equal(t, "POST", submitRequest.HTTPMethod)
+		})
+
+		t.Run("v3: updates existing issue if firing (uses /search/jql)", func(t *testing.T) {
+			u3, _ := url.Parse(baseURLv3)
+			cfg3 := cfg
+			cfg3.URL = u3
+
+			mock := receivers.NewMockWebhookSender()
+			issueKey := "TEST-1"
+			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
+				switch cmd.URL {
+				case baseURLv3 + "/search/jql":
+					return cmd.Validation(mustMarshal(issueSearchResultV3{Issues: []issue{{
+						Key:    issueKey,
+						Fields: &issueFields{Status: &issueStatus{StatusCategory: keyValue{Key: "blah"}}},
+					}}}), 200)
+				case baseURLv3 + "/issue/" + issueKey:
+					return cmd.Validation(nil, 201)
+				default:
+					t.Fatalf("unexpected url: %s", cmd.URL)
+					return nil
+				}
+			}
+
+			n := New(cfg3, receivers.Metadata{}, tmpl, mock, logging.FakeLogger{})
+			retry, err := n.Notify(ctx, alert)
+			require.NoError(t, err)
+			require.False(t, retry)
+			assert.Len(t, mock.Calls, 2)
+
+			submitRequest := mock.Calls[1].Args[1].(*receivers.SendWebhookSettings)
+			assert.Equal(t, baseURLv3+"/issue/"+issueKey, submitRequest.URL)
+			assert.Equal(t, "PUT", submitRequest.HTTPMethod)
+		})
+
 		t.Run("reopen the issue if it's status is done", func(t *testing.T) {
 			cfg := cfg
 			cfg.ReopenTransition = "quickly"
@@ -520,8 +589,8 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search/jql":
-					return cmd.Validation(mustMarshal(issueSearchResult{
+				case baseURL + "/search":
+					return cmd.Validation(mustMarshal(issueSearchResultV2{
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -646,8 +715,8 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search/jql":
-					return cmd.Validation(mustMarshal(issueSearchResult{}), 200)
+				case baseURL + "/search":
+					return cmd.Validation(mustMarshal(issueSearchResultV2{}), 200)
 				default:
 					t.Fatalf("unexpected url: %s", cmd.URL)
 					return nil
@@ -673,8 +742,8 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search/jql":
-					return cmd.Validation(mustMarshal(issueSearchResult{
+				case baseURL + "/search":
+					return cmd.Validation(mustMarshal(issueSearchResultV2{
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -724,8 +793,8 @@ func TestNotify(t *testing.T) {
 			mock := receivers.NewMockWebhookSender()
 			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
 				switch cmd.URL {
-				case baseURL + "/search/jql":
-					return cmd.Validation(mustMarshal(issueSearchResult{
+				case baseURL + "/search":
+					return cmd.Validation(mustMarshal(issueSearchResultV2{
 						Issues: []issue{
 							{
 								Key: issueKey,
@@ -818,6 +887,29 @@ func TestNotify(t *testing.T) {
 				assert.Equal(t, "GET", transitionsSearchRequest.HTTPMethod)
 			})
 		})
+		t.Run("v3: does nothing if issue is not found (uses /search/jql)", func(t *testing.T) {
+			u3, _ := url.Parse(baseURLv3)
+			cfg3 := cfg
+			cfg3.URL = u3
+
+			mock := receivers.NewMockWebhookSender()
+			mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
+				switch cmd.URL {
+				case baseURLv3 + "/search/jql":
+					return cmd.Validation(mustMarshal(issueSearchResultV3{}), 200)
+				default:
+					t.Fatalf("unexpected url: %s", cmd.URL)
+					return nil
+				}
+			}
+
+			n := New(cfg3, receivers.Metadata{}, tmpl, mock, logging.FakeLogger{})
+			retry, err := n.Notify(ctx, alert)
+			require.NoError(t, err)
+			require.False(t, retry)
+			require.Len(t, mock.Calls, 1)
+		})
+
 	})
 }
 

--- a/receivers/jira/types.go
+++ b/receivers/jira/types.go
@@ -48,8 +48,20 @@ type issueSearch struct {
 }
 
 // see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post-response
-type issueSearchResult struct {
-	Issues []issue `json:"issues"`
+// v2 search results (legacy /search endpoints)
+type issueSearchResultV2 struct {
+	Expand     string  `json:"expand,omitempty"`
+	StartAt    int     `json:"startAt,omitempty"`
+	MaxResults int     `json:"maxResults,omitempty"`
+	Total      int     `json:"total,omitempty"`
+	Issues     []issue `json:"issues"`
+}
+
+// v3 search results (enhanced /search/jql endpoints)
+type issueSearchResultV3 struct {
+	IsLast        bool    `json:"isLast"`
+	NextPageToken string  `json:"nextPageToken,omitempty"`
+	Issues        []issue `json:"issues"`
 }
 
 type issueTransitions struct {


### PR DESCRIPTION
JIRA cloud removed support for the v2 API, but some self-hosted instances still support it.

Relates to https://github.com/grafana/grafana/issues/112921