### PR TITLE
Notify: Use alternative Notifer interface for passing ExtraData around.

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -60,9 +60,9 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-type WrapNotifierFunc func(integrationName string, notifier notify.Notifier) notify.Notifier
+type WrapNotifierFunc func(integrationName string, notifier nfstatus.Notifier) nfstatus.Notifier
 
-var NoWrap WrapNotifierFunc = func(_ string, notifier notify.Notifier) notify.Notifier { return notifier }
+var NoWrap WrapNotifierFunc = func(_ string, notifier nfstatus.Notifier) nfstatus.Notifier { return notifier }
 
 // BuildGrafanaReceiverIntegrations creates integrations for each configured notification channel in GrafanaReceiverConfig.
 // It returns a slice of Integration objects, one for each notification channel, along with any errors that occurred.
@@ -92,7 +92,7 @@ func BuildGrafanaReceiverIntegrations(
 				return
 			}
 			n := newInt(client)
-			notify := wrapNotifier(cfg.Name, n)
+			notify := wrapNotifier(cfg.Name, nfstatus.NewNotifierAdapter(n))
 			i := NewIntegration(notify, n, cfg.Type, idx, cfg.Name, notificationHistorian, logger)
 			integrations = append(integrations, i)
 		}
@@ -249,10 +249,11 @@ func BuildPrometheusReceiverIntegrations(
 				errs.Add(err)
 				return
 			}
+			nw := nfstatus.NewNotifierAdapter(n)
 			if wrapper != nil {
-				n = wrapper(name, n)
+				nw = wrapper(name, nw)
 			}
-			integrations = append(integrations, nfstatus.NewIntegration(n, rs, name, i, nc.Name, notificationHistorian, integrationLogger))
+			integrations = append(integrations, nfstatus.NewIntegration(nw, rs, name, i, nc.Name, notificationHistorian, integrationLogger))
 		}
 	)
 

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
@@ -34,7 +35,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 
 	emailService := receivers.MockNotificationService()
 
-	noopWrapper := func(_ string, n Notifier) Notifier {
+	noopWrapper := func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
 		return n
 	}
 
@@ -53,7 +54,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 		fullCfg, qty := getFullConfig(t)
 
 		wrapped := 0
-		notifyWrapper := func(_ string, n Notifier) Notifier {
+		notifyWrapper := func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
 			wrapped++
 			return n
 		}
@@ -170,7 +171,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			DecodeSecretsFromBase64,
 			emailService,
 			nil,
-			func(_ string, n notify.Notifier) notify.Notifier {
+			func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
 				return n
 			},
 			version,
@@ -217,7 +218,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			DecodeSecretsFromBase64,
 			emailService,
 			nil,
