### PR TITLE
Alerting-Gen: Change names for alerting and recording rules argument

### DIFF
--- a/testing/alerting-gen/cmd/alerting-gen/main.go
+++ b/testing/alerting-gen/cmd/alerting-gen/main.go
@@ -28,8 +28,8 @@ func main() {
 
 func parseFlags() CLIOptions {
 	var cfg CLIOptions
-	flag.IntVar(&cfg.NumAlerting, "alerts", 0, "Number of alerting rules to generate")
-	flag.IntVar(&cfg.NumRecording, "recordings", 0, "Number of recording rules to generate")
+	flag.IntVar(&cfg.NumAlerting, "num-alerting", 0, "Number of alerting rules to generate")
+	flag.IntVar(&cfg.NumRecording, "num-recording", 0, "Number of recording rules to generate")
 	flag.StringVar(&cfg.QueryDS, "query-ds", "", "Data source UID to query from")
 	flag.StringVar(&cfg.WriteDS, "write-ds", "", "Data source UID to write recording rules to (defaults to same as query-ds)")
 	flag.IntVar(&cfg.RulesPerGroup, "rules-per-group", 0, "Number of rules per group")


### PR DESCRIPTION
Make them consistent with their JSON tags (config) and the `num-folders` argument.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames CLI flags in `alerting-gen` for consistency with config and other args.
> 
> - `alerts` -> `num-alerting`
> - `recordings` -> `num-recording`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7daf926db8ee455867a6d29ae9e5d57682dcf62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->