### PR TITLE
Revert Opsgenie deprecation

### DIFF
--- a/receivers/opsgenie/v1/config.go
+++ b/receivers/opsgenie/v1/config.go
@@ -130,8 +130,8 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 
 var Schema = schema.IntegrationSchemaVersion{
 	Version:    Version,
-	CanCreate:  false,
-	Deprecated: true,
+	CanCreate:  true,
+	Deprecated: false,
 	Options: []schema.Field{
 		{
 			Label:        "API Key",


### PR DESCRIPTION
Opsgenie pushed EOL to April 5, 2027. So, undeprecating it for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change that affects UI/availability of the OpsGenie integration; no changes to runtime notification logic or data handling.
> 
> **Overview**
> Undeprecates the OpsGenie `v1` receiver integration by flipping its schema flags to allow creation again (`CanCreate: true`) and marking it as not deprecated (`Deprecated: false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b95d21748faf3e0b8d337c4bc48a145581dc484. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->