### PR TITLE
Noop mode for Webhook integration

### DIFF
--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -45,6 +45,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, GetDecryptedValueFnForTesting)
 		require.NoError(t, err)
+		parsed.WebhookConfigs[0].Settings.URL = "http://localhost:8080" // to make sure Notify test works
 		return parsed, len(recCfg.Integrations)
 	}
 

--- a/receivers/webhook/v1/config.go
+++ b/receivers/webhook/v1/config.go
@@ -14,6 +14,7 @@ import (
 )
 
 const Version = schema.V1
+const NoopURL = "grafana://noop"
 
 type CustomPayload struct {
 	// Template is the template used to generate the payload for the webhook.

--- a/receivers/webhook/v1/config_test.go
+++ b/receivers/webhook/v1/config_test.go
@@ -76,7 +76,7 @@ func TestNewConfig(t *testing.T) {
 			name:     "Extracts all fields",
 			settings: FullValidConfigForTesting,
 			expectedConfig: Config{
-				URL:                      "http://localhost",
+				URL:                      NoopURL,
 				HTTPMethod:               "PUT",
 				MaxAlerts:                2,
 				AuthorizationScheme:      "basic",
@@ -103,7 +103,7 @@ func TestNewConfig(t *testing.T) {
 			settings:       FullValidConfigForTesting,
 			secretSettings: receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
 			expectedConfig: Config{
-				URL:                      "http://localhost",
+				URL:                      NoopURL,
 				HTTPMethod:               "PUT",
 				MaxAlerts:                2,
 				AuthorizationScheme:      "basic",

--- a/receivers/webhook/v1/testing.go
+++ b/receivers/webhook/v1/testing.go
@@ -8,7 +8,7 @@ import (
 
 // FullValidConfigForTesting is a string representation of a JSON object that contains all fields supported by the notifier Config. It can be used without secrets.
 var FullValidConfigForTesting = fmt.Sprintf(`{
-	"url": "http://localhost",
+	"url": %q,
 	"httpMethod": "PUT",
 	"maxAlerts": "2",
 	"authorization_scheme": "basic",
@@ -28,7 +28,7 @@ var FullValidConfigForTesting = fmt.Sprintf(`{
 		"header": "X-Grafana-Alerting-Signature",
 		"timestampHeader": "X-Grafana-Alerting-Timestamp"
 	}
-}`, http.TestCertPem, http.TestKeyPem, http.TestCACert)
+}`, NoopURL, http.TestCertPem, http.TestKeyPem, http.TestCACert)
 
 // FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
 var FullValidSecretsForTesting = fmt.Sprintf(`{

--- a/receivers/webhook/v1/webhook.go
+++ b/receivers/webhook/v1/webhook.go
@@ -157,6 +157,11 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		}
 	}
 
+	if parsedURL == NoopURL {
+		level.Debug(l).Log("msg", "skipping webhook notification, URL is set to noop")
+		return true, nil
+	}
+
 	cmd := &receivers.SendWebhookSettings{
 		URL:        parsedURL,
 		User:       wn.settings.User,


### PR DESCRIPTION
Introduces a special mode for webhook integration in which the integration does all the transformations and expansions but does not send the payload if URL is specified as "grafana://noop"

This can be useful in integration testing and avoid the possibilities of unintentionally hitting some endpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a noop mode for webhook notifications that performs templating and processing but skips the outbound request when `url` is `grafana://noop`.
> 
> - Adds `NoopURL` constant and short-circuit in `webhook.Notify` with debug log; returns success without sending
> - Updates tests: new case asserting no send when using noop URL; fixture configs now use `NoopURL`; adjust `factory_test` to set a real webhook URL (`http://localhost:8080`) for integration tests
> - Keeps existing behavior for all other URLs, including headers, TLS, HMAC, payload templating, and error handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08d04f1e4a0a50c985ee94b50d86eb4c8d73ad47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->