### PR TITLE
Optional Merging matchers

### DIFF
--- a/definition/merge.go
+++ b/definition/merge.go
@@ -161,7 +161,7 @@ func Merge(a, b PostableApiAlertingConfig, opts MergeOpts) (MergeResult, error) 
 	}
 
 	route := a.Route
-	var inhibitRules []config.InhibitRule
+	inhibitRules := a.InhibitRules
 	if len(opts.SubtreeMatchers) > 0 {
 		RenameResourceUsagesInRoutes([]*Route{b.Route}, renamed)
 		if route == nil {
@@ -171,7 +171,7 @@ func Merge(a, b PostableApiAlertingConfig, opts MergeOpts) (MergeResult, error) 
 			return MergeResult{}, fmt.Errorf("cannot merge undefined routing tree")
 		}
 		route = MergeRoutes(*route, *b.Route, opts.SubtreeMatchers)
-		inhibitRules = MergeInhibitRules(a.InhibitRules, b.InhibitRules, opts.SubtreeMatchers)
+		inhibitRules = MergeInhibitRules(inhibitRules, b.InhibitRules, opts.SubtreeMatchers)
 	}
 
 	return MergeResult{

--- a/definition/merge.go
+++ b/definition/merge.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	ErrNoMatchers              = errors.New("matchers must not be empty")
 	ErrInvalidMatchers         = errors.New("only equality matchers are allowed")
 	ErrDuplicateMatchers       = errors.New("matchers should be unique")
 	ErrSubtreeMatchersConflict = errors.New("subtree matchers conflict with existing Grafana routes, merging will break existing notifications")
@@ -65,9 +64,6 @@ type MergeOpts struct {
 }
 
 func (o MergeOpts) Validate() error {
-	if len(o.SubtreeMatchers) == 0 {
-		return ErrNoMatchers
-	}
 	seenNames := make(map[string]struct{}, len(o.SubtreeMatchers))
 	for _, matcher := range o.SubtreeMatchers {
 		if _, ok := seenNames[matcher.Name]; ok {
@@ -138,12 +134,15 @@ func Merge(a, b PostableApiAlertingConfig, opts MergeOpts) (MergeResult, error) 
 	if err := opts.Validate(); err != nil {
 		return MergeResult{}, err
 	}
-	match, err := checkIfMatchersUsed(opts.SubtreeMatchers, a.Route.Routes)
-	if err != nil {
-		return MergeResult{}, err
-	}
-	if match {
-		return MergeResult{}, fmt.Errorf("%w: sub tree matchers: %s", ErrSubtreeMatchersConflict, opts.SubtreeMatchers)
+
+	if len(opts.SubtreeMatchers) > 0 {
+		match, err := checkIfMatchersUsed(opts.SubtreeMatchers, a.Route.Routes)
+		if err != nil {
+			return MergeResult{}, err
+		}
+		if match {
+			return MergeResult{}, fmt.Errorf("%w: sub tree matchers: %s", ErrSubtreeMatchersConflict, opts.SubtreeMatchers)
+		}
 	}
 
 	mergedReceivers, renamedReceivers := MergeReceivers(a.Receivers, b.Receivers, opts.DedupSuffix)
@@ -161,17 +160,19 @@ func Merge(a, b PostableApiAlertingConfig, opts MergeOpts) (MergeResult, error) 
 		TimeIntervals: renamedTimeIntervals,
 	}
 
-	RenameResourceUsagesInRoutes([]*Route{b.Route}, renamed)
-
-	if a.Route == nil {
-		return MergeResult{}, fmt.Errorf("cannot merge into undefined routing tree")
+	route := a.Route
+	var inhibitRules []config.InhibitRule
+	if len(opts.SubtreeMatchers) > 0 {
+		RenameResourceUsagesInRoutes([]*Route{b.Route}, renamed)
+		if route == nil {
+			return MergeResult{}, fmt.Errorf("cannot merge into undefined routing tree")
+		}
+		if b.Route == nil {
+			return MergeResult{}, fmt.Errorf("cannot merge undefined routing tree")
+		}
+		route = MergeRoutes(*route, *b.Route, opts.SubtreeMatchers)
+		inhibitRules = MergeInhibitRules(a.InhibitRules, b.InhibitRules, opts.SubtreeMatchers)
 	}
-	if b.Route == nil {
-		return MergeResult{}, fmt.Errorf("cannot merge undefined routing tree")
-	}
-	route := mergeRoutes(*a.Route, *b.Route, opts.SubtreeMatchers)
-
-	inhibitRules := MergeInhibitRules(a.InhibitRules, b.InhibitRules, opts.SubtreeMatchers)
 
 	return MergeResult{
 		Config: PostableApiAlertingConfig{
@@ -259,7 +260,7 @@ func createIndexTimeIntervals(
 	return usedNames
 }
 
-func mergeRoutes(a, b Route, matcher config.Matchers) *Route {
+func MergeRoutes(a, b Route, matcher config.Matchers) *Route {
 	// get a and b by value so we get shallow copies of the top level routes, which we can modify.
 	// make sure "b" route has all defaults set explicitly to avoid inheriting "a"'s default route settings.
 	defaultOpts := dispatch.DefaultRouteOpts

--- a/definition/merge_test.go
+++ b/definition/merge_test.go
@@ -383,7 +383,7 @@ func TestMerge(t *testing.T) {
 
 		full := load(t, fullMergedConfig)
 		full.Route.Routes = full.Route.Routes[1:]
-		full.InhibitRules = nil
+		full.InhibitRules = g.InhibitRules
 		full.Global = nil
 
 		diff := cmp.Diff(MergeResult{Config: *full}, result,

--- a/definition/merge_test.go
+++ b/definition/merge_test.go
@@ -22,11 +22,10 @@ func TestMergeOpts_Validate(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "error if subtree matchers are empty",
+			name: "no error if subtree matchers are empty",
 			opts: MergeOpts{
 				SubtreeMatchers: config.Matchers{},
 			},
-			expectedErr: ErrNoMatchers,
 		},
 		{
 			name: "error if subtree matchers are not equal",
@@ -370,6 +369,38 @@ func TestMerge(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, load(t, fullGrafanaConfig), g)
 		assert.Equal(t, load(t, fullMimirConfig), m)
+	})
+
+	t.Run("should skip merging routes and inhibition rules if matchers are empty", func(t *testing.T) {
+		g := load(t, fullGrafanaConfig)
+		m := load(t, fullMimirConfig)
+		opts := MergeOpts{
+			DedupSuffix:     "_mimir-12345",
+			SubtreeMatchers: config.Matchers{},
+		}
+		result, err := Merge(*g, *m, opts)
+		require.NoError(t, err)
+
+		full := load(t, fullMergedConfig)
+		full.Route.Routes = full.Route.Routes[1:]
+		full.InhibitRules = nil
+		full.Global = nil
+
+		diff := cmp.Diff(MergeResult{Config: *full}, result,
+			cmpopts.IgnoreUnexported(commoncfg.ProxyConfig{}, labels.Matcher{}),
+			cmpopts.SortSlices(func(a, b *labels.Matcher) bool {
+				return a.Name < b.Name
+			}),
+			cmpopts.SortSlices(func(a, b *PostableApiReceiver) bool {
+				return a.Name < b.Name
+			}),
+			cmpopts.EquateEmpty(),
+		)
+		if !assert.Empty(t, diff) {
+			data, err := yaml.Marshal(result.Config)
+			require.NoError(t, err)
+			t.Fatalf("YAML:\n%v", string(data))
+		}
 	})
 }
 


### PR DESCRIPTION
Since the introduction of managed routes, merging matchers semantics gets deprecated. 
This is the first step in deprecating them: matchers become optional. If extra config does not provide ones, the resulting config will not include routes and inhibition rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the semantics of config merging and can silently omit merged routes/inhibition rules when matchers are empty, potentially altering notification behavior depending on caller expectations.
> 
> **Overview**
> Makes `MergeOpts.SubtreeMatchers` optional by removing the “non-empty” validation requirement and gating all subtree conflict checks and route/inhibit-rule merging behind `len(SubtreeMatchers) > 0`.
> 
> When matchers are omitted, the merge now **only deduplicates/merges receivers and time intervals** and leaves the primary config’s routing tree and inhibit rules unchanged; route merge logic is also exported/renamed to `MergeRoutes` and tests are updated/added to cover the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e44b3f72f4f458ef8d74e0a0d2613baa01a8bcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->