### PR TITLE
Add method Kinds to template factory

### DIFF
--- a/templates/factory.go
+++ b/templates/factory.go
@@ -2,7 +2,9 @@ package templates
 
 import (
 	"fmt"
+	"maps"
 	"net/url"
+	"slices"
 	"sync"
 
 	"github.com/go-kit/log"
@@ -79,6 +81,11 @@ func (tp *Factory) GetTemplate(kind Kind) (*Template, error) {
 		*t.ExternalURL = *tp.cfg.ExternalURL
 	}
 	return result, nil
+}
+
+// Kinds returns kinds that have user-defined templates
+func (tp *Factory) Kinds() []Kind {
+	return slices.Collect(maps.Keys(tp.templates))
 }
 
 // WithTemplate creates a new factory that has the provided TemplateDefinition. If definition with the same name already exists for this kind, it is replaced.

--- a/templates/factory_test.go
+++ b/templates/factory_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
+	"slices"
 	"testing"
 	"time"
 
@@ -62,6 +63,8 @@ func TestNewFactory(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+
+			assert.ElementsMatch(t, slices.Collect(maps.Keys(tc.expected)), factory.Kinds())
 			// Validate the templates map
 			for kind, expectedTemplates := range tc.expected {
 				require.ElementsMatch(t, expectedTemplates, factory.templates[kind])


### PR DESCRIPTION
Adds a method to provide available kinds of user defined templates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API and a test update; no changes to template rendering, parsing, or validation paths.
> 
> **Overview**
> Adds `Factory.Kinds()` to list which `Kind`s currently have user-defined templates loaded (derived from the factory’s internal templates map).
> 
> Updates `TestNewFactory` to assert the returned kinds match the expected set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f9a2880e17f382a27b615b4748599e6f60aa388. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->