### PR TITLE
Add additional golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,9 +6,24 @@ output:
       colors: false
 linters:
   enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - errcheck
     - errorlint
+    - exhaustive
+    - forbidigo
+    - goprintffuncname
+    - govet
+    - ineffassign
+    - loggercheck
     - misspell
+    - nakedret
+    - prealloc
     - revive
+    - staticcheck
+    - unconvert
+    - unused
   settings:
     errcheck:
       exclude-functions:

--- a/notify/alerts.go
+++ b/notify/alerts.go
@@ -91,7 +91,7 @@ func (am *GrafanaAlertmanager) GetAlerts(active, silenced, inhibited bool, filte
 	am.reloadConfigMtx.RUnlock()
 
 	if err != nil {
-		level.Error(am.logger).Log("failed to iterate through the alerts", "err", err)
+		level.Error(am.logger).Log("msg", "failed to iterate through the alerts", "err", err)
 		return nil, fmt.Errorf("%s: %w", err.Error(), ErrGetAlertsInternal)
 	}
 	sort.Slice(res, func(i, j int) bool {
@@ -197,7 +197,7 @@ func matchFilterLabels(matchers []*labels.Matcher, sms map[string]string) bool {
 			if !m.Matches(v) {
 				return false
 			}
-		default:
+		case labels.MatchEqual, labels.MatchRegexp:
 			if m.Value == "" && !prs {
 				continue
 			}

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -166,6 +166,8 @@ func TestConfigReceiverToMimirIntegrations(t *testing.T) {
 			case schema.V0mimir2:
 				found++
 				require.IsType(t, config.MSTeamsV2Config{}, ic.Config)
+			case schema.V1:
+				require.Fail(t, "unexpected V1 version for msteams integration")
 			default:
 				require.Fail(t, "unexpected version for msteams integration")
 			}

--- a/notify/dispatch_timer.go
+++ b/notify/dispatch_timer.go
@@ -15,6 +15,8 @@ func (t DispatchTimer) String() string {
 	switch t {
 	case DispatchTimerSync:
 		return "sync"
+	case DispatchTimerDefault:
+		return "default"
 	default:
 		return "default"
 	}

--- a/notify/historian/lokiclient/client.go
+++ b/notify/historian/lokiclient/client.go
@@ -239,7 +239,7 @@ func (c *HTTPLokiClient) RangeQuery(ctx context.Context, logQL string, start, en
 	result := QueryRes{}
 	err = json.Unmarshal(data, &result)
 	if err != nil {
-		fmt.Println(string(data))
+		level.Error(c.logger).Log("msg", "Failed to parse response", "err", err, "data", string(data))
 		return QueryRes{}, fmt.Errorf("error parsing request response: %w", err)
 	}
 

--- a/notify/silences.go
+++ b/notify/silences.go
@@ -130,7 +130,7 @@ func (am *GrafanaAlertmanager) UpsertSilence(ps *PostableSilence) (string, error
 func (am *GrafanaAlertmanager) validateSilence(sil *silencepb.Silence) error {
 	if sil.StartsAt.After(sil.EndsAt) || sil.StartsAt.Equal(sil.EndsAt) {
 		msg := "start time must be before end time"
-		level.Error(am.logger).Log("msg", msg, "err", "starts_at", sil.StartsAt, "ends_at", sil.EndsAt)
+		level.Error(am.logger).Log("msg", msg, "starts_at", sil.StartsAt, "ends_at", sil.EndsAt)
 		return fmt.Errorf("%s: %w", msg, ErrCreateSilenceBadPayload)
 	}
 

--- a/receivers/jira/v1/testing.go
+++ b/receivers/jira/v1/testing.go
@@ -24,5 +24,5 @@ const FullValidConfigForTesting = `{
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
 const FullValidSecretsForTesting = `{
 	"user": "test-user",
-	"password": "test-password"    
+	"password": "test-password"
 }`

--- a/receivers/slack/v1/slack.go
+++ b/receivers/slack/v1/slack.go
@@ -561,7 +561,7 @@ func initialCommentForImage(alert templates.ExtendedAlert) (string, string) {
 
 	titleBuilder.WriteString(" ")
 	if alert.Labels != nil {
-		titleBuilder.WriteString(string(alert.Labels[model.AlertNameLabel]))
+		titleBuilder.WriteString(alert.Labels[model.AlertNameLabel])
 	}
 
 	textBuilder := strings.Builder{}
@@ -747,6 +747,13 @@ func uploadFile(_ context.Context, req *http.Request, logger log.Logger) error {
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			level.Warn(logger).Log("msg", "Failed to close response body", "err", err)
+		}
+	}()
+
 	// no need to check body, just check the status code
 	return errorForStatusCode(logger, resp.StatusCode)
 }

--- a/receivers/sns/v1/sns.go
+++ b/receivers/sns/v1/sns.go
@@ -89,7 +89,7 @@ func (s *Notifier) createSNSClient(tmpl func(string) string) (*sns.SNS, error) {
 	var creds *credentials.Credentials
 	// If there are provided sigV4 credentials we want to use those to create a session.
 	if s.settings.Sigv4.AccessKey != "" && s.settings.Sigv4.SecretKey != "" {
-		creds = credentials.NewStaticCredentials(s.settings.Sigv4.AccessKey, string(s.settings.Sigv4.SecretKey), "")
+		creds = credentials.NewStaticCredentials(s.settings.Sigv4.AccessKey, s.settings.Sigv4.SecretKey, "")
 	}
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{

--- a/receivers/wecom/v1/wecom.go
+++ b/receivers/wecom/v1/wecom.go
@@ -80,7 +80,7 @@ func (w *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 
 	if tmplErr != nil {
-		level.Warn(l).Log("failed to template WeCom message", "err", tmplErr.Error())
+		level.Warn(l).Log("msg", "failed to template WeCom message", "err", tmplErr.Error())
 	}
 
 	cmd := &receivers.SendWebhookSettings{
@@ -89,7 +89,7 @@ func (w *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 
 	if err = w.ns.SendWebhook(ctx, l, cmd); err != nil {
-		level.Error(l).Log("failed to send WeCom webhook", "err", err)
+		level.Error(l).Log("msg", "failed to send WeCom webhook", "err", err)
 		return false, err
 	}
 

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -100,7 +100,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 		},
 	}
 
-	var def []TemplateDefinition
+	def := make([]TemplateDefinition, 0, len(validKinds))
 	for kind := range validKinds {
 		def = append(def, TemplateDefinition{
 			Name:     "test",

--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -16,6 +16,8 @@ func defaultTemplatesPerKind(kind Kind) []string {
 		return []string{
 			DefaultTemplateString,
 		}
+	case MimirKind:
+		return nil
 	default:
 		return nil
 	}

--- a/templates/gomplate/collections.go
+++ b/templates/gomplate/collections.go
@@ -76,6 +76,7 @@ func interfaceSlice(slice interface{}) ([]interface{}, error) {
 	}
 	s := reflect.ValueOf(slice)
 	kind := s.Kind()
+	//nolint:exhaustive // Only checking for slice/array types, default handles all others
 	switch kind {
 	case reflect.Slice, reflect.Array:
 		l := s.Len()

--- a/templates/gomplate/evalargs.go
+++ b/templates/gomplate/evalargs.go
@@ -52,6 +52,7 @@ func printableValue(v reflect.Value) (any, bool) {
 		if v.CanAddr() && (reflect.PointerTo(v.Type()).Implements(errorType) || reflect.PointerTo(v.Type()).Implements(fmtStringerType)) {
 			v = v.Addr()
 		} else {
+			//nolint:exhaustive // Only checking for Chan/Func types, other types are allowed
 			switch v.Kind() {
 			case reflect.Chan, reflect.Func:
 				return nil, false

--- a/templates/util.go
+++ b/templates/util.go
@@ -85,6 +85,7 @@ func checkListNode(node *parse.ListNode, executedTmpls map[string]struct{}) {
 }
 
 func checkNode(node parse.Node, executedTmpls map[string]struct{}) {
+	//nolint:exhaustive
 	switch node.Type() {
 	// The node is an if statement (with optional else)
 	case parse.NodeIf:


### PR DESCRIPTION
Added a few additional linters, found a few logging issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens static checks and cleans up related issues across notify, receivers, templates, and tests.
> 
> - Add many linters/formatters in `.golangci.yml` (asciicheck, bodyclose, errcheck, govet, staticcheck, unused, etc.)
> - Standardize structured logging: add `"msg"` field, replace prints, improve error messages in `notify/*`, `receivers/*`, and Loki client
> - Resource handling: ensure HTTP response bodies are closed in Slack file upload paths
> - Logic fixes: make label matcher switch explicit (`MatchEqual`/`MatchRegexp`), include `DispatchTimerDefault` in `String()`, adjust Slack alert name access, correct SNS static credentials secret key usage
> - Small optimizations/cleanups: preallocate slices (receivers, template defs), add `nolint:exhaustive` where applicable, update template defaults/options (handle `MimirKind`), and tighten tests (Teams schema version checks)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 479d2143d895fc70cf07a532e47b72129f3d84d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->