### PR TITLE
Deprecate OpsGenie integrations

### DIFF
--- a/receivers/opsgenie/v0mimir1/config.go
+++ b/receivers/opsgenie/v0mimir1/config.go
@@ -11,8 +11,9 @@ const Version = schema.V0mimir1
 type Config = config.OpsGenieConfig
 
 var Schema = schema.IntegrationSchemaVersion{
-	Version:   Version,
-	CanCreate: false,
+	Version:    Version,
+	CanCreate:  false,
+	Deprecated: true,
 	Options: []schema.Field{
 		{
 			Label:        "API key",

--- a/receivers/opsgenie/v1/config.go
+++ b/receivers/opsgenie/v1/config.go
@@ -129,8 +129,9 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 }
 
 var Schema = schema.IntegrationSchemaVersion{
-	Version:   Version,
-	CanCreate: true,
+	Version:    Version,
+	CanCreate:  false,
+	Deprecated: true,
 	Options: []schema.Field{
 		{
 			Label:        "API Key",


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/114413
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Schema-only change that just flags OpsGenie as deprecated and blocks creation of new integrations; minimal runtime impact aside from UI/API capabilities.
> 
> **Overview**
> Marks the OpsGenie receiver schemas (both `v0mimir1` and `v1`) as **deprecated** and disables creating new OpsGenie integrations by setting `Deprecated: true` and `CanCreate: false` in their schema definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a0e8bd80687081b99bff7a2ce3f065e29ba7de5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->