### PR TITLE
Deprecate LINE integration

### DIFF
--- a/receivers/line/schema.go
+++ b/receivers/line/schema.go
@@ -10,9 +10,10 @@ const Type schema.IntegrationType = "LINE"
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,
 	Name:           "LINE",
-	Description:    "Send notifications to LINE notify",
+	Description:    "Send notifications to LINE notify. This integration is deprecated and will be removed in a future release.",
 	Heading:        "LINE notify settings",
 	CurrentVersion: v1.Version,
+	Deprecated:     true,
 	Versions: []schema.IntegrationSchemaVersion{
 		v1.Schema,
 	},

--- a/receivers/line/v1/config.go
+++ b/receivers/line/v1/config.go
@@ -40,7 +40,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 var Schema = schema.IntegrationSchemaVersion{
 	TypeAlias: "line",
 	Version:   Version,
-	CanCreate: true,
+	CanCreate: false,
 	Options: []schema.Field{
 		{
 			Label:        "Token",

--- a/receivers/schema/schema.go
+++ b/receivers/schema/schema.go
@@ -58,6 +58,7 @@ type IntegrationTypeSchema struct {
 	Description    string                     `json:"description,omitempty"`
 	Info           string                     `json:"info,omitempty"`
 	Versions       []IntegrationSchemaVersion `json:"versions"`
+	Deprecated     bool                       `json:"deprecated,omitempty"`
 }
 
 // GetAllTypes returns a list of all types that are mentioned by the schema.
@@ -115,6 +116,8 @@ type IntegrationSchemaVersion struct {
 	Options []Field `json:"options"`
 	// Additional information about the version
 	Info string `json:"info,omitempty"`
+	// Indicates whether the version is deprecated and will be removed in a future release
+	Deprecated bool `json:"deprecated,omitempty"`
 
 	typeSchema *IntegrationTypeSchema
 }


### PR DESCRIPTION
- Introduces deprecated field to integration schema
- Marks LINE integration as deprecated and sets 'canCreate' to false.


Related to https://github.com/grafana/alerting/issues/334

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deprecates the LINE integration and introduces deprecation metadata in the schema.
> 
> - Adds `deprecated` flag to `schema.IntegrationTypeSchema` and `schema.IntegrationSchemaVersion`
> - Updates LINE: description now notes deprecation/removal, sets `Deprecated: true`, and sets `CanCreate: false` in `v1` schema
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdc209630a62f2aa69a1e5c6ae1615a1f3acbb97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->