### PR TITLE
Alerting-Gen: Improve alert creation

### DIFF
--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -49,8 +49,8 @@ func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.Provision
 		}
 		execErr := genExecErrState().Draw(t, "exec_err_state")
 		noData := genNoDataState().Draw(t, "no_data_state")
-		// 10% chance of being paused
-		paused := rapid.IntRange(0, 100).Draw(t, "is_paused") < 10
+		// 10% chance of being paused.
+		paused := rapid.IntRange(0, 99).Draw(t, "is_paused") < 10
 		missingToResolve := rapid.Int64Range(0, 5).Draw(t, "missing_to_resolve")
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
@@ -103,8 +103,8 @@ func NewRecordingRuleGenerator(queryDS, writeDS string) *rapid.Generator[*models
 			}
 			anns[k] = v
 		}
-		// 10% chance of being paused
-		paused := rapid.IntRange(0, 100).Draw(t, "is_paused") < 10
+		// 10% chance of being paused.
+		paused := rapid.IntRange(0, 99).Draw(t, "is_paused") < 10
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
 		// Recording rules require For field set to 0 for Grafana API

--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -49,7 +49,8 @@ func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.Provision
 		}
 		execErr := genExecErrState().Draw(t, "exec_err_state")
 		noData := genNoDataState().Draw(t, "no_data_state")
-		paused := rapid.Bool().Draw(t, "is_paused")
+		// 10% chance of being paused
+		paused := rapid.IntRange(0, 100).Draw(t, "is_paused") < 10
 		missingToResolve := rapid.Int64Range(0, 5).Draw(t, "missing_to_resolve")
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
@@ -102,7 +103,8 @@ func NewRecordingRuleGenerator(queryDS, writeDS string) *rapid.Generator[*models
 			}
 			anns[k] = v
 		}
-		paused := rapid.Bool().Draw(t, "is_paused")
+		// 10% chance of being paused
+		paused := rapid.IntRange(0, 100).Draw(t, "is_paused") < 10
 		// TODO: make orgID configurable; assume 1 for now
 		orgID := int64(1)
 		// Recording rules require For field set to 0 for Grafana API

--- a/testing/alerting-gen/pkg/generate/groups.go
+++ b/testing/alerting-gen/pkg/generate/groups.go
@@ -1,8 +1,6 @@
 package generate
 
 import (
-	"fmt"
-
 	models "github.com/grafana/grafana-openapi-client-go/models"
 	"pgregory.net/rapid"
 )
@@ -38,9 +36,10 @@ func GroupRules(rules []*models.ProvisionedAlertRule, rulesPerGroup, groupsPerFo
 
 	groups := make([]*models.AlertRuleGroup, 0)
 	groupIdx := 0
+	uidGen := RandomUID()
 	for i := 0; i < len(rules); i += rulesPerGroup {
 		end := min(i+rulesPerGroup, len(rules))
-		name := fmt.Sprintf("group-%d", groupIdx+1)
+		name := uidGen.Example(int(seed) + groupIdx)
 		folderUID := folderUIDs[(groupIdx/groupsPerFolder)%len(folderUIDs)]
 
 		// Use fixed interval if provided, otherwise generate random (1-20 minutes, divisible by 10).

--- a/testing/alerting-gen/pkg/generate/groups_test.go
+++ b/testing/alerting-gen/pkg/generate/groups_test.go
@@ -58,9 +58,9 @@ func TestGroupRules_PartitionAndFolderCycling(t *testing.T) {
 
 	// Group 1 in f1, group 2 in f2 when groupsPerFolder=1
 	require.Equal(t, "f1", groups[0].FolderUID)
-	require.Equal(t, "group-1", groups[0].Title)
+	require.Len(t, groups[0].Rules, 2)
 	require.Equal(t, "f2", groups[1].FolderUID)
-	require.Equal(t, "group-2", groups[1].Title)
+	require.Len(t, groups[1].Rules, 2)
 
 	// Each rule should be annotated with the group's folder and title
 	for gi, g := range groups {
@@ -87,7 +87,6 @@ func TestGroupRules_DefaultsWhenZeroOrEmpty(t *testing.T) {
 	g := groups[0]
 	require.Equal(t, int64(60), g.Interval)
 	require.Equal(t, "default", g.FolderUID)
-	require.Equal(t, "group-1", g.Title)
 	require.Len(t, g.Rules, len(rules))
 
 	// sanity: math ceiling is enforced when grouping is applied (not applicable here since one group)

--- a/testing/alerting-gen/pkg/generate/helpers.go
+++ b/testing/alerting-gen/pkg/generate/helpers.go
@@ -64,23 +64,13 @@ var (
 	queries = []string{
 		"vector(0)",
 		"vector(1)",
-		"sum by (name) (group by (id, name) (grafanacloud_instance_info))",
-		"sum by (plan) (group by (id, plan) (grafanacloud_grafana_instance_info))",
-		"sum by (id, state) (grafanacloud_grafana_instance_active_user_count)",
-		"grafanacloud_instance_rule_evaluation_failures_total:rate5m > 0",
-		"grafanacloud_instance_ruler_notifications_errors_total:rate5m > 0",
-		"grafanacloud_org_total_overage > 0",
-		"grafanacloud_org_spend_commit_balance_total == 0 or grafanacloud_org_spend_commit_balance_total < grafanacloud_org_spend_commit_credit_total * 0.1",
-
-		// Multi-dimensional alerts. Number of instances capped to k.
-		"topk(1, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(3, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(5, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(8, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(10, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(20, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(50, sum by (alertname) (GRAFANA_ALERTS))",
-		"topk(100, sum by (alertname) (GRAFANA_ALERTS))",
+		"test_metric > 0",
+		"sum by (service) (test_metric_labeled) > 0",
+		"sum by (service) (test_metric_labeled) > 5",
+		"sum by (service) (test_metric_labeled) > 10",
+		"sum by (service) (test_metric_labeled) > 20",
+		"sum by (service) (test_metric_labeled) > 50",
+		"sum by (service) (test_metric_labeled) > 100",
 	}
 )
 


### PR DESCRIPTION
- The cardinality on `GRAFANA_ALERTS` can be huge, switching that metric for `test_metric*`
- 50% of paused alets is not realistic, dropping it to 10%
- Due to our naming scheme  (`group-n`), groups get overwritten when running the generation for the same folder twice. Fixed this using UIDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates alert generation to be more realistic and collision-free.
> 
> - Replace high-cardinality queries with low-cardinality `test_metric`/`test_metric_labeled` expressions in `helpers.go`
> - Reduce `is_paused` probability to 10% in both alerting and recording rule generators (`generate.go`)
> - Generate group `Title` via `RandomUID()` (seeded) instead of `group-n` to prevent overwrites across reruns (`groups.go`); adjust tests to drop fixed title assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47475a79714730878e76004f919dabe8204da299. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->