### PR TITLE
Notify: Add integration information to notification history.

### DIFF
--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -26,18 +26,20 @@ const (
 )
 
 type NotificationHistoryLokiEntry struct {
-	SchemaVersion int                               `json:"schemaVersion"`
-	Receiver      string                            `json:"receiver"`
-	GroupKey      string                            `json:"groupKey"`
-	Status        string                            `json:"status"`
-	GroupLabels   map[string]string                 `json:"groupLabels"`
-	Alert         NotificationHistoryLokiEntryAlert `json:"alert"`
-	AlertIndex    int                               `json:"alertIndex"`
-	AlertCount    int                               `json:"alertCount"`
-	Retry         bool                              `json:"retry"`
-	Error         string                            `json:"error,omitempty"`
-	Duration      int64                             `json:"duration"`
-	PipelineTime  time.Time                         `json:"pipelineTime"`
+	SchemaVersion  int                               `json:"schemaVersion"`
+	Receiver       string                            `json:"receiver"`
+	Integration    string                            `json:"integration"`
+	IntegrationIdx int                               `json:"integrationIdx"`
+	GroupKey       string                            `json:"groupKey"`
+	Status         string                            `json:"status"`
+	GroupLabels    map[string]string                 `json:"groupLabels"`
+	Alert          NotificationHistoryLokiEntryAlert `json:"alert"`
+	AlertIndex     int                               `json:"alertIndex"`
+	AlertCount     int                               `json:"alertCount"`
+	Retry          bool                              `json:"retry"`
+	Error          string                            `json:"error,omitempty"`
+	Duration       int64                             `json:"duration"`
+	PipelineTime   time.Time                         `json:"pipelineTime"`
 }
 
 type NotificationHistoryLokiEntryAlert struct {
@@ -140,18 +142,20 @@ func (h *NotificationHistorian) prepareStream(nhe nfstatus.NotificationHistoryEn
 	values := make([]lokiclient.Sample, len(nhe.Alerts))
 	for i := range nhe.Alerts {
 		entry := NotificationHistoryLokiEntry{
-			SchemaVersion: 1,
-			Receiver:      nhe.ReceiverName,
-			Status:        string(types.Alerts(as...).StatusAt(now)),
-			GroupKey:      nhe.GroupKey,
-			GroupLabels:   prepareLabels(nhe.GroupLabels),
-			Alert:         entryAlerts[i],
-			AlertIndex:    i,
-			AlertCount:    len(nhe.Alerts),
-			Retry:         nhe.Retry,
-			Error:         notificationErrStr,
-			Duration:      int64(nhe.Duration),
-			PipelineTime:  nhe.PipelineTime,
+			SchemaVersion:  1,
+			Receiver:       nhe.ReceiverName,
+			Integration:    nhe.IntegrationName,
+			IntegrationIdx: nhe.IntegrationIdx,
+			Status:         string(types.Alerts(as...).StatusAt(now)),
+			GroupKey:       nhe.GroupKey,
+			GroupLabels:    prepareLabels(nhe.GroupLabels),
+			Alert:          entryAlerts[i],
+			AlertIndex:     i,
+			AlertCount:     len(nhe.Alerts),
+			Retry:          nhe.Retry,
+			Error:          notificationErrStr,
+			Duration:       int64(nhe.Duration),
+			PipelineTime:   nhe.PipelineTime,
 		}
 
 		entryJSON, err := json.Marshal(entry)

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -68,7 +68,7 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
 							},
 						},
 					},
@@ -87,7 +87,7 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T: testNow,
-								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
+								V: "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
 							},
 						},
 					},
@@ -108,6 +108,8 @@ func TestRecord(t *testing.T) {
 					NotificationErr: tc.notificationErr,
 					Duration:        time.Second,
 					ReceiverName:    testReceiverName,
+					IntegrationName: "testIntegrationName",
+					IntegrationIdx:  42,
 					GroupLabels:     testGroupLabels,
 					PipelineTime:    testPipelineTime,
 				})

--- a/notify/nfstatus/integration_test.go
+++ b/notify/nfstatus/integration_test.go
@@ -144,6 +144,8 @@ func TestIntegrationWithNotificationHistorian(t *testing.T) {
 		NotificationErr: notifier.err,
 		Duration:        0,
 		ReceiverName:    testReceiverName,
+		IntegrationName: "foo",
+		IntegrationIdx:  42,
 		GroupLabels:     testGroupLabels,
 		PipelineTime:    testPipelineTime,
 	}


### PR DESCRIPTION
We record notification history per integration, so this needs to be present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive metadata change to notification history logging and related tests; minimal behavioral impact beyond a schema/payload change for Loki consumers.
> 
> **Overview**
> Notification history now records **per-integration metadata** by adding `integration` and `integrationIdx` to the Loki log entry payload.
> 
> This threads integration name/index through `nfstatus.NotificationHistoryEntry` and `statusCaptureNotifier`, ensuring `NotificationHistorian.Record` emits the new fields, and updates unit tests to assert the updated JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bd09aa537d30062017fd9b49948f88d7e2078ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->