### PR TITLE
[v12.3.x] Add limit to template expansion

### DIFF
--- a/notify/templates.go
+++ b/notify/templates.go
@@ -3,12 +3,15 @@ package notify
 import (
 	"bytes"
 	"context"
+	"errors"
+
 	tmpltext "text/template"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/template"
 
 	"github.com/grafana/alerting/templates"
+	"github.com/grafana/alerting/utils"
 )
 
 type TestTemplatesConfigBodyParams struct {
@@ -64,6 +67,7 @@ const (
 	DefaultReceiverName    = "TestReceiver"
 	DefaultGroupLabel      = "group_label"
 	DefaultGroupLabelValue = "group_label_value"
+	MaxTemplateOutputSize  = 1024 * 1024 // 1MB
 )
 
 // TemplateScope is the scope used to interpolate the template when testing.
@@ -115,11 +119,13 @@ func (am *GrafanaAlertmanager) GetTemplate(kind templates.Kind) (*template.Templ
 // If none of the more specific scopes work either, the original error is returned.
 func testTemplateScopes(newTextTmpl *tmpltext.Template, def string, data *templates.ExtendedData) (string, TemplateScope, error) {
 	var buf bytes.Buffer
-	defaultErr := newTextTmpl.ExecuteTemplate(&buf, def, data)
+	defaultErr := newTextTmpl.ExecuteTemplate(utils.NewLimitedWriter(&buf, MaxTemplateOutputSize), def, data)
 	if defaultErr == nil {
 		return buf.String(), rootScope, nil
 	}
-
+	if errors.Is(defaultErr, utils.ErrWriteLimitExceeded) {
+		return "", rootScope, templates.ErrTemplateOutputTooLarge
+	}
 	// Before returning this error, we try others scopes to see if the error is due to the template being intended
 	// to be used with a specific scope, such as ".Alerts" or ".Alert". If none of these scopes work, we return
 	// the original error.
@@ -127,11 +133,13 @@ func testTemplateScopes(newTextTmpl *tmpltext.Template, def string, data *templa
 	// caller to provide the correct scope.
 	for _, scope := range []TemplateScope{alertsScope, alertScope} {
 		var buf bytes.Buffer
-		err := newTextTmpl.ExecuteTemplate(&buf, def, scope.Data(data))
+		err := newTextTmpl.ExecuteTemplate(utils.NewLimitedWriter(&buf, MaxTemplateOutputSize), def, scope.Data(data))
 		if err == nil {
 			return buf.String(), scope, nil
 		}
+		if errors.Is(err, utils.ErrWriteLimitExceeded) {
+			return "", rootScope, templates.ErrTemplateOutputTooLarge
+		}
 	}
-
 	return "", rootScope, defaultErr
 }

--- a/notify/templates_test.go
+++ b/notify/templates_test.go
@@ -350,6 +350,19 @@ func TestTemplateSpecialCases(t *testing.T) {
 			}},
 			Errors: nil,
 		},
+	}, {
+		name: "error on really big template",
+		input: TestTemplatesConfigBodyParams{
+			Alerts:   []*amv2.PostableAlert{&simpleAlert},
+			Name:     "",
+			Template: fmt.Sprintf("{{- $spaces := printf \"%%%ds\" \"\" }}{{- range $i := (len $spaces) }}.{{- end }}", MaxTemplateOutputSize+1),
+		},
+		expected: TestTemplatesResults{
+			Errors: []TestTemplatesErrorResult{{
+				Kind:  ExecutionError,
+				Error: templates.ErrTemplateOutputTooLarge.Error(),
+			}},
+		},
 	},
 	}
 

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/templates/gomplate"
+	"github.com/grafana/alerting/utils"
 )
 
 type KV = template.KV
@@ -32,8 +34,10 @@ type Template = template.Template
 
 var (
 	// Provides current time. Can be overwritten in tests.
-	timeNow        = time.Now
-	ErrInvalidKind = errors.New("invalid template kind")
+	timeNow                   = time.Now
+	ErrInvalidKind            = errors.New("invalid template kind")
+	ErrTemplateOutputTooLarge = errors.New("template output exceeds maximum size")
+	MaxTemplateOutputSize     = int64(10 * 1024 * 1024) // TODO replace it to configuration
 )
 
 // Kind represents the type or category of a template. It is used to differentiate between various template kinds.
@@ -374,9 +378,30 @@ func TmplText(ctx context.Context, tmpl *Template, alerts []*types.Alert, l log.
 		if *tmplErr != nil {
 			return
 		}
-		s, *tmplErr = tmpl.ExecuteTextString(name, data)
+		s, *tmplErr = executeTextString(tmpl, name, data)
 		return s
 	}, data
