### PR TITLE
Configurable template output limits

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -239,7 +239,7 @@ func BuildPrometheusReceiverIntegrations(
 				errs.Add(err)
 				return
 			}
-			tmpl = t
+			tmpl = t.Template
 		})
 		add = func(name string, i int, rs notify.ResolvedSender, f func(l log.Logger) (notify.Notifier, error)) {
 			initOnce()

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -131,6 +131,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
 	imageProvider := &images.URLProvider{}
 	cfg, err := templates.NewConfig("grafana", "http://localhost", templates.DefaultLimits)
+	require.NoError(t, err)
 	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
 	require.NoError(t, err)
 	emailService := receivers.MockNotificationService()
@@ -236,6 +237,7 @@ func TestBuildPrometheusReceiverIntegrations(t *testing.T) {
 	err = definition.ValidateAlertmanagerConfig(receiver)
 	require.NoError(t, err)
 	cfg, err := templates.NewConfig("1", "http://localhost", templates.DefaultLimits)
+	require.NoError(t, err)
 	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
 	require.NoError(t, err)
 	integrations, err := BuildPrometheusReceiverIntegrations(receiver, tmpl, nil, log.NewNopLogger(), NoWrap, nil)

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -130,7 +130,8 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 	var orgID = rand.Int63()
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
 	imageProvider := &images.URLProvider{}
-	tmpl, err := templates.NewFactory(nil, log.NewNopLogger(), "http://localhost", "grafana")
+	cfg, err := templates.NewConfig("grafana", "http://localhost", templates.DefaultLimits)
+	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
 	require.NoError(t, err)
 	emailService := receivers.MockNotificationService()
 
@@ -234,7 +235,8 @@ func TestBuildPrometheusReceiverIntegrations(t *testing.T) {
 	require.NoError(t, err)
 	err = definition.ValidateAlertmanagerConfig(receiver)
 	require.NoError(t, err)
-	tmpl, err := templates.NewFactory(nil, log.NewNopLogger(), "http://localhost", "1")
+	cfg, err := templates.NewConfig("1", "http://localhost", templates.DefaultLimits)
+	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
 	require.NoError(t, err)
 	integrations, err := BuildPrometheusReceiverIntegrations(receiver, tmpl, nil, log.NewNopLogger(), NoWrap, nil)
 	require.NoError(t, err)

--- a/notify/templates.go
+++ b/notify/templates.go
@@ -8,7 +8,6 @@ import (
 	tmpltext "text/template"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/alertmanager/template"
 
 	"github.com/grafana/alerting/templates"
 	"github.com/grafana/alerting/utils"
@@ -104,7 +103,7 @@ func (am *GrafanaAlertmanager) TestTemplate(ctx context.Context, c TestTemplates
 	return TestTemplate(ctx, c, templateFactory, log.With(am.logger, "operation", "TestTemplate"))
 }
 
-func (am *GrafanaAlertmanager) GetTemplate(kind templates.Kind) (*template.Template, error) {
+func (am *GrafanaAlertmanager) GetTemplate(kind templates.Kind) (*templates.Template, error) {
 	am.reloadConfigMtx.RLock()
 	defer am.reloadConfigMtx.RUnlock()
 	t, err := am.templates.GetTemplate(kind)

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -491,7 +491,8 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if len(test.existingTemplates) > 0 {
 				var err error
-				am.templates, err = templates.NewFactory(test.existingTemplates, log.NewNopLogger(), am.ExternalURL(), "grafana")
+				cfg, err := templates.NewConfig("grafana", am.ExternalURL(), templates.DefaultLimits)
+				am.templates, err = templates.NewFactory(test.existingTemplates, cfg, log.NewNopLogger())
 				require.NoError(t, err)
 			}
 			res, err := am.TestTemplate(context.Background(), test.input)

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -492,6 +492,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 			if len(test.existingTemplates) > 0 {
 				var err error
 				cfg, err := templates.NewConfig("grafana", am.ExternalURL(), templates.DefaultLimits)
+				require.NoError(t, err)
 				am.templates, err = templates.NewFactory(test.existingTemplates, cfg, log.NewNopLogger())
 				require.NoError(t, err)
 			}

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -210,7 +210,10 @@ func ForTests(t *testing.T) *Template {
 	externalURL, err := url.Parse("http://test.com")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
-	return tmpl
+	return &Template{
+		Template: tmpl,
+		limits:   DefaultLimits,
+	}
 }
 
 var DefaultTemplateName = "__default__"

--- a/templates/default_template_test.go
+++ b/templates/default_template_test.go
@@ -138,9 +138,14 @@ func TestDefaultTemplateString(t *testing.T) {
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
 
+	tmp := &Template{
+		Template: tmpl,
+		limits:   DefaultLimits,
+	}
+
 	var tmplErr error
 	l := log.NewNopLogger()
-	expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+	expand, _ := TmplText(context.Background(), tmp, alerts, l, &tmplErr)
 
 	tmplDef, err := DefaultTemplate(nil)
 	require.NoError(t, err)
@@ -152,8 +157,13 @@ func TestDefaultTemplateString(t *testing.T) {
 	require.NoError(t, err)
 	tmplFromDefinition.ExternalURL = externalURL
 
+	tpl := &Template{
+		Template: tmplFromDefinition,
+		limits:   DefaultLimits,
+	}
+
 	var tmplDefErr error
-	expandFromDefinition, _ := TmplText(context.Background(), tmplFromDefinition, alerts, l, &tmplDefErr)
+	expandFromDefinition, _ := TmplText(context.Background(), tpl, alerts, l, &tmplDefErr)
 
 	cases := []struct {
 		templateString string

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -9,6 +9,10 @@ import (
 	"github.com/go-kit/log/level"
 )
 
+type Limits struct {
+	MaxTemplateOutputSize int64
+}
+
 // Factory is a factory that can be used to create templates of specific kind.
 type Factory struct {
 	templates   map[Kind][]TemplateDefinition

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -9,15 +9,48 @@ import (
 	"github.com/go-kit/log/level"
 )
 
+type Config struct {
+	OrgID       string
+	ExternalURL *url.URL
+	Limits      Limits
+}
+
+func (c Config) Validate() error {
+	if c.ExternalURL == nil {
+		return fmt.Errorf("externalURL must be set")
+	}
+	return c.Limits.Validate()
+}
+
 type Limits struct {
+	// MaxTemplateOutputSize limits the size of the rendered template output. 0 means no limit.
 	MaxTemplateOutputSize int64
+}
+
+func (l Limits) Validate() error {
+	if l.MaxTemplateOutputSize < 0 {
+		return fmt.Errorf("maxTemplateOutputSize must be greater than or equal to 0")
+	}
+	return nil
+}
+
+func NewConfig(orgID string, externalURL string, limits Limits) (Config, error) {
+	u, err := url.Parse(externalURL)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg := Config{
+		OrgID:       orgID,
+		ExternalURL: u,
+		Limits:      limits,
+	}
+	return cfg, cfg.Validate()
 }
 
 // Factory is a factory that can be used to create templates of specific kind.
 type Factory struct {
-	templates   map[Kind][]TemplateDefinition
-	externalURL *url.URL
-	orgID       string
+	templates map[Kind][]TemplateDefinition
+	cfg       Config
 }
 
 // GetTemplate creates a new template of the given kind. If Kind is not known, GrafanaKind automatically assumed
@@ -30,15 +63,19 @@ func (tp *Factory) GetTemplate(kind Kind) (*Template, error) {
 	for _, def := range definitions { // TODO sort the list by name?
 		content = append(content, def.Template)
 	}
-	t, err := fromContent(content, defaultOptionsPerKind(kind, tp.orgID)...)
+	t, err := fromContent(content, defaultOptionsPerKind(kind, tp.cfg.OrgID)...)
 	if err != nil {
 		return nil, err
 	}
-	if tp.externalURL != nil {
-		t.ExternalURL = new(url.URL)
-		*t.ExternalURL = *tp.externalURL
+	result := &Template{
+		Template: t,
+		limits:   tp.cfg.Limits,
 	}
-	return t, nil
+	if tp.cfg.ExternalURL != nil {
+		t.ExternalURL = new(url.URL)
+		*t.ExternalURL = *tp.cfg.ExternalURL
+	}
+	return result, nil
 }
 
 // WithTemplate creates a new factory that has the provided TemplateDefinition. If definition with the same name already exists for this kind, it is replaced.
@@ -70,18 +107,14 @@ func (tp *Factory) WithTemplate(def TemplateDefinition) (*Factory, error) {
 	}
 
 	return &Factory{
-		templates:   templates,
-		externalURL: tp.externalURL,
+		templates: templates,
+		cfg:       tp.cfg,
 	}, nil
 }
 
 // NewFactory creates a new template provider. Accepts list of user-defined templates that are added to the kind's default templates.
 // Returns error if externalURL is not a valid URL or if TemplateDefinition.Kind is not known.
-func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string, orgID string) (*Factory, error) {
-	extURL, err := url.Parse(externalURL)
-	if err != nil {
-		return nil, err
-	}
+func NewFactory(t []TemplateDefinition, cfg Config, logger log.Logger) (*Factory, error) {
 	type seenKey struct {
 		Name string
 		Type Kind
@@ -100,12 +133,11 @@ func NewFactory(t []TemplateDefinition, logger log.Logger, externalURL string, o
 		byType[def.Kind] = append(byType[def.Kind], def)
 		seen[seenKey{Name: def.Name, Type: def.Kind}] = struct{}{}
 	}
-	level.Info(logger).Log("msg", "template definitions loaded", "mimir", len(byType[MimirKind]), "grafana", len(byType[GrafanaKind]), "total", len(t))
+	level.Info(logger).Log("msg", "template definitions loaded", "mimir", len(byType[MimirKind]), "grafana", len(byType[GrafanaKind]), "total", len(t), "maxTemplateOutput", cfg.Limits.MaxTemplateOutputSize)
 
 	provider := &Factory{
-		templates:   byType,
-		externalURL: extURL,
-		orgID:       orgID,
+		templates: byType,
+		cfg:       cfg,
 	}
 	return provider, nil
 }

--- a/templates/mimir_template_test.go
+++ b/templates/mimir_template_test.go
@@ -25,7 +25,9 @@ func Test_withCustomFunctions(t *testing.T) {
 		expectError bool
 	}
 
-	f, err := NewFactory(nil, log.NewNopLogger(), "http://localhost", "test")
+	cfg, err := NewConfig("test", "http://localhost", DefaultLimits)
+	require.NoError(t, err)
+	f, err := NewFactory(nil, cfg, log.NewNopLogger())
 	assert.NoError(t, err)
 	tmpl, err := f.GetTemplate(MimirKind)
 	assert.NoError(t, err)
@@ -151,7 +153,9 @@ func Test_loadTemplates(t *testing.T) {
 					Kind:     MimirKind,
 				})
 			}
-			f, err := NewFactory(def, log.NewNopLogger(), "http://localhost", "grafana")
+			cfg, err := NewConfig("grafana", "http://localhost", DefaultLimits)
+			require.NoError(t, err)
+			f, err := NewFactory(def, cfg, log.NewNopLogger())
 			require.NoError(t, err)
 			tmpl, err := f.GetTemplate(MimirKind)
 			assert.NoError(t, err)

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -393,7 +393,7 @@ func executeTextString(tmpl *Template, text string, data *ExtendedData) (string,
 	if text == "" {
 		return "", nil
 	}
-	textTmpl, err := tmpl.Template.Text()
+	textTmpl, err := tmpl.Text()
 	if err != nil {
 		return "", err
 	}

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -30,14 +30,19 @@ import (
 
 type KV = template.KV
 type Data = template.Data
-type Template = template.Template
+type Template struct {
+	*template.Template
+	limits Limits
+}
 
 var (
 	// Provides current time. Can be overwritten in tests.
 	timeNow                   = time.Now
 	ErrInvalidKind            = errors.New("invalid template kind")
 	ErrTemplateOutputTooLarge = errors.New("template output exceeds maximum size")
-	MaxTemplateOutputSize     = int64(10 * 1024 * 1024) // TODO replace it to configuration
+	DefaultLimits             = Limits{
+		MaxTemplateOutputSize: 10 * 1024 * 1024,
+	}
 )
 
 // Kind represents the type or category of a template. It is used to differentiate between various template kinds.
@@ -159,7 +164,7 @@ func addFuncs(text *tmpltext.Template, html *tmplhtml.Template) {
 }
 
 // fromContent calls Parse on all provided template content and returns the resulting Template. Content equivalent to templates.FromGlobs.
-func fromContent(tmpls []string, options ...template.Option) (*Template, error) {
+func fromContent(tmpls []string, options ...template.Option) (*template.Template, error) {
 	t, err := template.New(options...)
 	if err != nil {
 		return nil, err
@@ -365,7 +370,7 @@ func ExtendData(data *Data, logger log.Logger) *ExtendedData {
 }
 
 func TmplText(ctx context.Context, tmpl *Template, alerts []*types.Alert, l log.Logger, tmplErr *error) (func(string) string, *ExtendedData) {
-	promTmplData := notify.GetTemplateData(ctx, tmpl, alerts, l)
+	promTmplData := notify.GetTemplateData(ctx, tmpl.Template, alerts, l)
 	data := ExtendData(promTmplData, l)
 
 	if groupKey, err := notify.ExtractGroupKey(ctx); err == nil {
@@ -388,7 +393,7 @@ func executeTextString(tmpl *Template, text string, data *ExtendedData) (string,
 	if text == "" {
 		return "", nil
 	}
-	textTmpl, err := tmpl.Text()
+	textTmpl, err := tmpl.Template.Text()
 	if err != nil {
 		return "", err
 	}
@@ -397,7 +402,7 @@ func executeTextString(tmpl *Template, text string, data *ExtendedData) (string,
 		return "", err
 	}
 	var buf bytes.Buffer
-	err = textTmpl.Execute(utils.NewLimitedWriter(&buf, MaxTemplateOutputSize), data)
+	err = textTmpl.Execute(utils.NewLimitedWriter(&buf, tmpl.limits.MaxTemplateOutputSize), data)
 	if errors.Is(err, utils.ErrWriteLimitExceeded) {
 		err = ErrTemplateOutputTooLarge
 	}


### PR DESCRIPTION
This PR builds on the feature https://github.com/grafana/alerting/pull/437 and make the template output limits be propagated from the configuration. 
Key changes:
- `templates.Template` is not an alias to upstream's Template but an extension of it. 
- A few new structs are introduced in templates package: Config and Limits 
- DispatchLimit field in NotificationConfiguration is replaced with DynamicLimits that include dispatch and template limits

NOTE: the hardcoded limit for template testing is not changed and is still 1Mb
