### PR TITLE
Make Webhook URL secret

### DIFF
--- a/notify/schema_test.go
+++ b/notify/schema_test.go
@@ -61,6 +61,7 @@ func TestGetSecretKeysForContactPointType(t *testing.T) {
 		{receiverType: teams.Type, version: schema.V1, expectedSecretFields: []string{}},
 		{receiverType: telegram.Type, version: schema.V1, expectedSecretFields: []string{"bottoken"}},
 		{receiverType: webhook.Type, version: schema.V1, expectedSecretFields: []string{
+			"url",
 			"password",
 			"authorization_credentials",
 			"tlsConfig.caCertificate",

--- a/receivers/webhook/v1/config.go
+++ b/receivers/webhook/v1/config.go
@@ -69,10 +69,10 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	if rawSettings.URL == "" {
+	settings.URL = decryptFn("url", rawSettings.URL)
+	if settings.URL == "" {
 		return settings, errors.New("required field 'url' is not specified")
 	}
-	settings.URL = rawSettings.URL
 	settings.AuthorizationScheme = rawSettings.AuthorizationScheme
 
 	if rawSettings.HTTPMethod == "" {
@@ -194,6 +194,7 @@ var Schema = schema.IntegrationSchemaVersion{
 			InputType:    schema.InputTypeText,
 			PropertyName: "url",
 			Required:     true,
+			Secure:       true,
 			Protected:    true,
 		},
 		{

--- a/receivers/webhook/v1/testing.go
+++ b/receivers/webhook/v1/testing.go
@@ -32,6 +32,7 @@ var FullValidConfigForTesting = fmt.Sprintf(`{
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
 var FullValidSecretsForTesting = fmt.Sprintf(`{
+    "url": "http://localhost/url-secret",
 	"username": "test-secret-user",
 	"password": "test-secret-pass",
 	"tlsConfig.clientCertificate": %q,


### PR DESCRIPTION
This PR makes the url in the Webhook configuration a secure field. Addressing #430 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification delivery configuration by changing how webhook URLs are sourced and validated; mistakes could break existing webhook setups if secret resolution is misconfigured.
> 
> **Overview**
> Makes the Webhook contact point `url` a *secret/secure* field. Webhook config parsing now always resolves `url` via `decryptFn("url", ...)`, allowing the URL to be provided (or overridden) from secure settings and failing if the decrypted URL is empty.
> 
> Updates schema secret-field expectations and expands webhook config tests/fixtures to cover URL-from-secrets and URL override behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52b9a0352cda207ae9053324db4f0f2895707d8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->