+}
+
+// This is a copy of method ExecuteTextString of Template with addition of utils.LimitedWriter
+func executeTextString(tmpl *Template, text string, data *ExtendedData) (string, error) {
+	if text == "" {
+		return "", nil
+	}
+	textTmpl, err := tmpl.Text()
+	if err != nil {
+		return "", err
+	}
+	textTmpl, err = textTmpl.New("").Option("missingkey=zero").Parse(text)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	err = textTmpl.Execute(utils.NewLimitedWriter(&buf, MaxTemplateOutputSize), data)
+	if errors.Is(err, utils.ErrWriteLimitExceeded) {
+		err = ErrTemplateOutputTooLarge
+	}
+	return buf.String(), err
 }
 
 // Firing returns the subset of alerts that are firing.

--- a/templates/template_data_test.go
+++ b/templates/template_data_test.go
@@ -1,0 +1,171 @@
+package templates
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/models"
+)
+
+func TestTmplText(t *testing.T) {
+	constNow := time.Now()
+	defer mockTimeNow(constNow)()
+
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels: model.LabelSet{
+					"alertname":             "TestAlert",
+					"severity":              "critical",
+					models.FolderTitleLabel: "test-folder",
+					models.RuleUIDLabel:     "test-rule-uid",
+				},
+				Annotations: model.LabelSet{
+					"summary":     "Test summary",
+					"description": "Test description",
+					"__orgId__":   "1",
+				},
+				StartsAt:     constNow,
+				EndsAt:       constNow.Add(1 * time.Hour),
+				GeneratorURL: "http://localhost/alert",
+			},
+		},
+	}
+	tmpl, err := fromContent(defaultTemplatesPerKind(GrafanaKind), defaultOptionsPerKind(GrafanaKind, "grafana")...)
+	require.NoError(t, err)
+
+	externalURL, err := url.Parse("http://localhost/grafana")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+	l := log.NewNopLogger()
+
+	t.Run("should execute simple template successfully", func(t *testing.T) {
+		var tmplErr error
+		expand, data := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		result := expand("{{ len .Alerts }}")
+		assert.NoError(t, tmplErr)
+		assert.Equal(t, "1", result)
+		assert.NotNil(t, data)
+		assert.Len(t, data.Alerts, 1)
+	})
+
+	t.Run("should execute multiple templates in sequence", func(t *testing.T) {
+		var tmplErr error
+		expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		result1 := expand("{{ len .Alerts }}")
+		assert.NoError(t, tmplErr)
+		assert.Equal(t, "1", result1)
+
+		result2 := expand("{{ .Status }}")
+		assert.NoError(t, tmplErr)
+		assert.Equal(t, "firing", result2)
+	})
+
+	t.Run("should propagate template parsing error", func(t *testing.T) {
+		var tmplErr error
+		expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		// Invalid template syntax
+		result := expand("{{ .InvalidField }")
+		assert.Error(t, tmplErr)
+		assert.Empty(t, result)
+		// Just verify there's an error, don't check specific message
+	})
+
+	t.Run("should not execute subsequent templates after error", func(t *testing.T) {
+		var tmplErr error
+		expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		// First template with error
+		result1 := expand("{{ .InvalidField }")
+		assert.Error(t, tmplErr)
+		assert.Empty(t, result1)
+
+		// Second template should not execute
+		result2 := expand("{{ len .Alerts }}")
+		assert.Error(t, tmplErr) // Error persists
+		assert.Empty(t, result2) // Should return empty string
+	})
+
+	t.Run("should handle empty template string", func(t *testing.T) {
+		var tmplErr error
+		expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		result := expand("")
+		assert.NoError(t, tmplErr)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("should include extended data fields", func(t *testing.T) {
+		var tmplErr error
+		_, data := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		assert.NotNil(t, data)
+		assert.Equal(t, "http://localhost/grafana", data.ExternalURL)
+		assert.Len(t, data.Alerts, 1)
+		assert.Equal(t, "TestAlert", data.Alerts[0].Labels["alertname"])
+	})
+
+	t.Run("should extract group key from context", func(t *testing.T) {
+		// Create context with group key
+		ctx := context.Background()
+		groupKey := "test-group-key"
+		ctx = notify.WithGroupKey(ctx, groupKey)
+
+		var tmplErr error
+		_, data := TmplText(ctx, tmpl, alerts, l, &tmplErr)
+
+		assert.NotNil(t, data)
+		assert.Equal(t, groupKey, data.GroupKey)
+	})
+
+	t.Run("should handle context without group key", func(t *testing.T) {
+		var tmplErr error
+		_, data := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		assert.NotNil(t, data)
+		assert.Equal(t, "", data.GroupKey) // Should be empty when not in context
+	})
+
+	t.Run("should allow template output under size limit", func(t *testing.T) {
+		var tmplErr error
+		expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		// Small output should work
+		result := expand("{{ range .Alerts }}{{ .Labels.alertname }}{{ end }}")
+		assert.NoError(t, tmplErr)
+		assert.Equal(t, "TestAlert", result)
+	})
+
+	t.Run("should reject template output exceeding size limit", func(t *testing.T) {
+		// Save original limit and restore after test
+		originalLimit := MaxTemplateOutputSize
+		defer func() { MaxTemplateOutputSize = originalLimit }()
+
+		// Set a small limit for testing (1 KB)
+		MaxTemplateOutputSize = 1024
+
+		var tmplErr error
+		expand, _ := TmplText(context.Background(), tmpl, alerts, l, &tmplErr)
+
+		// Create a template that generates output larger than 1 KB by repeating a pattern
+		largeTemplate := `{{ range .Alerts }}` + strings.Repeat("X", 2000) + `{{ end }}`
+
+		result := expand(largeTemplate)
+		assert.Error(t, tmplErr)
+		assert.ErrorIs(t, tmplErr, ErrTemplateOutputTooLarge)
+		assert.NotEmpty(t, result) // Should contain partial output up to limit
+	})
+}

--- a/utils/limited_writer.go
+++ b/utils/limited_writer.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"errors"
+	"io"
+)
+
+var ErrWriteLimitExceeded = errors.New("write limit exceeded")
+
+// LimitedWriter wraps an io.Writer and limits the total bytes written.
+type LimitedWriter struct {
+	w       io.Writer // underlying writer
+	limit   int64     // max bytes allowed
+	written int64     // bytes written so far
+}
+
+// Write implements io.Writer.
+func (lw *LimitedWriter) Write(p []byte) (n int, err error) {
+	// If already at limit, reject immediately.
+	if lw.written >= lw.limit {
+		return 0, ErrWriteLimitExceeded
+	}
+
+	// Calculate how much we can write without exceeding the limit.
+	remaining := lw.limit - lw.written
+	exceeded := false
+	if int64(len(p)) > remaining {
+		// Only write up to the limit.
+		p = p[:remaining]
+		exceeded = true
+	}
+
+	// Perform the write.
+	n, writeErr := lw.w.Write(p)
+	lw.written += int64(n)
+
+	// If underlying write failed, return that error.
+	if writeErr != nil {
+		return n, writeErr
+	}
+
+	// If this write filled to the limit, return error to prevent further writes.
+	if exceeded {
+		return n, ErrWriteLimitExceeded
+	}
+
+	return n, nil
+}
+
+// NewLimitedWriter creates a new LimitedWriter.
+func NewLimitedWriter(w io.Writer, limit int64) io.Writer {
+	if limit <= 0 {
+		return w
+	}
+	return &LimitedWriter{w: w, limit: limit}
+}

