### PR TITLE
Export ResolveOptions and ChannelOptions from cluster package

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -20,10 +20,12 @@ var (
 
 type ClusterChannel = cluster.ClusterChannel //nolint:revive
 type ChannelOption = cluster.ChannelOption
+type ChannelOptions = cluster.ChannelOptions
 type Peer = cluster.Peer
 type State = cluster.State
 
 var (
 	WithReliableDelivery = cluster.WithReliableDelivery
 	WithQueueSize        = cluster.WithQueueSize
+	ResolveOptions       = cluster.ResolveOptions
 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple re-exports only; no behavioral changes, but it slightly expands the public API surface.
> 
> **Overview**
> Exports `ChannelOptions` and `ResolveOptions` from the local `cluster` wrapper package by re-exporting the upstream `github.com/prometheus/alertmanager/cluster` types/vars, expanding the public API for configuring cluster channels and address resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcefe1dc4b2b776a14d1e9b72762b73161f21a82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->