### PR TITLE
Alerting-Gen: Add notification settings to generated alerts

### DIFF
--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -20,11 +20,7 @@ type Config struct {
 	FolderUIDs      []string
 }
 
-// GenerateGroups moved to groups.go
-
-// Helpers moved to helpers.go
-
-// NewAlertingRuleGenerator returns a rapid generator for alerting rules
+// NewAlertingRuleGenerator returns a rapid generator for alerting rules.
 func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.ProvisionedAlertRule] {
 	return rapid.Custom(func(t *rapid.T) *models.ProvisionedAlertRule {
 		// local refID scoped to this rule
@@ -58,6 +54,15 @@ func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.Provision
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
 
+		// Randomly add receiver to some rules
+		var notificationSettings *models.AlertRuleNotificationSettings
+		if rapid.Bool().Draw(t, "with_notification_settings") {
+			r := "grafana-default-email"
+			notificationSettings = &models.AlertRuleNotificationSettings{
+				Receiver: &r,
+			}
+		}
+
 		return &models.ProvisionedAlertRule{
 			Title:                       strPtr(title),
 			UID:                         uid,
@@ -72,6 +77,7 @@ func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.Provision
 			NoDataState:                 strPtr(noData),
 			Labels:                      labels,
 			Annotations:                 anns,
+			NotificationSettings:        notificationSettings,
 			MissingSeriesEvalsToResolve: missingToResolve,
 			OrgID:                       &orgID,
 		}

--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -54,7 +54,7 @@ func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.Provision
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
 
-		// Randomly add receiver to some rules
+		// Randomly add receiver to some rules.
 		var notificationSettings *models.AlertRuleNotificationSettings
 		if rapid.Bool().Draw(t, "with_notification_settings") {
 			r := "grafana-default-email"


### PR DESCRIPTION
Add notification settings to generated alerts (randomly), using Grafana's default contact point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional notification routing to generated alert rules.
> 
> - `NewAlertingRuleGenerator`: randomly sets `NotificationSettings` with receiver `grafana-default-email` on some rules
> - Populates `ProvisionedAlertRule.NotificationSettings` when present; no change to recording rules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19203519bae3ed24b0f4262953ba73d80c173714. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->