### PR TITLE
Notify: Improvements to Loki notification history writing.

### DIFF
--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -67,8 +67,9 @@ func TestRecord(t *testing.T) {
 						},
 						Values: []lokiclient.Sample{
 							{
-								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								T:        testNow,
+								V:        "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								Metadata: map[string]string{"receiver": testReceiverName, "rule_uid": "testRuleUID"},
 							},
 						},
 					},
@@ -86,8 +87,9 @@ func TestRecord(t *testing.T) {
 						},
 						Values: []lokiclient.Sample{
 							{
-								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								T:        testNow,
+								V:        "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								Metadata: map[string]string{"receiver": testReceiverName, "rule_uid": "testRuleUID"},
 							},
 						},
 					},

--- a/notify/historian/lokiclient/encode.go
+++ b/notify/historian/lokiclient/encode.go
@@ -42,10 +42,17 @@ func (e SnappyProtoEncoder) encode(s []Stream) ([]byte, error) {
 	for _, str := range s {
 		entries := make([]push.Entry, 0, len(str.Values))
 		for _, sample := range str.Values {
-			entries = append(entries, push.Entry{
+			entry := push.Entry{
 				Timestamp: sample.T,
 				Line:      sample.V,
-			})
+			}
+			if len(sample.Metadata) > 0 {
+				entry.StructuredMetadata = make(push.LabelsAdapter, 0, len(sample.Metadata))
+				for k, v := range sample.Metadata {
+					entry.StructuredMetadata = append(entry.StructuredMetadata, push.LabelAdapter{Name: k, Value: v})
+				}
+			}
+			entries = append(entries, entry)
 		}
 		body.Streams = append(body.Streams, push.Stream{
 			Labels:  labelsMapToString(str.Stream, ""),


### PR DESCRIPTION
Couple of small improvements:
- Write distinct timestamps for the individual alerts logs
- Write rule_uid and receiver structured metadata fields

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Loki push payload format (optional third tuple element / structured metadata) and timestamp behavior, which could affect compatibility with Loki deployments or downstream consumers if assumptions about sample shape/order exist.
> 
> **Overview**
> Notification history writes to Loki now assign **slightly different timestamps per alert** (nanosecond increments) so large multi-alert notifications can be paginated/retrieved correctly.
> 
> Each Loki sample can now include **structured metadata**; the historian populates `receiver` and `rule_uid`, and the Loki client/encoders are updated to marshal/unmarshal optional metadata and include it in Snappy-proto pushes. Tests are updated to assert the new metadata field while normalizing timestamps for determinism.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dd26b69ecda0578d1f363d27b983e2370f06bde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->