### PR TITLE
Notify: Rework historian persistance format.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/grafana/dskit v0.0.0-20250818234656-8ff9c6532e85
 	github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000
 	github.com/json-iterator/go v1.1.12
@@ -64,7 +65,6 @@ require (
 	github.com/gogo/status v1.1.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -27,7 +27,7 @@ const (
 	LokiClientSpanName              = "ngalert.notification-historian.client"
 	NotificationHistoryWriteTimeout = time.Minute
 	LabelFrom                       = "from"
-	LabelFromValue                  = "notify-history"
+	LabelFromValue                  = "notify-history-events"
 	LabelFromValueAlerts            = "notify-history-alerts"
 	SchemaVersion                   = 2
 )

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -66,7 +66,7 @@ func TestRecord(t *testing.T) {
 					{
 						Stream: map[string]string{
 							"externalLabelKey": "externalLabelValue",
-							"from":             "notify-history",
+							"from":             "notify-history-events",
 						},
 						Values: []lokiclient.Sample{
 							{
@@ -99,7 +99,7 @@ func TestRecord(t *testing.T) {
 					{
 						Stream: map[string]string{
 							"externalLabelKey": "externalLabelValue",
-							"from":             "notify-history",
+							"from":             "notify-history-events",
 						},
 						Values: []lokiclient.Sample{
 							{

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -26,7 +26,10 @@ import (
 	"github.com/grafana/alerting/notify/nfstatus"
 )
 
-const testReceiverName = "testReceiverName"
+const (
+	testReceiverName = "testReceiverName"
+	testUUID         = "00000000-0000-0000-0000-000000000001"
+)
 
 var (
 	testGroupLabels  = model.LabelSet{"foo": "bar"}
@@ -56,10 +59,10 @@ func TestRecord(t *testing.T) {
 			expected        []lokiclient.Stream
 		}{
 			{
-				"successful notification",
-				false,
-				nil,
-				[]lokiclient.Stream{
+				name:            "successful notification",
+				retry:           false,
+				notificationErr: nil,
+				expected: []lokiclient.Stream{
 					{
 						Stream: map[string]string{
 							"externalLabelKey": "externalLabelValue",
@@ -68,18 +71,31 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":false,\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
-								Metadata: map[string]string{"receiver": testReceiverName, "rule_uid": "testRuleUID"},
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","ruleUIDs":["testRuleUID"],"receiver":"testReceiverName","integration":"testIntegrationName","integrationIdx":42,"groupKey":"testGroupKey","status":"resolved","groupLabels":{"foo":"bar"},"alertCount":1,"retry":false,"duration":1000000000,"pipelineTime":"2025-07-15T16:55:00Z"}`,
+								Metadata: map[string]string{"uuid": testUUID, "receiver": testReceiverName, "rule_uids": "testRuleUID"},
+							},
+						},
+					},
+					{
+						Stream: map[string]string{
+							"externalLabelKey": "externalLabelValue",
+							"from":             "notify-history-alerts",
+						},
+						Values: []lokiclient.Sample{
+							{
+								T:        testNow,
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
+								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID"},
 							},
 						},
 					},
 				},
 			},
 			{
-				"failed notification",
-				true,
-				errors.New("test notification error"),
-				[]lokiclient.Stream{
+				name:            "failed notification",
+				retry:           true,
+				notificationErr: errors.New("test notification error"),
+				expected: []lokiclient.Stream{
 					{
 						Stream: map[string]string{
 							"externalLabelKey": "externalLabelValue",
@@ -88,8 +104,21 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        "{\"schemaVersion\":1,\"receiver\":\"testReceiverName\",\"integration\":\"testIntegrationName\",\"integrationIdx\":42,\"groupKey\":\"testGroupKey\",\"status\":\"resolved\",\"groupLabels\":{\"foo\":\"bar\"},\"alert\":{\"status\":\"resolved\",\"labels\":{\"__alert_rule_uid__\":\"testRuleUID\",\"alertname\":\"Alert1\"},\"annotations\":{\"__private__\":\"baz\",\"foo\":\"bar\"},\"startsAt\":\"2025-07-15T16:55:00Z\",\"endsAt\":\"2025-07-15T16:55:00Z\",\"enrichments\":{\"things\":[\"foo\",\"bar\"]}},\"alertIndex\":0,\"alertCount\":1,\"retry\":true,\"error\":\"test notification error\",\"duration\":1000000000,\"pipelineTime\":\"2025-07-15T16:55:00Z\"}",
-								Metadata: map[string]string{"receiver": testReceiverName, "rule_uid": "testRuleUID"},
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","ruleUIDs":["testRuleUID"],"receiver":"testReceiverName","integration":"testIntegrationName","integrationIdx":42,"groupKey":"testGroupKey","status":"resolved","groupLabels":{"foo":"bar"},"alertCount":1,"retry":true,"error":"test notification error","duration":1000000000,"pipelineTime":"2025-07-15T16:55:00Z"}`,
+								Metadata: map[string]string{"uuid": testUUID, "receiver": testReceiverName, "rule_uids": "testRuleUID"},
+							},
+						},
+					},
+					{
+						Stream: map[string]string{
+							"externalLabelKey": "externalLabelValue",
+							"from":             "notify-history-alerts",
+						},
+						Values: []lokiclient.Sample{
+							{
+								T:        testNow,
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
+								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID"},
 							},
 						},
 					},
@@ -104,6 +133,7 @@ func TestRecord(t *testing.T) {
 
 				h := createTestNotificationHistorian(req, writesTotal, writesFailed)
 				h.Record(context.Background(), nfstatus.NotificationHistoryEntry{
+					UUID:            testUUID,
 					Alerts:          testAlerts,
 					GroupKey:        testGroupKey,
 					Retry:           tc.retry,
@@ -145,6 +175,7 @@ func TestRecord(t *testing.T) {
 		badHistorian := createTestNotificationHistorian(instrumenttest.NewFakeRequester().WithResponse(instrumenttest.BadResponse()), writesTotal, writesFailed)
 
 		nhe := nfstatus.NotificationHistoryEntry{
+			UUID:            testUUID,
 			Alerts:          testAlerts,
 			GroupKey:        testGroupKey,
 			Retry:           false,

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -9,9 +9,14 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
+)
+
+var (
+	newUUID func() string = uuid.NewString
 )
 
 type NotificationHistoryAlert struct {
@@ -20,6 +25,7 @@ type NotificationHistoryAlert struct {
 }
 
 type NotificationHistoryEntry struct {
+	UUID            string
 	Alerts          []NotificationHistoryAlert
 	GroupKey        string
 	Retry           bool
@@ -35,6 +41,9 @@ type NotificationHistoryEntry struct {
 func (e NotificationHistoryEntry) Validate() error {
 	var errs []error
 
+	if e.UUID == "" {
+		errs = append(errs, errors.New("missing UUID"))
+	}
 	if e.ReceiverName == "" {
 		errs = append(errs, errors.New("missing receiver name"))
 	}
@@ -210,6 +219,7 @@ func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, a
 	}
 
 	entry := NotificationHistoryEntry{
+		UUID:            newUUID(),
 		Alerts:          entryAlerts,
 		GroupKey:        groupKey,
 		Retry:           retry,


### PR DESCRIPTION
The fundamantal change here is to split the writing of notification metadata
from the detail about individual alerts in the notification. The reason for
this is to optimize searching for notifications when notifications have large
numbers of alerts grouped together. This does mean that two queries will be
required if alert detail is needed. To make searching for notifications for a
particular rule easier, the list of rule uids is included in the notification
entry.

The addition of a UUID field makes finding alerts for a notification simpler,
or vice versa. It also means in the future we can ship the UUID in the
notification itself, to make linking back to the notification detail possible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk/query format of notification history written to Loki (new labels, schema, and stream splitting), so downstream queries/parsers must be updated and data will be written in a new format going forward.
> 
> **Overview**
> Reworks notification historian persistence by changing from *one Loki log line per alert* to **two Loki streams**: a single per-notification "event" entry plus per-alert "detail" entries, linked via a new `uuid` field and bumped to `schemaVersion: 2`.
> 
> The per-notification entry now includes a sorted list of `ruleUIDs` and structured metadata (`uuid`, `receiver`, `rule_uids`) to improve search/filtering, while the per-alert stream stores alert-level JSON plus metadata (`uuid`, `rule_uid`) and keeps per-alert timestamp offsets for pagination.
> 
> Adds UUID generation/validation to `nfstatus.NotificationHistoryEntry` (with test-time override) and updates historian/integration tests accordingly; `go.mod` promotes `github.com/google/uuid` to a direct dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe9c8b9d64c01454adbc7edf40c7d31a05e85503. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->