### PR TITLE
Add configurable footer support for Slack receiver

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -130,7 +130,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 	var orgID = rand.Int63()
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
 	imageProvider := &images.URLProvider{}
-	cfg, err := templates.NewConfig("grafana", "http://localhost", templates.DefaultLimits)
+	cfg, err := templates.NewConfig("grafana", "http://localhost", "", templates.DefaultLimits)
 	require.NoError(t, err)
 	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestBuildPrometheusReceiverIntegrations(t *testing.T) {
 	require.NoError(t, err)
 	err = definition.ValidateAlertmanagerConfig(receiver)
 	require.NoError(t, err)
-	cfg, err := templates.NewConfig("1", "http://localhost", templates.DefaultLimits)
+	cfg, err := templates.NewConfig("1", "http://localhost", "", templates.DefaultLimits)
 	require.NoError(t, err)
 	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
 	require.NoError(t, err)

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -346,7 +346,7 @@ func NewGrafanaAlertmanager(opts GrafanaAlertmanagerOpts) (*GrafanaAlertmanager,
 		return nil, fmt.Errorf("unable to initialize the alert provider component of alerting: %w", err)
 	}
 
-	cfg, err := templates.NewConfig(fmt.Sprintf("%d", am.TenantID()), am.ExternalURL(), templates.DefaultLimits)
+	cfg, err := templates.NewConfig(fmt.Sprintf("%d", am.TenantID()), am.ExternalURL(), am.opts.Version, templates.DefaultLimits)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize the template provider component of alerting: %w", err)
 	}
