### PR TITLE
Populate messages for more receivers with ExtraData if present

### DIFF
--- a/receivers/email/v1/email.go
+++ b/receivers/email/v1/email.go
@@ -85,6 +85,9 @@ func (en *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, e
 		level.Warn(l).Log("msg", "failed to get all images for email", "err", err)
 	}
 
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
+
 	cmd := &receivers.SendEmailSettings{
 		Subject: subject,
 		Data: map[string]interface{}{

--- a/receivers/mqtt/v1/mqtt.go
+++ b/receivers/mqtt/v1/mqtt.go
@@ -124,6 +124,10 @@ func (n *Notifier) buildMessage(ctx context.Context, l log.Logger, as ...*types.
 
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, n.tmpl, as, l, &tmplErr)
+
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
+
 	messageText := tmpl(n.settings.Message)
 	if tmplErr != nil {
 		level.Warn(l).Log("msg", "Failed to template MQTT message", "err", tmplErr.Error())

--- a/receivers/oncall/v1/oncall.go
+++ b/receivers/oncall/v1/oncall.go
@@ -88,15 +88,8 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		},
 		as...)
 
-	// Augment extended Alert data with any extra data if provided
-	// If there is no extra data in the context or it is malformed,
-	// we simply continue without erroring
-	extraData, ok := receivers.GetExtraDataFromContext(ctx)
-	if ok && len(data.Alerts) == len(extraData) {
-		for i, ed := range extraData {
-			data.Alerts[i].ExtraData = ed
-		}
-	}
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	msg := &oncallMessage{
 		Version:         "1",

--- a/receivers/opsgenie/v1/opsgenie.go
+++ b/receivers/opsgenie/v1/opsgenie.go
@@ -119,6 +119,9 @@ func (on *Notifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alert
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, on.tmpl, as, l, &tmplErr)
 
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
+
 	message, truncated := receivers.TruncateInRunes(tmpl(on.settings.Message), opsGenieMaxMessageLenRunes)
 	if truncated {
 		level.Warn(l).Log("msg", "truncated message", "alert", key, "max_runes", opsGenieMaxMessageLenRunes)

--- a/receivers/pagerduty/v1/pagerduty.go
+++ b/receivers/pagerduty/v1/pagerduty.go
@@ -123,6 +123,9 @@ func (pn *Notifier) buildPagerdutyMessage(ctx context.Context, alerts model.Aler
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, pn.tmpl, as, l, &tmplErr)
 
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
+
 	details := make(map[string]string, len(pn.settings.Details))
 	for k, v := range pn.settings.Details {
 		detail, err := pn.tmpl.ExecuteTextString(v, data)

--- a/receivers/slack/v1/slack.go
+++ b/receivers/slack/v1/slack.go
@@ -283,6 +283,10 @@ func commonAlertGeneratorURL(_ context.Context, alerts templates.ExtendedAlerts)
 func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Alert, l log.Logger) (*slackMessage, *templates.ExtendedData, error) {
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, sn.tmpl, alerts, l, &tmplErr)
+
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
+
 	ruleURL := receivers.JoinURLPath(sn.tmpl.ExternalURL.String(), "/alerting/list", l)
 
 	// If all alerts have the same GeneratorURL, use that.

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -235,3 +235,23 @@ func GetExtraDataFromContext(ctx context.Context) ([]json.RawMessage, bool) {
 	v, ok := ctx.Value(ExtraDataKey).([]json.RawMessage)
 	return v, ok
 }
+
+// ApplyExtraData augments the extended Alert data with any extra data if provided in the context.
+// If there is no extra data in the context or the length of extra data doesn't match the number
+// of alerts, the function does nothing. This allows callers to safely use this helper without
+// needing to handle errors.
+func ApplyExtraData(ctx context.Context, alerts ExtraDataAlerts) {
+	extraData, ok := GetExtraDataFromContext(ctx)
+	if ok && alerts.Len() == len(extraData) {
+		for i, ed := range extraData {
+			alerts.SetExtraData(i, ed)
+		}
+	}
+}
+
+// ExtraDataAlerts is an interface that allows setting extra data on a slice of alerts.
+// This is implemented by templates.ExtendedAlerts.
+type ExtraDataAlerts interface {
+	Len() int
+	SetExtraData(index int, data json.RawMessage)
+}

--- a/receivers/webex/v1/webex.go
+++ b/receivers/webex/v1/webex.go
@@ -50,6 +50,9 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, wn.tmpl, as, l, &tmplErr)
 
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
+
 	message, truncated := receivers.TruncateInBytes(tmpl(wn.settings.Message), 4096)
 	if truncated {
 		level.Warn(l).Log("msg", "Webex message too long, truncating message", "originalMessage", wn.settings.Message)

--- a/receivers/webhook/v1/webhook.go
+++ b/receivers/webhook/v1/webhook.go
@@ -90,15 +90,8 @@ func (wn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		state = string(receivers.AlertStateAlerting)
 	}
 
-	// Augment extended Alert data with any extra data if provided
-	// If there is no extra data in the context or it is malformed,
-	// we simply continue without erroring
-	extraData, ok := receivers.GetExtraDataFromContext(ctx)
-	if ok && len(data.Alerts) == len(extraData) {
-		for i, ed := range extraData {
-			data.Alerts[i].ExtraData = ed
-		}
-	}
+	// Augment extended Alert data with any extra data if provided.
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	// Provide variables to the template for use in the custom payload.
 	for k, v := range wn.settings.Payload.Vars {

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -414,6 +414,16 @@ func executeTextString(tmpl *Template, text string, data *ExtendedData) (string,
 	return buf.String(), err
 }
 
+// Len returns the number of alerts.
+func (as ExtendedAlerts) Len() int {
+	return len(as)
+}
+
+// SetExtraData sets the extra data for the alert at the given index.
+func (as ExtendedAlerts) SetExtraData(index int, data json.RawMessage) {
+	as[index].ExtraData = data
+}
+
 // Firing returns the subset of alerts that are firing.
 func (as ExtendedAlerts) Firing() []ExtendedAlert {
 	res := []ExtendedAlert{}


### PR DESCRIPTION
If there is `ExtraData` present in the `ctx`, then adds it to the message payload for the following additional receivers:
- `email`
- `mqtt`
- `opsgenie`
- `pagerduty`
- `slack`
- `webex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outward notification content across multiple integrations when `ExtraData` is present, which could affect downstream consumers/templates. Guarded by a length check and no behavior change when `ExtraData` is absent or mismatched.
> 
> **Overview**
> Propagates per-alert `ExtraData` provided via `context.Context` into the templating/payload data for more receivers (`email`, `mqtt`, `opsgenie`, `pagerduty`, `slack`, `webex`), so templates and JSON payloads can reference `.Alerts[i].ExtraData`.
> 
> Refactors the prior ad-hoc implementations in `oncall`/`webhook` into a shared `receivers.ApplyExtraData` helper plus a small interface, and updates `templates.ExtendedAlerts` to support that interface. Adds focused `TestNotify_ExtraData` coverage for each newly-supported receiver.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24bc2dfc523fb344069f3b2ece41a1d00443a17d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->