### PR TITLE
Alerting-Gen: Update default receiver name

### DIFF
--- a/testing/alerting-gen/pkg/generate/generate.go
+++ b/testing/alerting-gen/pkg/generate/generate.go
@@ -58,7 +58,7 @@ func NewAlertingRuleGenerator(queryDS string) *rapid.Generator[*models.Provision
 		// Randomly add receiver to some rules.
 		var notificationSettings *models.AlertRuleNotificationSettings
 		if rapid.Bool().Draw(t, "with_notification_settings") {
-			r := "grafana-default-email"
+			r := "empty"
 			notificationSettings = &models.AlertRuleNotificationSettings{
 				Receiver: &r,
 			}


### PR DESCRIPTION
We switched from `grafana-default-email` to `empty`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small test-data generation change that only affects the receiver name assigned in generated notification settings.
> 
> **Overview**
> Updates `testing/alerting-gen`’s alert rule generator to use `empty` as the receiver name when randomly attaching `NotificationSettings`, replacing the previous `grafana-default-email` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2706cad8d8f35afbefc662b5a540de2f0b6034e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->