@@ -681,6 +681,7 @@ func TestTemplate(ctx context.Context, c TestTemplatesConfigBodyParams, tmplsFac
 
 	promTmplData := notify.GetTemplateData(ctx, newTmpl.Template, alerts, logger)
 	data := templates.ExtendData(promTmplData, logger)
+	data.AppVersion = newTmpl.AppVersion
 
 	// Iterate over each definition in the template and evaluate it.
 	var results TestTemplatesResults
@@ -740,7 +741,7 @@ func (am *GrafanaAlertmanager) buildTimeIntervals(timeIntervals []config.TimeInt
 // ApplyConfig applies a new configuration by re-initializing all components using the configuration provided.
 // It is not safe to call concurrently.
 func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err error) {
-	tmplCfg, err := templates.NewConfig(fmt.Sprintf("%d", am.TenantID()), am.ExternalURL(), cfg.Limits.Templates)
+	tmplCfg, err := templates.NewConfig(fmt.Sprintf("%d", am.TenantID()), am.ExternalURL(), am.opts.Version, cfg.Limits.Templates)
 	if err != nil {
 		return err
 	}

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -491,7 +491,7 @@ func TestTemplateWithExistingTemplates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if len(test.existingTemplates) > 0 {
 				var err error
-				cfg, err := templates.NewConfig("grafana", am.ExternalURL(), templates.DefaultLimits)
+				cfg, err := templates.NewConfig("grafana", am.ExternalURL(), "", templates.DefaultLimits)
 				require.NoError(t, err)
 				am.templates, err = templates.NewFactory(test.existingTemplates, cfg, log.NewNopLogger())
 				require.NoError(t, err)

--- a/receivers/slack/v1/config.go
+++ b/receivers/slack/v1/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	MentionUsers   receivers.CommaSeparatedStrings `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty"`
 	MentionGroups  receivers.CommaSeparatedStrings `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
 	Color          string                          `json:"color,omitempty" yaml:"color,omitempty"`
+	Footer         string                          `json:"footer,omitempty" yaml:"footer,omitempty"`
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
@@ -202,6 +203,14 @@ var Schema = schema.IntegrationSchemaVersion{
 			Description:  "Body of the slack message",
 			PropertyName: "text",
 			Placeholder:  `{{ template "slack.default.text" . }}`,
+		},
+		{
+			Label:        "Footer",
+			Element:      schema.ElementTypeInput,
+			InputType:    schema.InputTypeText,
+			Description:  "Templated footer of the slack message",
+			PropertyName: "footer",
+			Placeholder:  `{{ template "slack.default.footer" . }}`,
 		},
 	},
 }

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -44,6 +44,7 @@ Labels:
 {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}**Resolved**
 {{ template "__text_alert_list" .Alerts.Resolved }}{{ end }}{{ end }}
 
+{{ define "slack.default.footer" }}Grafana{{ if .AppVersion }} v{{ .AppVersion }}{{ end }}{{ end }}
 
 {{ define "__teams_text_alert_list" }}{{ range . }}
 Value: {{ template "__text_values_list" . }}
@@ -160,6 +161,8 @@ Labels:
 
 {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}**Resolved**
 {{ template "__text_alert_list" .Alerts.Resolved }}{{ end }}{{ end }}
+
+{{ define "slack.default.footer" }}Grafana{{ if .AppVersion }} v{{ .AppVersion }}{{ end }}{{ end }}
 
 {{ define "teams.default.message" }}{{ template "default.message" . }}{{ end }}
 

--- a/templates/factory.go
+++ b/templates/factory.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	OrgID       string
 	ExternalURL *url.URL
+	AppVersion  string
 	Limits      Limits
 }
 
@@ -34,7 +35,7 @@ func (l Limits) Validate() error {
 	return nil
 }
 
-func NewConfig(orgID string, externalURL string, limits Limits) (Config, error) {
+func NewConfig(orgID string, externalURL string, appVersion string, limits Limits) (Config, error) {
 	u, err := url.Parse(externalURL)
 	if err != nil {
 		return Config{}, err
@@ -42,6 +43,7 @@ func NewConfig(orgID string, externalURL string, limits Limits) (Config, error) 
 	cfg := Config{
 		OrgID:       orgID,
 		ExternalURL: u,
+		AppVersion:  appVersion,
 		Limits:      limits,
 	}
 	return cfg, cfg.Validate()
@@ -68,8 +70,9 @@ func (tp *Factory) GetTemplate(kind Kind) (*Template, error) {
 		return nil, err
 	}
 	result := &Template{
-		Template: t,
-		limits:   tp.cfg.Limits,
+		Template:   t,
+		limits:     tp.cfg.Limits,
+		AppVersion: tp.cfg.AppVersion,
 	}
 	if tp.cfg.ExternalURL != nil {
 		t.ExternalURL = new(url.URL)

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -54,7 +54,7 @@ func TestNewFactory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := NewConfig("grafana", externalURL, DefaultLimits)
+			cfg, err := NewConfig("grafana", externalURL, "", DefaultLimits)
 			require.NoError(t, err)
 			factory, err := NewFactory(tc.templates, cfg, logger)
 			if tc.expectError != nil {
@@ -108,7 +108,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 			Template: fmt.Sprintf(`{{ define "factory_test" }}TEST %s KIND{{ end }}`, kind),
 		})
 	}
-	cfg, err := NewConfig("grafana", "http://localhost", DefaultLimits)
+	cfg, err := NewConfig("grafana", "http://localhost", "", DefaultLimits)
 	require.NoError(t, err)
 	f, err := NewFactory(def, cfg, log.NewNopLogger())
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestFactoryNewTemplate(t *testing.T) {
 	})
 
 	t.Run("user-defined template only applies to the given kind", func(t *testing.T) {
-		cfg, err := NewConfig("grafana", "http://localhost", DefaultLimits)
+		cfg, err := NewConfig("grafana", "http://localhost", "", DefaultLimits)
 		require.NoError(t, err)
 		f, err := NewFactory([]TemplateDefinition{
 			{
@@ -307,7 +307,7 @@ func TestFactoryWithTemplate(t *testing.T) {
 	as := []*types.Alert{{}}
 	kind := GrafanaKind
 	initial := TemplateDefinition{Name: "test", Kind: kind, Template: `{{ define "factory_test" }}TEST{{ end }}`}
-	cfg, err := NewConfig("grafana", "http://localhost", DefaultLimits)
+	cfg, err := NewConfig("grafana", "http://localhost", "", DefaultLimits)
 	require.NoError(t, err)
 	f, err := NewFactory([]TemplateDefinition{initial}, cfg, log.NewNopLogger())
 	require.NoError(t, err)

--- a/templates/mimir_template_test.go
+++ b/templates/mimir_template_test.go
@@ -25,7 +25,7 @@ func Test_withCustomFunctions(t *testing.T) {
 		expectError bool
 	}
 
-	cfg, err := NewConfig("test", "http://localhost", DefaultLimits)
+	cfg, err := NewConfig("test", "http://localhost", "", DefaultLimits)
 	require.NoError(t, err)
 	f, err := NewFactory(nil, cfg, log.NewNopLogger())
 	assert.NoError(t, err)
@@ -153,7 +153,7 @@ func Test_loadTemplates(t *testing.T) {
 					Kind:     MimirKind,
 				})
 			}
-			cfg, err := NewConfig("grafana", "http://localhost", DefaultLimits)
+			cfg, err := NewConfig("grafana", "http://localhost", "", DefaultLimits)
 			require.NoError(t, err)
 			f, err := NewFactory(def, cfg, log.NewNopLogger())
 			require.NoError(t, err)

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -32,7 +32,8 @@ type KV = template.KV
 type Data = template.Data
 type Template struct {
 	*template.Template
-	limits Limits
+	limits     Limits
+	AppVersion string
 }
 
 var (
@@ -142,6 +143,7 @@ type ExtendedData struct {
 	CommonAnnotations KV `json:"commonAnnotations"`
 
 	ExternalURL string `json:"externalURL"`
+	AppVersion  string `json:"appVersion,omitempty"`
 
 	// Webhook-specific fields
 	GroupKey string `json:"groupKey"`
@@ -372,6 +374,7 @@ func ExtendData(data *Data, logger log.Logger) *ExtendedData {
 func TmplText(ctx context.Context, tmpl *Template, alerts []*types.Alert, l log.Logger, tmplErr *error) (func(string) string, *ExtendedData) {
 	promTmplData := notify.GetTemplateData(ctx, tmpl.Template, alerts, l)
 	data := ExtendData(promTmplData, l)
+	data.AppVersion = tmpl.AppVersion
 
 	if groupKey, err := notify.ExtractGroupKey(ctx); err == nil {
 		data.GroupKey = groupKey.String()

--- a/templates/template_data_test.go
+++ b/templates/template_data_test.go
@@ -123,6 +123,20 @@ func TestTmplText(t *testing.T) {
 		assert.Equal(t, "TestAlert", data.Alerts[0].Labels["alertname"])
 	})
 
+	t.Run("should pass AppVersion from template to data", func(t *testing.T) {
+		tmplWithVersion := &Template{
+			Template:   tm,
+			limits:     DefaultLimits,
+			AppVersion: "10.0.0",
+		}
+
+		var tmplErr error
+		_, data := TmplText(context.Background(), tmplWithVersion, alerts, l, &tmplErr)
+
+		assert.NotNil(t, data)
+		assert.Equal(t, "10.0.0", data.AppVersion)
+	})
+
 	t.Run("should extract group key from context", func(t *testing.T) {
 		// Create context with group key
 		ctx := context.Background()


### PR DESCRIPTION
Add configurable footer support for Slack receiver

Related to https://github.com/grafana/alerting/issues/297

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configurable Slack footer and propagates app version into templating.
> 
> - Adds `footer` to Slack v1 config/schema and renders it via `Notifier.footer` with 300-char truncation and error handling; applied to main and image replies
> - Defines `"slack.default.footer"` ("Grafana v<AppVersion>") in default templates
> - Extends template plumbing: `templates.NewConfig(orgID, externalURL, appVersion, limits)`, `templates.Config.AppVersion`, and `templates.Template.AppVersion`; `TmplText`/`ExtendedData` now include `.AppVersion`
> - Wires AppVersion through Alertmanager (`NewGrafanaAlertmanager`, `ApplyConfig`, `TestTemplate`) and tests; updates callers to new `NewConfig` signature
> - Adds/updates tests for Slack footer behavior (custom, truncation, invalid template) and for passing AppVersion in template data
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76eb1a12bc98e5f201b9d24d02d921946a47e298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->