### PR TITLE
Changes to the notification history format.

### DIFF
--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -64,12 +64,11 @@ func TestRecord(t *testing.T) {
 						Stream: map[string]string{
 							"externalLabelKey": "externalLabelValue",
 							"from":             "notify-history",
-							"ruleUID":          "testRuleUID",
 						},
 						Values: []lokiclient.Sample{
 							{
 								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alerts\":[{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}}],\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
 							},
 						},
 					},
@@ -84,12 +83,11 @@ func TestRecord(t *testing.T) {
 						Stream: map[string]string{
 							"externalLabelKey": "externalLabelValue",
 							"from":             "notify-history",
-							"ruleUID":          "testRuleUID",
 						},
 						Values: []lokiclient.Sample{
 							{
 								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alerts\":[{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}}],\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
 							},
 						},
 					},


### PR DESCRIPTION
Makes two changes:

1. Remove the ruleUID from the stream labels.
  - This is going to be too high cardinality for Loki.

2. Write one entry per alert.
  - The array of alerts is hard to work with in Loki, e.g. searching by label value.
  - With many alerts per notification, we can hit the Loki log line limit.
  - We should prefer accuracy of data, so do not want to truncate if at all possible.
