### PR TITLE
Notify: Support instant queries on lokiclient.

### DIFF
--- a/notify/historian/lokiclient/client_test.go
+++ b/notify/historian/lokiclient/client_test.go
@@ -179,6 +179,115 @@ func TestLokiHTTPClient_Manual(t *testing.T) {
 	})
 }
 
+func TestLokiHTTPClient_MetricsQuery(t *testing.T) {
+	okResponse := func() *http.Response {
+		return &http.Response{
+			Status:        "200 OK",
+			StatusCode:    200,
+			Body:          io.NopCloser(bytes.NewBufferString(`{}`)),
+			ContentLength: int64(0),
+			Header:        make(http.Header, 0),
+		}
+	}
+
+	t.Run("hits instant query endpoint", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsQuery(context.Background(), `rate({from="state-history"}[5m])`, now, defaultPageSize)
+
+		require.NoError(t, err)
+		require.Contains(t, req.LastRequest.URL.Path, "/loki/api/v1/query")
+		require.NotContains(t, req.LastRequest.URL.Path, "query_range")
+	})
+
+	t.Run("passes along time parameter", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsQuery(context.Background(), `rate({from="state-history"}[5m])`, now, defaultPageSize)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.True(t, params.Has("time"), "query params did not contain 'time': %#v", params)
+		require.Equal(t, fmt.Sprint(now), params.Get("time"))
+		require.False(t, params.Has("start"), "metrics query should not have 'start' param")
+		require.False(t, params.Has("end"), "metrics query should not have 'end' param")
+	})
+
+	t.Run("passes along page size", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsQuery(context.Background(), `rate({from="state-history"}[5m])`, now, 1100)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.True(t, params.Has("limit"), "query params did not contain 'limit': %#v", params)
+		require.Equal(t, fmt.Sprint(1100), params.Get("limit"))
+	})
+
+	t.Run("uses default page size if limit not provided", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsQuery(context.Background(), `rate({from="state-history"}[5m])`, now, 0)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.Equal(t, fmt.Sprint(defaultPageSize), params.Get("limit"))
+	})
+
+	t.Run("uses maximum page size if limit too big", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsQuery(context.Background(), `rate({from="state-history"}[5m])`, now, maximumPageSize+1000)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.Equal(t, fmt.Sprint(maximumPageSize), params.Get("limit"))
+	})
+
+	t.Run("parses metric sample response", func(t *testing.T) {
+		body := `{"data":{"result":[{"metric":{"job":"my-app"},"value":[1700000000.123,"42.5"]}]}}`
+		req := instrumenttest.NewFakeRequester().WithResponse(&http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+			Header:     make(http.Header, 0),
+		})
+		client := createTestLokiClient(req)
+
+		res, err := client.MetricsQuery(context.Background(), `rate({job="my-app"}[5m])`, time.Now().UnixNano(), defaultPageSize)
+
+		require.NoError(t, err)
+		require.Len(t, res.Data.Result, 1)
+		require.Equal(t, map[string]string{"job": "my-app"}, res.Data.Result[0].Metric)
+		ts, err := res.Data.Result[0].Value.Timestamp()
+		require.NoError(t, err)
+		require.InDelta(t, 1700000000.123, ts, 0.001)
+		val, err := res.Data.Result[0].Value.Value()
+		require.NoError(t, err)
+		require.Equal(t, "42.5", val)
+	})
+}
+
 func TestRow(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		row := Sample{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Loki read-path query method and response parsing for instant vector results; risk is mainly around correctness of query parameters/time units and JSON decoding when used by callers.
> 
> **Overview**
> Adds `HTTPLokiClient.MetricsQuery` to perform Loki *instant* queries against `/loki/api/v1/query`, including `time` and `limit` handling with default/max clamping.
> 
> Introduces new response types (`MetricsQueryRes`, `MetricSample`, `MetricSampleValue`) plus helpers to decode `[timestamp,value]` pairs, and extends tests to verify endpoint/params and metric sample parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27f5abfd6a43379097b9b79939bd8555c45d69e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->