### PR TITLE
alerting-gen: imporve alerting and recording rule creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ vendor
 .DS_Store
 
 .idea
+
+testing/alerting-gen/alerting-gen

--- a/testing/alerting-gen/Makefile
+++ b/testing/alerting-gen/Makefile
@@ -1,0 +1,5 @@
+build:
+	go build ./cmd/alerting-gen
+
+test:
+	go test ./...

--- a/testing/alerting-gen/README.md
+++ b/testing/alerting-gen/README.md
@@ -10,8 +10,7 @@ It outputs a list of valid `AlertingRuleGroup` JSON that you can inspect. Option
 ## Install
 
 ```bash
-cd ./alerting-gen
-go build ./cmd/alerting-gen
+make build
 ```
 
 ## Usage

--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -99,6 +99,8 @@ func NewRecordingRuleGenerator(queryDS, writeDS string) *rapid.Generator[*models
 		paused := rapid.Bool().Draw(t, "is_paused")
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
+		// Recording rules require For field set to 0 for Grafana API
+		forDur := strfmt.Duration(0)
 
 		return &models.ProvisionedAlertRule{
 			Title:       strPtr(title),
@@ -106,6 +108,7 @@ func NewRecordingRuleGenerator(queryDS, writeDS string) *rapid.Generator[*models
 			RuleGroup:   nil,
 			FolderUID:   nil,
 			Data:        data,
+			For:         &forDur,
 			IsPaused:    paused,
 			Labels:      map[string]string{"rule_kind": "recording"},
 			Annotations: anns,

--- a/testing/alerting-gen/pkg/generate/generate_test.go
+++ b/testing/alerting-gen/pkg/generate/generate_test.go
@@ -70,9 +70,6 @@ func TestRecordingRuleGenerator_Properties(t *testing.T) {
 		require.NotNil(t, rule.For, "Recording rules still require For pointer")
 		require.Equal(t, int64(0), int64(*rule.For), "Recording rules For expected 0")
 
-		require.NotNil(t, rule.ExecErrState)
-		require.NotNil(t, rule.NoDataState)
-
 		require.NotNil(t, rule.OrgID)
 		require.Equal(t, int64(1), *rule.OrgID, "OrgID must be 1 for now")
 


### PR DESCRIPTION
* Currently created alert rules aren't working properly (`invalid format of evaluation results for the alert definition A: looks like time series data, only reduced data can be alerted on.`) because they create ranged queries, not instant, fixed.
* Fixed recording rule creation
* Made generated rule names slightly more readable: `Brilliant Zebra [961h7]`, `Adorable Alpaca [T0CPlV]`, etc.