### PR TITLE
Expose ChannelOption in ClusterPeer.AddState interface

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,5 +19,11 @@ var (
 )
 
 type ClusterChannel = cluster.ClusterChannel //nolint:revive
+type ChannelOption = cluster.ChannelOption
 type Peer = cluster.Peer
 type State = cluster.State
+
+var (
+	WithReliableDelivery = cluster.WithReliableDelivery
+	WithQueueSize        = cluster.WithQueueSize
+)

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 type ClusterPeer interface {
-	AddState(string, cluster.State, prometheus.Registerer) cluster.ClusterChannel
+	AddState(string, cluster.State, prometheus.Registerer, ...cluster.ChannelOption) cluster.ClusterChannel
 	Position() int
 	WaitReady(context.Context) error
 }

--- a/notify/multiorg_alertmanager.go
+++ b/notify/multiorg_alertmanager.go
@@ -12,7 +12,7 @@ type NilPeer struct{}
 
 func (p *NilPeer) Position() int                   { return 0 }
 func (p *NilPeer) WaitReady(context.Context) error { return nil }
-func (p *NilPeer) AddState(string, cluster.State, prometheus.Registerer) cluster.ClusterChannel {
+func (p *NilPeer) AddState(string, cluster.State, prometheus.Registerer, ...cluster.ChannelOption) cluster.ClusterChannel {
 	return &NilChannel{}
 }
 


### PR DESCRIPTION
- Expose `ChannelOption`, `WithReliableDelivery`, and `WithQueueSize` from the `cluster` package                                                                                                                                                              
- Update `ClusterPeer.AddState` interface to accept `...ChannelOption`                                               

The options were added in:
- https://github.com/grafana/prometheus-alertmanager/pull/144 (`WithReliableDelivery`)
- https://github.com/grafana/prometheus-alertmanager/pull/147 (`WithQueueSize`)

Part of https://github.com/grafana/grafana/issues/116545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, compile-time API surface change limited to clustering abstractions; main risk is downstream implementers needing to update `AddState` method signatures.
> 
> **Overview**
> Exposes `cluster.ChannelOption` (plus `WithReliableDelivery` and `WithQueueSize`) through the local `cluster` wrapper so callers can configure cluster channel behavior.
> 
> Updates the `ClusterPeer`/`NilPeer` `AddState` method signature to accept `...cluster.ChannelOption`, enabling per-state channel configuration without changing the returned `ClusterChannel` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e8538d5315d44a7b099da9ae9e1b5112b66a1d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->