### PR TITLE
Add GroupKey to notification log entry

### DIFF
--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -23,6 +23,7 @@ type NotificationHistoryAlert struct {
 
 type NotificationHistoryEntry struct {
 	Alerts          []NotificationHistoryAlert
+	GroupKey        string
 	Retry           bool
 	NotificationErr error
 	Duration        time.Duration
@@ -42,6 +43,9 @@ func (e NotificationHistoryEntry) Validate() error {
 	}
 	if e.PipelineTime.IsZero() {
 		errs = append(errs, errors.New("missing pipeline time"))
+	}
+	if e.GroupKey == "" {
+		errs = append(errs, errors.New("missing group key"))
 	}
 
 	return errors.Join(errs...)
@@ -157,6 +161,7 @@ func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, a
 	receiverName, _ := notify.ReceiverName(ctx)
 	groupLabels, _ := notify.GroupLabels(ctx)
 	pipelineTime, _ := notify.Now(ctx)
+	groupKey, _ := notify.GroupKey(ctx)
 
 	// Don't log/return because extra data is optional.
 	extraData, _ := receivers.GetExtraDataFromContext(ctx)
@@ -173,6 +178,7 @@ func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, a
 
 	entry := NotificationHistoryEntry{
 		Alerts:          entryAlerts,
+		GroupKey:        groupKey,
 		Retry:           retry,
 		NotificationErr: err,
 		Duration:        duration,

--- a/notify/nfstatus/integration_test.go
+++ b/notify/nfstatus/integration_test.go
@@ -116,6 +116,7 @@ func TestIntegrationWithNotificationHistorian(t *testing.T) {
 	ctx := notify.WithReceiverName(context.Background(), testReceiverName)
 	ctx = notify.WithGroupLabels(ctx, testGroupLabels)
 	ctx = notify.WithNow(ctx, testPipelineTime)
+	ctx = notify.WithGroupKey(ctx, "testGroupKey")
 
 	// Add extra data.
 	ctx = context.WithValue(ctx, receivers.ExtraDataKey, []json.RawMessage{
@@ -138,6 +139,7 @@ func TestIntegrationWithNotificationHistorian(t *testing.T) {
 			Alert:     alerts[0],
 			ExtraData: json.RawMessage([]byte(`{"foo":"bar"}`)),
 		}},
+		GroupKey:        "testGroupKey",
 		Retry:           notifier.retry,
 		NotificationErr: notifier.err,
 		Duration:        0,
@@ -163,6 +165,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
+				GroupKey:     "test-group-key",
 			},
 			wantErr: false,
 		},
@@ -172,6 +175,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{},
 				PipelineTime: now,
+				GroupKey:     "test-group-key",
 			},
 			wantErr: false,
 		},
@@ -181,6 +185,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
+				GroupKey:     "test-group-key",
 			},
 			wantErr:           true,
 			expectedErrSubstr: []string{"missing receiver name"},
@@ -191,6 +196,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "test-receiver",
 				GroupLabels:  nil,
 				PipelineTime: now,
+				GroupKey:     "test-group-key",
 			},
 			wantErr:           true,
 			expectedErrSubstr: []string{"missing group labels"},
@@ -201,6 +207,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: time.Time{},
+				GroupKey:     "test-group-key",
 			},
 			wantErr:           true,
 			expectedErrSubstr: []string{"missing pipeline time"},
@@ -211,6 +218,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
+				GroupKey:     "",
 			},
 			wantErr:           true,
 			expectedErrSubstr: []string{"missing group key"},
@@ -221,6 +229,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 				ReceiverName: "",
 				GroupLabels:  nil,
 				PipelineTime: time.Time{},
+				GroupKey:     "",
 			},
 			wantErr: true,
 			expectedErrSubstr: []string{


### PR DESCRIPTION
Currently, every aggregation group flush event is disaggregated to per-alert-rule entry. Therefore, in general, every "flush" event could have many entries. 

This PR adds a new field "group key" to the log entry which makes every log entry be bound to aggregation group key, which makes it simpler to calculate statistics per aggregation group \ route. 