### PR TITLE
Make config merge logic more modular

### DIFF
--- a/definition/merge_test.go
+++ b/definition/merge_test.go
@@ -205,8 +205,10 @@ func TestMerge(t *testing.T) {
 					})
 
 				}),
-				RenamedReceivers: map[string]string{
-					"grafana-default-email": "grafana-default-email_mimir-12345",
+				RenameResources: RenameResources{
+					Receivers: map[string]string{
+						"grafana-default-email": "grafana-default-email_mimir-12345",
+					},
 				},
 			},
 		},
@@ -241,8 +243,10 @@ func TestMerge(t *testing.T) {
 						},
 					)
 				}),
-				RenamedReceivers: map[string]string{
-					"grafana-default-email": "grafana-default-email_mimir-12345_01",
+				RenameResources: RenameResources{
+					Receivers: map[string]string{
+						"grafana-default-email": "grafana-default-email_mimir-12345_01",
+					},
 				},
 			},
 		},
@@ -294,9 +298,11 @@ func TestMerge(t *testing.T) {
 						ActiveTimeIntervals: []string{"mti-1_mimir-12345"},
 					})
 				}),
-				RenamedTimeIntervals: map[string]string{
-					"ti-1":  "ti-1_mimir-12345",
-					"mti-1": "mti-1_mimir-12345",
+				RenameResources: RenameResources{
+					TimeIntervals: map[string]string{
+						"ti-1":  "ti-1_mimir-12345",
+						"mti-1": "mti-1_mimir-12345",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This will make them more usable with managed route

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core config-merge logic and rename propagation through routing trees; while mostly refactoring, mistakes could cause incorrect routing/interval references after merges.
> 
> **Overview**
> Refactors merge outputs to return a single `RenameResources` struct (embedded in `MergeResult`) instead of separate `RenamedReceivers`/`RenamedTimeIntervals` maps.
> 
> Extracts reusable helpers: `RenameResourceUsagesInRoutes` (renames receiver and time-interval references throughout route trees) and `DeduplicateResources` (computes rename maps for conflicting receivers/time intervals without performing a full merge), and exports inhibit-rule merging via `MergeInhibitRules`.
> 
> Updates merge tests to assert the new result shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 363253d28bae4d3d4a0c065cde32a308e00a836a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->