--- a/utils/limited_writer_test.go
+++ b/utils/limited_writer_test.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitedWriter(t *testing.T) {
+	tests := []struct {
+		name          string
+		limit         int64
+		writes        [][]byte
+		expectedData  string
+		expectedError error
+		errorOnWrite  int // which write should return an error (0-indexed)
+	}{
+		{
+			name:         "single write under limit",
+			limit:        100,
+			writes:       [][]byte{[]byte("hello")},
+			expectedData: "hello",
+		},
+		{
+			name:         "single write exactly at limit",
+			limit:        5,
+			writes:       [][]byte{[]byte("hello")},
+			expectedData: "hello",
+		},
+		{
+			name:          "single write exceeds limit",
+			limit:         5,
+			writes:        [][]byte{[]byte("hello world")},
+			expectedData:  "hello",
+			expectedError: ErrWriteLimitExceeded,
+			errorOnWrite:  1,
+		},
+		{
+			name:         "multiple writes under limit",
+			limit:        20,
+			writes:       [][]byte{[]byte("hello"), []byte(" "), []byte("world")},
+			expectedData: "hello world",
+		},
+		{
+			name:         "multiple writes exactly at limit",
+			limit:        11,
+			writes:       [][]byte{[]byte("hello"), []byte(" "), []byte("world")},
+			expectedData: "hello world",
+		},
+		{
+			name:          "multiple writes exceed limit on second write",
+			limit:         10,
+			writes:        [][]byte{[]byte("hello"), []byte(" world")},
+			expectedData:  "hello worl",
+			expectedError: ErrWriteLimitExceeded,
+			errorOnWrite:  2,
+		},
+		{
+			name:          "multiple writes exceed limit on third write",
+			limit:         8,
+			writes:        [][]byte{[]byte("hello"), []byte(" wo"), []byte("rld")},
+			expectedData:  "hello wo",
+			expectedError: ErrWriteLimitExceeded,
+			errorOnWrite:  3,
+		},
+		{
+			name:          "write after hitting limit",
+			limit:         5,
+			writes:        [][]byte{[]byte("hello"), []byte("world")},
+			expectedData:  "hello",
+			expectedError: ErrWriteLimitExceeded,
+			errorOnWrite:  2,
+		},
+		{
+			name:          "write after exceeding limit",
+			limit:         3,
+			writes:        [][]byte{[]byte("hello"), []byte("world")},
+			expectedData:  "hel",
+			expectedError: ErrWriteLimitExceeded,
+			errorOnWrite:  1,
+		},
+		{
+			name:         "zero byte writes",
+			limit:        10,
+			writes:       [][]byte{[]byte("hello"), []byte(""), []byte("world")},
+			expectedData: "helloworld",
+		},
+		{
+			name:         "empty writes only",
+			limit:        10,
+			writes:       [][]byte{[]byte(""), []byte(""), []byte("")},
+			expectedData: "",
+		},
+		{
+			name:         "write to zero limit",
+			limit:        0,
+			writes:       [][]byte{[]byte("hello")},
+			expectedData: "hello",
+		},
+		{
+			name:          "many small writes exceed limit",
+			limit:         10,
+			writes:        [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e"), []byte("f"), []byte("g"), []byte("h"), []byte("i"), []byte("j"), []byte("k")},
+			expectedData:  "abcdefghij",
+			expectedError: ErrWriteLimitExceeded,
+			errorOnWrite:  11,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			lw := NewLimitedWriter(buf, tt.limit)
+
+			var err error
+			var errIndex int
+			for i, data := range tt.writes {
+				_, err = lw.Write(data)
+				if err != nil {
+					errIndex = i
+					break
+				}
+			}
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError, "expected error %v, got %v", tt.expectedError, err)
+				assert.Equal(t, tt.errorOnWrite, errIndex+1, "expected error on write %d, got %d", tt.errorOnWrite, errIndex)
+			} else {
+				require.NoErrorf(t, err, "expected no error, got %v on write %d", err, errIndex)
+			}
+			assert.Equal(t, tt.expectedData, buf.String(), "written data mismatch")
+		})
+	}
+}
+
+func TestLimitedWriter_UnderlyingWriterError(t *testing.T) {
+	expectedErr := errors.New("underlying writer error")
+
+	// Create a writer that always fails
+	failWriter := &failingWriter{err: expectedErr}
+	lw := NewLimitedWriter(failWriter, 100)
+
+	n, err := lw.Write([]byte("hello"))
+
+	// Should get the underlying writer's error, not the limit error
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 0, n)
+}
+
+func TestLimitedWriter_PartialWriteFromUnderlyingWriter(t *testing.T) {
+	// Create a writer that only writes 3 bytes at a time
+	buf := &bytes.Buffer{}
+	partialWriter := &partialWriter{w: buf, maxBytes: 3}
+	lw := NewLimitedWriter(partialWriter, 100)
+
+	n, err := lw.Write([]byte("hello"))
+
+	// Should write only 3 bytes and return no error
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "hel", buf.String())
+}
+
+// failingWriter is a writer that always returns an error
+type failingWriter struct {
+	err error
+}
+
+func (w *failingWriter) Write(p []byte) (n int, err error) {
+	return 0, w.err
+}
+
+// partialWriter is a writer that only writes a limited number of bytes per call
+type partialWriter struct {
+	w        io.Writer
+	maxBytes int
+}
+
+func (w *partialWriter) Write(p []byte) (n int, err error) {
+	if len(p) > w.maxBytes {
+		p = p[:w.maxBytes]
+	}
+	return w.w.Write(p)
+}


### PR DESCRIPTION
Backport of https://github.com/grafana/alerting/pull/437 to version branch v12.3.x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core template rendering paths and changes error behavior when output is large, which could affect existing integrations relying on previous unlimited output or error messages.
> 
> **Overview**
> Adds a hard cap to rendered template output by introducing `utils.LimitedWriter` and using it during template execution in both `notify.TestTemplate` scope testing and `templates.TmplText` expansion.
> 
> When the limit is hit, execution now fails with a dedicated `ErrTemplateOutputTooLarge` error (surfaced as `templates.ErrTemplateOutputTooLarge` in the notify test endpoint). New unit tests cover the writer behavior and verify oversized templates are rejected while normal templates still render correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96508643d38be41148f4a0745fc24f296da15c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->