### PR TITLE
Alerting-Gen: Add queries for generated rules

### DIFF
--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -25,11 +25,11 @@ type Config struct {
 // Helpers moved to helpers.go
 
 // NewAlertingRuleGenerator returns a rapid generator for alerting rules
-func NewAlertingRuleGenerator(queryDs string) *rapid.Generator[*models.ProvisionedAlertRule] {
+func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.ProvisionedAlertRule] {
 	return rapid.Custom(func(t *rapid.T) *models.ProvisionedAlertRule {
 		// local refID scoped to this rule
 		refID := "A"
-		data := []*models.AlertQuery{buildQuery(queryDs, refID)}
+		data := []*models.AlertQuery{buildQuery(t, queryDS, refID)}
 		title := genTitle().Draw(t, "title")
 		forDur := mustParseDuration(genDurationStr().Draw(t, "for"))
 		// KeepFiringFor must be a multiple of For (0 inclusive)
@@ -83,7 +83,7 @@ func NewRecordingRuleGenerator(queryDS, writeDS string) *rapid.Generator[*models
 	return rapid.Custom(func(t *rapid.T) *models.ProvisionedAlertRule {
 		// local refID scoped to this rule
 		refID := "A"
-		data := []*models.AlertQuery{buildQuery(queryDS, refID)}
+		data := []*models.AlertQuery{buildQuery(t, queryDS, refID)}
 		title := genTitle().Draw(t, "title")
 		uid := RandomUID().Draw(t, "uid")
 		metric := genMetricName().Draw(t, "metric")

--- a/testing/alerting-gen/pkg/generate/helpers.go
+++ b/testing/alerting-gen/pkg/generate/helpers.go
@@ -60,10 +60,34 @@ var (
 		"Vulture", "Wallaby", "Walrus", "Whale", "Wildcat", "Wolf",
 		"Woodpecker", "Wombat", "Yak", "Zebra",
 	}
+
+	queries = []string{
+		"vector(0)",
+		"vector(1)",
+		"sum by (name) (group by (id, name) (grafanacloud_instance_info))",
+		"sum by (plan) (group by (id, plan) (grafanacloud_grafana_instance_info))",
+		"sum by (id, state) (grafanacloud_grafana_instance_active_user_count)",
+		"grafanacloud_instance_rule_evaluation_failures_total:rate5m > 0",
+		"grafanacloud_instance_ruler_notifications_errors_total:rate5m > 0",
+		"grafanacloud_org_total_overage > 0",
+		"grafanacloud_org_spend_commit_balance_total == 0 or grafanacloud_org_spend_commit_balance_total < grafanacloud_org_spend_commit_credit_total * 0.1",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts)",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 10",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 25",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 50",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 100",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 500",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 1000",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 2500",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 5000",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 10000",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 50000",
+		"sum by (id, state) (grafanacloud_grafana_instance_alerting_alerts) > 100000",
+	}
 )
 
 // Helpers
-func buildQuery(dsUID, refID string) *models.AlertQuery {
+func buildQuery(t *rapid.T, dsUID, refID string) *models.AlertQuery {
 	// __expr__ math or a basic prom query
 	model := map[string]any{
 		"refId":      refID,
@@ -76,7 +100,7 @@ func buildQuery(dsUID, refID string) *models.AlertQuery {
 			"refId":      refID,
 			"type":       "query",
 			"datasource": map[string]any{"uid": dsUID},
-			"expr":       "vector(1)",
+			"expr":       rapid.SampledFrom(queries).Draw(t, "query"),
 			"instant":    true,
 			"range":      false,
 		}


### PR DESCRIPTION
This PR adds an array of possible queries to choose from (randomly) when generating alert rules. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces randomized query selection for generated rules.
> 
> - Adds `queries` list in `helpers.go`; `buildQuery` now samples an `expr` via `rapid.SampledFrom(queries)`
> - Changes `buildQuery` signature to `buildQuery(t *rapid.T, dsUID, refID string)` and updates callers in `NewAlertingRuleGenerator` and `NewRecordingRuleGenerator`
> - Minor parameter rename to `queryDS` for consistency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58a02a93945a05caf7156dcb149375db390e1e16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->