### PR TITLE
Update prometheus-alertmanager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 )
 
 // Using a fork of the Alertmanager with Alerting Squad specific changes.
-replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260112162805-d29cc9cf7f0f
+replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260220111149-e5bb689fb805
 
 replace github.com/Unknwon/com v1.0.1 => github.com/unknwon/com v1.0.1
 

--- a/go.sum
+++ b/go.sum
@@ -878,8 +878,8 @@ github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000 h1:/5LKSYgLm
 github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000/go.mod h1:/ZklAgE1i4f3Z8uriXwESmCr1VLF8lBGaJspuaGuf78=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20260112162805-d29cc9cf7f0f h1:9tRhudagkQO2s61SLFLSziIdCm7XlkfypVKDxpcHokg=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20260112162805-d29cc9cf7f0f/go.mod h1:AsVdCBeDFN9QbgpJg+8voDAcgsW0RmNvBd70ecMMdC0=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20260220111149-e5bb689fb805 h1:0v+pu/95MadZSmRZecfukhJ6mZGhax3YB1691dpX9HY=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20260220111149-e5bb689fb805/go.mod h1:sWX4vzxYuH91qFCd2Khubo61VjbksxRcb7SDHs5SDig=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/notify/multiorg_alertmanager.go
+++ b/notify/multiorg_alertmanager.go
@@ -18,4 +18,5 @@ func (p *NilPeer) AddState(string, cluster.State, prometheus.Registerer) cluster
 
 type NilChannel struct{}
 
-func (c *NilChannel) Broadcast([]byte) {}
+func (c *NilChannel) Broadcast([]byte)             {}
+func (c *NilChannel) ReliableDelivery([]byte) bool { return true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency update to a forked Alertmanager plus a clustering-interface change could subtly affect alert delivery/cluster behavior if upstream semantics changed, though local code changes are minimal.
> 
> **Overview**
> Updates the `replace` directive for the Alertmanager fork to a newer `github.com/grafana/prometheus-alertmanager` pseudo-version (and refreshes `go.sum` accordingly).
> 
> Adjusts `notify/NilChannel` (used as a no-op implementation of the clustering channel) to satisfy an updated interface by adding `ReliableDelivery([]byte) bool` returning `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47054fb59564f91c354056da69074e735959c53d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->