### PR TITLE
Historian: Fix duration to be nanoseconds not milliseconds.

### DIFF
--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -168,7 +168,7 @@ func (h *NotificationHistorian) prepareStream(nhe nfstatus.NotificationHistoryEn
 		Alerts:        entryAlerts,
 		Retry:         nhe.Retry,
 		Error:         notificationErrStr,
-		Duration:      nhe.Duration.Milliseconds(),
+		Duration:      int64(nhe.Duration),
 		PipelineTime:  nhe.PipelineTime,
 	}
 

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -66,7 +66,7 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alerts\":[{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\"}],\"retry\":false,\"duration\":1000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alerts\":[{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\"}],\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
 							},
 						},
 					},
@@ -86,7 +86,7 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alerts\":[{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\"}],\"retry\":true,\"error\":\"test notification error\",\"duration\":1000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alerts\":[{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\"}],\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
 							},
 						},
 					},


### PR DESCRIPTION
Only storing milliseconds means that anything less than a millisecond just
comes up as zero, which is common if a request was never made. Lets just
store the duration as-is instead.