-			func(_ string, n notify.Notifier) notify.Notifier {
+			func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
 				return n
 			},
 			version,

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -12,8 +12,6 @@ import (
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-
-	"github.com/grafana/alerting/receivers"
 )
 
 type NotificationHistoryAlert struct {
@@ -64,8 +62,34 @@ type Integration struct {
 	integration *notify.Integration
 }
 
+// NotifyInfo is informational data about notification attempts.
+type NotifyInfo struct {
+	ExtraData []json.RawMessage
+}
+
+// Notifier is an extended version of notify.Notifier which returns the
+// context with any modifications made to it by intermediate hooks.
+type Notifier interface {
+	Notify(context.Context, ...*types.Alert) (NotifyInfo, bool, error)
+}
+
+// NotifierAdapter adapts an upstream notify.Notifier to our Notifier
+type NotifierAdapter struct {
+	n notify.Notifier
+}
+
+// NotifierAdapter adapts an upstream notify.Notifier to our Notifier
+func NewNotifierAdapter(n notify.Notifier) Notifier {
+	return NotifierAdapter{n: n}
+}
+
+func (n NotifierAdapter) Notify(ctx context.Context, alerts ...*types.Alert) (NotifyInfo, bool, error) {
+	retry, err := n.n.Notify(ctx, alerts...)
+	return NotifyInfo{}, retry, err
+}
+
 // NewIntegration returns a new integration.
-func NewIntegration(notifier notify.Notifier, rs notify.ResolvedSender, name string, idx int, receiverName string, notificationHistorian NotificationHistorian, logger log.Logger) *Integration {
+func NewIntegration(notifier Notifier, rs notify.ResolvedSender, name string, idx int, receiverName string, notificationHistorian NotificationHistorian, logger log.Logger) *Integration {
 	// Wrap the provided Notifier with our own, which will capture notification attempt errors.
 	status := &statusCaptureNotifier{
 		integrationName:       name,
@@ -134,7 +158,7 @@ func GetIntegrations(integrations []*Integration) []*notify.Integration {
 type statusCaptureNotifier struct {
 	integrationName       string
 	integrationIdx        int
-	upstream              notify.Notifier
+	upstream              Notifier
 	notificationHistorian NotificationHistorian
 	logger                log.Logger
 
@@ -147,10 +171,10 @@ type statusCaptureNotifier struct {
 // Notify implements the Notifier interface.
 func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
 	start := time.Now()
-	retry, err := n.upstream.Notify(ctx, alerts...)
+	info, retry, err := n.upstream.Notify(ctx, alerts...)
 	duration := time.Since(start)
 
-	go n.recordNotificationHistory(ctx, alerts, retry, err, duration)
+	go n.recordNotificationHistory(ctx, alerts, retry, err, duration, info)
 
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
@@ -162,7 +186,7 @@ func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Ale
 	return retry, err
 }
 
-func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, alerts []*types.Alert, retry bool, err error, duration time.Duration) {
+func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, alerts []*types.Alert, retry bool, err error, duration time.Duration, info NotifyInfo) {
 	if n.notificationHistorian == nil {
 		return
 	}
@@ -173,9 +197,8 @@ func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, a
 	pipelineTime, _ := notify.Now(ctx)
 	groupKey, _ := notify.GroupKey(ctx)
 
-	// Don't log/return because extra data is optional.
-	extraData, _ := receivers.GetExtraDataFromContext(ctx)
-
+	// Inject ExtraData into alerts.
+	extraData := info.ExtraData
 	entryAlerts := make([]NotificationHistoryAlert, len(alerts))
 	for i := range alerts {
 		entryAlerts[i] = NotificationHistoryAlert{

--- a/notify/nfstatus/integration_test.go
+++ b/notify/nfstatus/integration_test.go
@@ -24,9 +24,13 @@ type fakeNotifier struct {
 	err   error
 }
 
-func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (bool, error) {
+func (f *fakeNotifier) Notify(ctx context.Context, _ ...*types.Alert) (NotifyInfo, bool, error) {
 	time.Sleep(10 * time.Millisecond)
-	return f.retry, f.err
+	var info NotifyInfo
+	if extraData, ok := ctx.Value(receivers.ExtraDataKey).([]json.RawMessage); ok {
+		info.ExtraData = extraData
+	}
+	return info, f.retry, f.err
 }
 
 type fakeResolvedSender struct {

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/alertmanager/types"
 
+	"github.com/grafana/alerting/notify/nfstatus"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -85,8 +86,8 @@ func (f *FakeConfig) Raw() []byte {
 
 type fakeNotifier struct{}
 
-func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (bool, error) {
-	return true, nil
+func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (nfstatus.NotifyInfo, bool, error) {
+	return nfstatus.NotifyInfo{}, true, nil
 }
 
 func (f *fakeNotifier) SendResolved() bool {


### PR DESCRIPTION
We want the wrapped notifier hooks to be able to pass additional data to the
notification historian, which is currently not possible. We can, for the time
being, have our own Notifer interface which allows the wrapped notifiers
pass information back to the caller.

In the future we may need to consider changing the Notifier interface
everywhere, so that notifiers themselves can return metadata for logging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core notification integration wiring and the notification-history capture path; behavior should be unchanged except for how `ExtraData` is propagated, but wrapper/adapter mismatches could break sends or history recording.
> 
> **Overview**
> Adds an `nfstatus.Notifier` interface (returning `NotifyInfo`) plus an adapter from Prometheus `notify.Notifier`, allowing wrapped notifier hooks to return per-alert `ExtraData` alongside retry/error results.
> 
> Updates integration factories (`BuildGrafanaReceiverIntegrations`, `BuildPrometheusReceiverIntegrations`) and related tests to wrap notifiers via `nfstatus.NewNotifierAdapter` and to have notification history recording consume `NotifyInfo.ExtraData` (instead of reading extra data directly from context).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cbb3f53d4769812db038d691b624bce19f4ea28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->