### PR TITLE
add TimeIntervalKind

### DIFF
--- a/definition/alertmanager.go
+++ b/definition/alertmanager.go
@@ -630,5 +630,14 @@ func (t *PostableApiTemplate) Validate() error {
 
 type TemplateKind string
 
-const GrafanaTemplateKind TemplateKind = "grafana"
-const MimirTemplateKind TemplateKind = "mimir"
+const (
+	GrafanaTemplateKind TemplateKind = "grafana"
+	MimirTemplateKind   TemplateKind = "mimir"
+)
+
+type TimeIntervalKind string
+
+const (
+	GrafanaTimeIntervalKind TimeIntervalKind = "grafana"
+	MimirTimeIntervalKind   TimeIntervalKind = "mimir"
+)


### PR DESCRIPTION
## Context
- Add `TimeIntervalKind` so we can add support for imported time intervals

Related to https://github.com/grafana/grafana/pull/116308

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support scaffolding for imported time intervals.
> 
> - Adds `TimeIntervalKind` with `grafana` and `mimir` variants in `definition/alertmanager.go`
> - Groups existing `TemplateKind` constants into a single `const` block
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c56cf1580dcfd5b88eeb441425b9a0e45350c650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->