### PR TITLE
Add ruleUID field to external notification payloads

### DIFF
--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -123,6 +123,7 @@ type ExtendedAlert struct {
 	SilenceURL    string             `json:"silenceURL"`
 	DashboardURL  string             `json:"dashboardURL"`
 	PanelURL      string             `json:"panelURL"`
+	RuleUID       string             `json:"ruleUID,omitempty"`
 	Values        map[string]float64 `json:"values"`
 	ValueString   string             `json:"valueString"` // TODO: Remove in Grafana 10
 	ImageURL      string             `json:"imageURL,omitempty"`
@@ -215,6 +216,7 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 		EndsAt:       alert.EndsAt,
 		GeneratorURL: alert.GeneratorURL,
 		Fingerprint:  alert.Fingerprint,
+		RuleUID:      alert.Labels[models.RuleUIDLabel],
 	}
 
 	if alert.Annotations[models.OrgIDAnnotation] != "" {


### PR DESCRIPTION
Currently the internal `__alert_rule_uid__` label is deleted by `removePrivateItems()` before sending labels, so consumers have to parse `silenceURL` or `generatorURL` to extract the rule UID. This PR adds a dedicated `ruleUID` field at the same level as `generatorURL`, `orgId`, etc.:

```json
{
    "alerts": [
      {
        "status": "firing",
        ...
        "generatorURL": "... /alerting/grafana/uid-123/view?orgId=1",
        "ruleUID": "uid-123", // the new field
        "orgId": 1
      }
    ]
  }

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated `ruleUID` to extended alert/template data and verifies it via tests.
> 
> - Adds `RuleUID` to `ExtendedAlert` and populates it in `extendAlert` from `labels[models.RuleUIDLabel]` while keeping the label stripped from `Labels`
> - Tests cover presence, template access, and absence of `RuleUID` without affecting other fields/behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e26b2c74c9f552cc356bcbec8e18655d85865b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->