### PR TITLE
Copy second-level config dependencies from upstream into receivers

### DIFF
--- a/definition/alertmanager_test.go
+++ b/definition/alertmanager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/alertmanager/matchers/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
 
+	"github.com/grafana/alerting/receivers"
 	email_v0mimir1 "github.com/grafana/alerting/receivers/email/v0mimir1"
 	slack_v0mimir1 "github.com/grafana/alerting/receivers/slack/v0mimir1"
 )
@@ -120,7 +121,7 @@ func Test_ApiAlertingConfig_Marshaling(t *testing.T) {
 						Receiver: Receiver{
 							Name: "am",
 							EmailConfigs: []*email_v0mimir1.Config{{
-								Smarthost: config.HostPort{
+								Smarthost: receivers.HostPort{
 									Host: "test",
 									Port: "567",
 								},
@@ -346,7 +347,7 @@ func Test_ApiAlertingConfig_Marshaling(t *testing.T) {
 						Receiver: Receiver{
 							Name: "am",
 							EmailConfigs: []*email_v0mimir1.Config{{
-								Smarthost: config.HostPort{
+								Smarthost: receivers.HostPort{
 									Host: "test",
 									Port: "567",
 								},

--- a/definition/compat.go
+++ b/definition/compat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/alertmanager/config"
 
 	"github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 // LoadCompat loads a PostableApiAlertingConfig from a YAML configuration
@@ -48,7 +49,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.SMTPSmarthost.String() == "" {
 					return nil, errors.New("no global SMTP smarthost set")
 				}
-				ec.Smarthost = c.Global.SMTPSmarthost
+				ec.Smarthost = receivers.HostPort(c.Global.SMTPSmarthost)
 			}
 			if ec.From == "" {
 				if c.Global.SMTPFrom == "" {
@@ -63,10 +64,10 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				ec.AuthUsername = c.Global.SMTPAuthUsername
 			}
 			if ec.AuthPassword == "" {
-				ec.AuthPassword = c.Global.SMTPAuthPassword
+				ec.AuthPassword = receivers.Secret(c.Global.SMTPAuthPassword)
 			}
 			if ec.AuthSecret == "" {
-				ec.AuthSecret = c.Global.SMTPAuthSecret
+				ec.AuthSecret = receivers.Secret(c.Global.SMTPAuthSecret)
 			}
 			if ec.AuthIdentity == "" {
 				ec.AuthIdentity = c.Global.SMTPAuthIdentity
@@ -84,7 +85,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.SlackAPIURL == nil {
 					return nil, errors.New("no global Slack API URL set")
 				}
-				sc.APIURL = c.Global.SlackAPIURL
+				sc.APIURL = (*receivers.SecretURL)(c.Global.SlackAPIURL)
 			}
 		}
 		for _, poc := range rcv.PushoverConfigs {
@@ -100,7 +101,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.PagerdutyURL == nil {
 					return nil, errors.New("no global PagerDuty URL set")
 				}
-				pdc.URL = c.Global.PagerdutyURL
+				pdc.URL = (*receivers.URL)(c.Global.PagerdutyURL)
 			}
 		}
 		for _, ogc := range rcv.OpsGenieConfigs {
@@ -111,7 +112,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.OpsGenieAPIURL == nil {
 					return nil, errors.New("no global OpsGenie URL set")
 				}
-				ogc.APIURL = c.Global.OpsGenieAPIURL
+				ogc.APIURL = (*receivers.URL)(c.Global.OpsGenieAPIURL)
 			}
 			if !strings.HasSuffix(ogc.APIURL.Path, "/") {
 				ogc.APIURL.Path += "/"
@@ -120,7 +121,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.OpsGenieAPIKey == "" {
 					return nil, errors.New("no global OpsGenie API Key set")
 				}
-				ogc.APIKey = c.Global.OpsGenieAPIKey
+				ogc.APIKey = receivers.Secret(c.Global.OpsGenieAPIKey)
 			}
 		}
 		for _, wcc := range rcv.WechatConfigs {
@@ -132,14 +133,14 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.WeChatAPIURL == nil {
 					return nil, errors.New("no global Wechat URL set")
 				}
-				wcc.APIURL = c.Global.WeChatAPIURL
+				wcc.APIURL = (*receivers.URL)(c.Global.WeChatAPIURL)
 			}
 
 			if wcc.APISecret == "" {
 				if c.Global.WeChatAPISecret == "" {
 					return nil, errors.New("no global Wechat ApiSecret set")
 				}
-				wcc.APISecret = c.Global.WeChatAPISecret
+				wcc.APISecret = receivers.Secret(c.Global.WeChatAPISecret)
 			}
 
 			if wcc.CorpID == "" {
@@ -161,7 +162,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.VictorOpsAPIURL == nil {
 					return nil, errors.New("no global VictorOps URL set")
 				}
-				voc.APIURL = c.Global.VictorOpsAPIURL
+				voc.APIURL = (*receivers.URL)(c.Global.VictorOpsAPIURL)
 			}
 			if !strings.HasSuffix(voc.APIURL.Path, "/") {
 				voc.APIURL.Path += "/"
@@ -170,7 +171,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.VictorOpsAPIKey == "" {
 					return nil, errors.New("no global VictorOps API Key set")
 				}
-				voc.APIKey = c.Global.VictorOpsAPIKey
+				voc.APIKey = receivers.Secret(c.Global.VictorOpsAPIKey)
 			}
 		}
 		for _, sns := range rcv.SNSConfigs {
@@ -184,7 +185,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				telegram.HTTPConfig = v0mimir1.FromCommonHTTPClientConfig(c.Global.HTTPConfig)
 			}
 			if telegram.APIUrl == nil {
-				telegram.APIUrl = c.Global.TelegramAPIUrl
+				telegram.APIUrl = (*receivers.URL)(c.Global.TelegramAPIUrl)
 			}
 		}
 		for _, discord := range rcv.DiscordConfigs {
@@ -201,7 +202,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 					return nil, errors.New("no global Webex URL set")
 				}
 
-				webex.APIURL = c.Global.WebexAPIURL
+				webex.APIURL = (*receivers.URL)(c.Global.WebexAPIURL)
 			}
 		}
 		for _, msteams := range rcv.MSTeamsConfigs {
@@ -228,7 +229,7 @@ func LoadCompat(rawCfg []byte) (*PostableApiAlertingConfig, error) {
 				if c.Global.JiraAPIURL == nil {
 					return nil, errors.New("no global Jira Cloud URL set")
 				}
-				jira.APIURL = c.Global.JiraAPIURL
+				jira.APIURL = (*receivers.URL)(c.Global.JiraAPIURL)
 			}
 		}
 		names[rcv.Name] = struct{}{}

--- a/definition/compat_test.go
+++ b/definition/compat_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 
 	"github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestLoadCompat(t *testing.T) {
@@ -109,11 +110,11 @@ func TestLoadCompat(t *testing.T) {
 			require.Equal(t, expectedHTTPConfig, c.Receivers[0].WechatConfigs[0].HTTPConfig)
 
 			if len(c.Receivers[0].EmailConfigs) > 0 {
-				require.Equal(t, c.Receivers[0].EmailConfigs[0].Smarthost, globalConfig.SMTPSmarthost)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].Smarthost, receivers.HostPort(globalConfig.SMTPSmarthost))
 				require.Equal(t, c.Receivers[0].EmailConfigs[0].From, globalConfig.SMTPFrom)
 				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthUsername, globalConfig.SMTPAuthUsername)
-				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthPassword, globalConfig.SMTPAuthPassword)
-				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthSecret, globalConfig.SMTPAuthSecret)
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthPassword, receivers.Secret(globalConfig.SMTPAuthPassword))
+				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthSecret, receivers.Secret(globalConfig.SMTPAuthSecret))
 				require.Equal(t, c.Receivers[0].EmailConfigs[0].AuthIdentity, globalConfig.SMTPAuthIdentity)
 				require.Equal(t, *c.Receivers[0].EmailConfigs[0].RequireTLS, globalConfig.SMTPRequireTLS)
 			}

--- a/definition/json.go
+++ b/definition/json.go
@@ -27,49 +27,65 @@ func getStr(ptr unsafe.Pointer) string {
 	return *(*string)(ptr)
 }
 
-// secretEncoder encodes SecretURL to plain text JSON,
+// secretURLEncoder encodes SecretURL to plain text JSON,
 // avoiding the default masking behavior of the structure.
-type secretURLEncoder struct{}
+type secretURLEncoder struct {
+	getURLString func(ptr unsafe.Pointer) *string
+}
 
 func (encoder *secretURLEncoder) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
-	url := getURL(ptr)
-	if url.URL != nil {
-		stream.WriteString(url.String())
+	s := encoder.getURLString(ptr)
+	if s != nil {
+		stream.WriteString(*s)
 	} else {
 		stream.WriteNil()
 	}
 }
 
 func (encoder *secretURLEncoder) IsEmpty(ptr unsafe.Pointer) bool {
-	url := getURL(ptr)
-	return url.URL == nil
+	return encoder.getURLString(ptr) == nil
 }
 
-func getURL(ptr unsafe.Pointer) *amcfg.URL {
+func getAmcfgURLString(ptr unsafe.Pointer) *string {
 	v := (*amcfg.SecretURL)(ptr)
-	url := amcfg.URL(*v)
-	return &url
+	u := amcfg.URL(*v)
+	if u.URL == nil {
+		return nil
+	}
+	s := u.String()
+	return &s
+}
+
+func getReceiversURLString(ptr unsafe.Pointer) *string {
+	v := (*receivers.SecretURL)(ptr)
+	u := receivers.URL(*v)
+	if u.URL == nil {
+		return nil
+	}
+	s := u.String()
+	return &s
 }
 
 func newPlainAPI() jsoniter.API {
 	api := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	secretEnc := &secretEncoder{}
-	secretURLEnc := &secretURLEncoder{}
+	amcfgSecretURLEnc := &secretURLEncoder{getURLString: getAmcfgURLString}
+	receiversSecretURLEnc := &secretURLEncoder{getURLString: getReceiversURLString}
 
 	extension := jsoniter.EncoderExtension{
 		// Value types
 		reflect2.TypeOfPtr((*amcfg.Secret)(nil)).Elem():        secretEnc,
 		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)).Elem():    secretEnc,
 		reflect2.TypeOfPtr((*receivers.Secret)(nil)).Elem():    secretEnc,
-		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)).Elem():     secretURLEnc,
-		reflect2.TypeOfPtr((*receivers.SecretURL)(nil)).Elem(): secretURLEnc,
+		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)).Elem():     amcfgSecretURLEnc,
+		reflect2.TypeOfPtr((*receivers.SecretURL)(nil)).Elem(): receiversSecretURLEnc,
 		// Pointer types
 		reflect2.TypeOfPtr((*amcfg.Secret)(nil)):        &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
 		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)):    &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
 		reflect2.TypeOfPtr((*receivers.Secret)(nil)):    &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
-		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)):     &jsoniter.OptionalEncoder{ValueEncoder: secretURLEnc},
-		reflect2.TypeOfPtr((*receivers.SecretURL)(nil)): &jsoniter.OptionalEncoder{ValueEncoder: secretURLEnc},
+		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)):     &jsoniter.OptionalEncoder{ValueEncoder: amcfgSecretURLEnc},
+		reflect2.TypeOfPtr((*receivers.SecretURL)(nil)): &jsoniter.OptionalEncoder{ValueEncoder: receiversSecretURLEnc},
 	}
 
 	api.RegisterExtension(extension)

--- a/definition/json.go
+++ b/definition/json.go
@@ -7,6 +7,8 @@ import (
 	"github.com/modern-go/reflect2"
 	amcfg "github.com/prometheus/alertmanager/config"
 	commoncfg "github.com/prometheus/common/config"
+
+	"github.com/grafana/alerting/receivers"
 )
 
 // secretEncoder encodes Secret to plain text JSON,
@@ -57,13 +59,17 @@ func newPlainAPI() jsoniter.API {
 
 	extension := jsoniter.EncoderExtension{
 		// Value types
-		reflect2.TypeOfPtr((*amcfg.Secret)(nil)).Elem():     secretEnc,
-		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)).Elem(): secretEnc,
-		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)).Elem():  secretURLEnc,
+		reflect2.TypeOfPtr((*amcfg.Secret)(nil)).Elem():        secretEnc,
+		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)).Elem():    secretEnc,
+		reflect2.TypeOfPtr((*receivers.Secret)(nil)).Elem():    secretEnc,
+		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)).Elem():     secretURLEnc,
+		reflect2.TypeOfPtr((*receivers.SecretURL)(nil)).Elem(): secretURLEnc,
 		// Pointer types
-		reflect2.TypeOfPtr((*amcfg.Secret)(nil)):     &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
-		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)): &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
-		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)):  &jsoniter.OptionalEncoder{ValueEncoder: secretURLEnc},
+		reflect2.TypeOfPtr((*amcfg.Secret)(nil)):        &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
+		reflect2.TypeOfPtr((*commoncfg.Secret)(nil)):    &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
+		reflect2.TypeOfPtr((*receivers.Secret)(nil)):    &jsoniter.OptionalEncoder{ValueEncoder: secretEnc},
+		reflect2.TypeOfPtr((*amcfg.SecretURL)(nil)):     &jsoniter.OptionalEncoder{ValueEncoder: secretURLEnc},
+		reflect2.TypeOfPtr((*receivers.SecretURL)(nil)): &jsoniter.OptionalEncoder{ValueEncoder: secretURLEnc},
 	}
 
 	api.RegisterExtension(extension)

--- a/receivers/discord/v0mimir1/config.go
+++ b/receivers/discord/v0mimir1/config.go
@@ -17,7 +17,7 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -27,7 +27,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for Discord configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Title:   `{{ template "discord.default.title" . }}`,
@@ -36,10 +36,10 @@ var DefaultConfig = Config{
 
 // Config configures notifications via Discord.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *config.SecretURL         `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *receivers.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                    `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title   string `yaml:"title,omitempty" json:"title,omitempty"`

--- a/receivers/discord/v0mimir1/discord.go
+++ b/receivers/discord/v0mimir1/discord.go
@@ -24,12 +24,13 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -54,7 +55,7 @@ type Notifier struct {
 	logger     log.Logger
 	client     *http.Client
 	retrier    *notify.Retrier
-	webhookURL *config.SecretURL
+	webhookURL *receivers.SecretURL
 }
 
 // New returns a new Discord notifier.

--- a/receivers/discord/v0mimir1/discord_test.go
+++ b/receivers/discord/v0mimir1/discord_test.go
@@ -25,12 +25,13 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -41,7 +42,7 @@ var testWebhookURL, _ = url.Parse("https://discord.com/api/webhooks/971139602272
 func TestDiscordRetry(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &receivers.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -99,7 +100,7 @@ func TestDiscordTemplating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &receivers.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)
@@ -136,7 +137,7 @@ func TestDiscordRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&Config{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &receivers.SecretURL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/receivers/email/v0mimir1/config.go
+++ b/receivers/email/v0mimir1/config.go
@@ -19,9 +19,8 @@ import (
 	"fmt"
 	"net/textproto"
 
-	"github.com/prometheus/alertmanager/config"
-
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 )
 
@@ -32,7 +31,7 @@ var DefaultEmailSubject = `{{ template "email.default.subject" . }}`
 
 // DefaultConfig defines default values for Email configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: false,
 	},
 	HTML: `{{ template "email.default.html" . }}`,
@@ -41,23 +40,23 @@ var DefaultConfig = Config{
 
 // Config configures notifications via mail.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	// Email address to notify.
-	To               string            `yaml:"to,omitempty" json:"to,omitempty"`
-	From             string            `yaml:"from,omitempty" json:"from,omitempty"`
-	Hello            string            `yaml:"hello,omitempty" json:"hello,omitempty"`
-	Smarthost        config.HostPort   `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
-	AuthUsername     string            `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
-	AuthPassword     config.Secret     `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
-	AuthPasswordFile string            `yaml:"auth_password_file,omitempty" json:"auth_password_file,omitempty"`
-	AuthSecret       config.Secret     `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
-	AuthIdentity     string            `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
-	Headers          map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
-	HTML             string            `yaml:"html,omitempty" json:"html,omitempty"`
-	Text             string            `yaml:"text,omitempty" json:"text,omitempty"`
-	RequireTLS       *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
-	TLSConfig        httpcfg.TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+	To               string             `yaml:"to,omitempty" json:"to,omitempty"`
+	From             string             `yaml:"from,omitempty" json:"from,omitempty"`
+	Hello            string             `yaml:"hello,omitempty" json:"hello,omitempty"`
+	Smarthost        receivers.HostPort `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
+	AuthUsername     string             `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
+	AuthPassword     receivers.Secret   `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
+	AuthPasswordFile string             `yaml:"auth_password_file,omitempty" json:"auth_password_file,omitempty"`
+	AuthSecret       receivers.Secret   `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
+	AuthIdentity     string             `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
+	Headers          map[string]string  `yaml:"headers,omitempty" json:"headers,omitempty"`
+	HTML             string             `yaml:"html,omitempty" json:"html,omitempty"`
+	Text             string             `yaml:"text,omitempty" json:"text,omitempty"`
+	RequireTLS       *bool              `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+	TLSConfig        httpcfg.TLSConfig  `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/receivers/jira/v0mimir1/config.go
+++ b/receivers/jira/v0mimir1/config.go
@@ -17,10 +17,10 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/common/model"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 )
 
@@ -28,7 +28,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for Jira configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Summary:     `{{ template "jira.default.summary" . }}`,
@@ -38,10 +38,10 @@ var DefaultConfig = Config{
 
 // Config configures notifications via JIRA.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig            *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig               *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIURL *config.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURL *receivers.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 
 	Project     string   `yaml:"project,omitempty" json:"project,omitempty"`
 	Summary     string   `yaml:"summary,omitempty" json:"summary,omitempty"`
@@ -107,7 +107,7 @@ var Schema = schema.IntegrationSchemaVersion{
 		{
 			Label:        "Summary",
 			Description:  "Issue summary template",
-			Placeholder:  config.DefaultJiraConfig.Summary,
+			Placeholder:  DefaultConfig.Summary,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "summary",
@@ -115,7 +115,7 @@ var Schema = schema.IntegrationSchemaVersion{
 		{
 			Label:        "Description",
 			Description:  "Issue description template",
-			Placeholder:  config.DefaultJiraConfig.Description,
+			Placeholder:  DefaultConfig.Description,
 			Element:      schema.ElementTypeTextArea,
 			PropertyName: "description",
 		},
@@ -128,7 +128,7 @@ var Schema = schema.IntegrationSchemaVersion{
 		{
 			Label:        "Priority",
 			Description:  "Priority of the issue",
-			Placeholder:  config.DefaultJiraConfig.Priority,
+			Placeholder:  DefaultConfig.Priority,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "priority",

--- a/receivers/jira/v0mimir1/jira_test.go
+++ b/receivers/jira/v0mimir1/jira_test.go
@@ -29,18 +29,19 @@ import (
 
 	"github.com/go-kit/log"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestJiraRetry(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			APIURL: &config.URL{
+			APIURL: &receivers.URL{
 				URL: &url.URL{
 					Scheme: "https",
 					Host:   "example.atlassian.net",
@@ -123,7 +124,7 @@ func TestJiraTemplating(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &receivers.URL{URL: u}
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)
@@ -565,7 +566,7 @@ func TestJiraNotify(t *testing.T) {
 			defer srv.Close()
 			u, _ := url.Parse(srv.URL)
 
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &receivers.URL{URL: u}
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
 
 			notifier, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())

--- a/receivers/opsgenie/v0mimir1/config.go
+++ b/receivers/opsgenie/v0mimir1/config.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -31,7 +31,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for OpsGenie configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Message:     `{{ template "opsgenie.default.message" . }}`,
@@ -41,13 +41,13 @@ var DefaultConfig = Config{
 
 // Config configures notifications via OpsGenie.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIKey       config.Secret     `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKey       receivers.Secret  `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile   string            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
-	APIURL       *config.URL       `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURL       *receivers.URL    `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	Message      string            `yaml:"message,omitempty" json:"message,omitempty"`
 	Description  string            `yaml:"description,omitempty" json:"description,omitempty"`
 	Source       string            `yaml:"source,omitempty" json:"source,omitempty"`

--- a/receivers/opsgenie/v0mimir1/opsgenie_test.go
+++ b/receivers/opsgenie/v0mimir1/opsgenie_test.go
@@ -27,11 +27,12 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestOpsGenieRetry(t *testing.T) {
@@ -58,8 +59,8 @@ func TestOpsGenieRedactedURL(t *testing.T) {
 	key := "key"
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.URL{URL: u},
-			APIKey:     config.Secret(key),
+			APIURL:     &receivers.URL{URL: u},
+			APIKey:     receivers.Secret(key),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -83,7 +84,7 @@ func TestGettingOpsGegineApikeyFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &receivers.URL{URL: u},
 			APIKeyFile: f.Name(),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
@@ -113,7 +114,7 @@ func TestOpsGenie(t *testing.T) {
 		{
 			title: "config without details",
 			cfg: &Config{
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: receivers.NotifierConfig{
 					VSendResolved: true,
 				},
 				Message:     `{{ .CommonLabels.Message }}`,
@@ -135,7 +136,7 @@ func TestOpsGenie(t *testing.T) {
 				Entity:     `{{ .CommonLabels.Entity }}`,
 				Actions:    `{{ .CommonLabels.Actions }}`,
 				APIKey:     `{{ .ExternalURL }}`,
-				APIURL:     &config.URL{URL: u},
+				APIURL:     &receivers.URL{URL: u},
 				HTTPConfig: &httpcfg.HTTPClientConfig{},
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{},"source":""}
@@ -146,7 +147,7 @@ func TestOpsGenie(t *testing.T) {
 		{
 			title: "config with details",
 			cfg: &Config{
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: receivers.NotifierConfig{
 					VSendResolved: true,
 				},
 				Message:     `{{ .CommonLabels.Message }}`,
@@ -171,7 +172,7 @@ func TestOpsGenie(t *testing.T) {
 				Entity:     `{{ .CommonLabels.Entity }}`,
 				Actions:    `{{ .CommonLabels.Actions }}`,
 				APIKey:     `{{ .ExternalURL }}`,
-				APIURL:     &config.URL{URL: u},
+				APIURL:     &receivers.URL{URL: u},
 				HTTPConfig: &httpcfg.HTTPClientConfig{},
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"Description":"adjusted "},"source":""}
@@ -182,7 +183,7 @@ func TestOpsGenie(t *testing.T) {
 		{
 			title: "config with multiple teams",
 			cfg: &Config{
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: receivers.NotifierConfig{
 					VSendResolved: true,
 				},
 				Message:     `{{ .CommonLabels.Message }}`,
@@ -201,7 +202,7 @@ func TestOpsGenie(t *testing.T) {
 				Note:       `{{ .CommonLabels.Note }}`,
 				Priority:   `{{ .CommonLabels.Priority }}`,
 				APIKey:     `{{ .ExternalURL }}`,
-				APIURL:     &config.URL{URL: u},
+				APIURL:     &receivers.URL{URL: u},
 				HTTPConfig: &httpcfg.HTTPClientConfig{},
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"Description":"adjusted "},"source":""}
@@ -284,7 +285,7 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 		Description:  `{{ .CommonLabels.Description }}`,
 		UpdateAlerts: true,
 		APIKey:       "test-api-key",
-		APIURL:       &config.URL{URL: u},
+		APIURL:       &receivers.URL{URL: u},
 		HTTPConfig:   &httpcfg.HTTPClientConfig{},
 	}
 	notifierWithUpdate, err := New(&opsGenieConfigWithUpdate, tmpl, log.NewNopLogger())

--- a/receivers/pagerduty/v0mimir1/config.go
+++ b/receivers/pagerduty/v0mimir1/config.go
@@ -17,9 +17,8 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
-
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 )
 
@@ -35,7 +34,7 @@ var DefaultPagerdutyDetails = map[string]string{
 
 // DefaultConfig defines default values for PagerDuty configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Description: `{{ template "pagerduty.default.description" .}}`,
@@ -45,26 +44,26 @@ var DefaultConfig = Config{
 
 // Config configures notifications via PagerDuty.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	ServiceKey     config.Secret           `yaml:"service_key,omitempty" json:"service_key,omitempty"`
-	ServiceKeyFile string                  `yaml:"service_key_file,omitempty" json:"service_key_file,omitempty"`
-	RoutingKey     config.Secret           `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
-	RoutingKeyFile string                  `yaml:"routing_key_file,omitempty" json:"routing_key_file,omitempty"`
-	URL            *config.URL             `yaml:"url,omitempty" json:"url,omitempty"`
-	Client         string                  `yaml:"client,omitempty" json:"client,omitempty"`
-	ClientURL      string                  `yaml:"client_url,omitempty" json:"client_url,omitempty"`
-	Description    string                  `yaml:"description,omitempty" json:"description,omitempty"`
-	Details        map[string]string       `yaml:"details,omitempty" json:"details,omitempty"`
-	Images         []config.PagerdutyImage `yaml:"images,omitempty" json:"images,omitempty"`
-	Links          []config.PagerdutyLink  `yaml:"links,omitempty" json:"links,omitempty"`
-	Source         string                  `yaml:"source,omitempty" json:"source,omitempty"`
-	Severity       string                  `yaml:"severity,omitempty" json:"severity,omitempty"`
-	Class          string                  `yaml:"class,omitempty" json:"class,omitempty"`
-	Component      string                  `yaml:"component,omitempty" json:"component,omitempty"`
-	Group          string                  `yaml:"group,omitempty" json:"group,omitempty"`
+	ServiceKey     receivers.Secret  `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	ServiceKeyFile string            `yaml:"service_key_file,omitempty" json:"service_key_file,omitempty"`
+	RoutingKey     receivers.Secret  `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	RoutingKeyFile string            `yaml:"routing_key_file,omitempty" json:"routing_key_file,omitempty"`
+	URL            *receivers.URL    `yaml:"url,omitempty" json:"url,omitempty"`
+	Client         string            `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL      string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description    string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Details        map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	Images         []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
+	Links          []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
+	Source         string            `yaml:"source,omitempty" json:"source,omitempty"`
+	Severity       string            `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Class          string            `yaml:"class,omitempty" json:"class,omitempty"`
+	Component      string            `yaml:"component,omitempty" json:"component,omitempty"`
+	Group          string            `yaml:"group,omitempty" json:"group,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -241,4 +240,17 @@ var Schema = schema.IntegrationSchemaVersion{
 		},
 		schema.V0HttpConfigOption(),
 	},
+}
+
+// PagerdutyLink is used to add link to an incident.
+type PagerdutyLink struct {
+	Href string `yaml:"href,omitempty" json:"href,omitempty"`
+	Text string `yaml:"text,omitempty" json:"text,omitempty"`
+}
+
+// PagerdutyImage is an image attached to an incident.
+type PagerdutyImage struct {
+	Src  string `yaml:"src,omitempty" json:"src,omitempty"`
+	Alt  string `yaml:"alt,omitempty" json:"alt,omitempty"`
+	Href string `yaml:"href,omitempty" json:"href,omitempty"`
 }

--- a/receivers/pagerduty/v0mimir1/pagerduty_test.go
+++ b/receivers/pagerduty/v0mimir1/pagerduty_test.go
@@ -416,11 +416,7 @@ func TestPagerDutyEmptySrcHref(t *testing.T) {
 		if image.Src == "" {
 			continue
 		}
-		expectedImages = append(expectedImages, pagerDutyImage{
-			Src:  image.Src,
-			Alt:  image.Alt,
-			Href: image.Href,
-		})
+		expectedImages = append(expectedImages, pagerDutyImage(image))
 	}
 
 	expectedLinks := make([]pagerDutyLink, 0, len(links))

--- a/receivers/pagerduty/v0mimir1/pagerduty_test.go
+++ b/receivers/pagerduty/v0mimir1/pagerduty_test.go
@@ -30,17 +30,18 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestPagerDutyRetryV1(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			ServiceKey: config.Secret("01234567890123456789012345678901"),
+			ServiceKey: receivers.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -58,7 +59,7 @@ func TestPagerDutyRetryV1(t *testing.T) {
 func TestPagerDutyRetryV2(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			RoutingKey: config.Secret("01234567890123456789012345678901"),
+			RoutingKey: receivers.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -80,7 +81,7 @@ func TestPagerDutyRedactedURLV1(t *testing.T) {
 	key := "01234567890123456789012345678901"
 	notifier, err := New(
 		&Config{
-			ServiceKey: config.Secret(key),
+			ServiceKey: receivers.Secret(key),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -99,8 +100,8 @@ func TestPagerDutyRedactedURLV2(t *testing.T) {
 	key := "01234567890123456789012345678901"
 	notifier, err := New(
 		&Config{
-			URL:        &config.URL{URL: u},
-			RoutingKey: config.Secret(key),
+			URL:        &receivers.URL{URL: u},
+			RoutingKey: receivers.Secret(key),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -147,7 +148,7 @@ func TestPagerDutyV2RoutingKeyFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			URL:            &config.URL{URL: u},
+			URL:            &receivers.URL{URL: u},
 			RoutingKeyFile: f.Name(),
 			HTTPConfig:     &httpcfg.HTTPClientConfig{},
 		},
@@ -181,15 +182,15 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "full-blown message",
 			cfg: &Config{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
-				Images: []config.PagerdutyImage{
+				RoutingKey: receivers.Secret("01234567890123456789012345678901"),
+				Images: []PagerdutyImage{
 					{
 						Src:  "{{ .Status }}",
 						Alt:  "{{ .Status }}",
 						Href: "{{ .Status }}",
 					},
 				},
-				Links: []config.PagerdutyLink{
+				Links: []PagerdutyLink{
 					{
 						Href: "{{ .Status }}",
 						Text: "{{ .Status }}",
@@ -206,7 +207,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "details with templating errors",
 			cfg: &Config{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: receivers.Secret("01234567890123456789012345678901"),
 				Details: map[string]string{
 					"firing":       `{{ template "pagerduty.default.instances" .Alerts.Firing`,
 					"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
@@ -219,7 +220,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "v2 message with templating errors",
 			cfg: &Config{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: receivers.Secret("01234567890123456789012345678901"),
 				Severity:   "{{ ",
 			},
 			errMsg: "failed to template",
@@ -227,7 +228,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "v1 message with templating errors",
 			cfg: &Config{
-				ServiceKey: config.Secret("01234567890123456789012345678901"),
+				ServiceKey: receivers.Secret("01234567890123456789012345678901"),
 				Client:     "{{ ",
 			},
 			errMsg: "failed to template",
@@ -235,20 +236,20 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "routing key cannot be empty",
 			cfg: &Config{
-				RoutingKey: config.Secret(`{{ "" }}`),
+				RoutingKey: receivers.Secret(`{{ "" }}`),
 			},
 			errMsg: "routing key cannot be empty",
 		},
 		{
 			title: "service_key cannot be empty",
 			cfg: &Config{
-				ServiceKey: config.Secret(`{{ "" }}`),
+				ServiceKey: receivers.Secret(`{{ "" }}`),
 			},
 			errMsg: "service key cannot be empty",
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.URL = &config.URL{URL: u}
+			tc.cfg.URL = &receivers.URL{URL: u}
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)
@@ -335,7 +336,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 
 	notifierV1, err := New(
 		&Config{
-			ServiceKey: config.Secret("01234567890123456789012345678901"),
+			ServiceKey: receivers.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -358,7 +359,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 
 	notifierV2, err := New(
 		&Config{
-			RoutingKey: config.Secret("01234567890123456789012345678901"),
+			RoutingKey: receivers.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -381,7 +382,7 @@ func TestPagerDutyEmptySrcHref(t *testing.T) {
 		Links       []pagerDutyLink
 	}
 
-	images := []config.PagerdutyImage{
+	images := []PagerdutyImage{
 		{
 			Src:  "",
 			Alt:  "Empty src",
@@ -399,7 +400,7 @@ func TestPagerDutyEmptySrcHref(t *testing.T) {
 		},
 	}
 
-	links := []config.PagerdutyLink{
+	links := []PagerdutyLink{
 		{
 			Href: "",
 			Text: "Empty href",
@@ -471,8 +472,8 @@ func TestPagerDutyEmptySrcHref(t *testing.T) {
 
 	pagerDutyConfig := Config{
 		HTTPConfig: &httpcfg.HTTPClientConfig{},
-		RoutingKey: config.Secret("01234567890123456789012345678901"),
-		URL:        &config.URL{URL: u},
+		RoutingKey: receivers.Secret("01234567890123456789012345678901"),
+		URL:        &receivers.URL{URL: u},
 		Images:     images,
 		Links:      links,
 	}

--- a/receivers/pushover/v0mimir1/config.go
+++ b/receivers/pushover/v0mimir1/config.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -42,7 +42,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for Pushover configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Title:    `{{ template "pushover.default.title" . }}`,
@@ -56,12 +56,12 @@ var DefaultConfig = Config{
 
 // Config configures notifications via Pushover.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig  *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	UserKey     config.Secret             `yaml:"user_key,omitempty" json:"user_key,omitempty"`
+	UserKey     receivers.Secret          `yaml:"user_key,omitempty" json:"user_key,omitempty"`
 	UserKeyFile string                    `yaml:"user_key_file,omitempty" json:"user_key_file,omitempty"`
-	Token       config.Secret             `yaml:"token,omitempty" json:"token,omitempty"`
+	Token       receivers.Secret          `yaml:"token,omitempty" json:"token,omitempty"`
 	TokenFile   string                    `yaml:"token_file,omitempty" json:"token_file,omitempty"`
 	Title       string                    `yaml:"title,omitempty" json:"title,omitempty"`
 	Message     string                    `yaml:"message,omitempty" json:"message,omitempty"`

--- a/receivers/pushover/v0mimir1/pushover_test.go
+++ b/receivers/pushover/v0mimir1/pushover_test.go
@@ -20,9 +20,10 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestPushoverRetry(t *testing.T) {
@@ -47,8 +48,8 @@ func TestPushoverRedactedURL(t *testing.T) {
 	key, token := "user_key", "token"
 	notifier, err := New(
 		&Config{
-			UserKey:    config.Secret(key),
-			Token:      config.Secret(token),
+			UserKey:    receivers.Secret(key),
+			Token:      receivers.Secret(token),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -73,7 +74,7 @@ func TestPushoverReadingUserKeyFromFile(t *testing.T) {
 	notifier, err := New(
 		&Config{
 			UserKeyFile: f.Name(),
-			Token:       config.Secret("token"),
+			Token:       receivers.Secret("token"),
 			HTTPConfig:  &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -97,7 +98,7 @@ func TestPushoverReadingTokenFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			UserKey:    config.Secret("user key"),
+			UserKey:    receivers.Secret("user key"),
 			TokenFile:  f.Name(),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},

--- a/receivers/slack/v0mimir1/config_test.go
+++ b/receivers/slack/v0mimir1/config_test.go
@@ -16,8 +16,6 @@ package v0mimir1
 import (
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
-
 	"gopkg.in/yaml.v2"
 )
 
@@ -160,7 +158,7 @@ fields:
   value: slack field test
   short: false
 `
-	expected := []*config.SlackField{
+	expected := []*SlackField{
 		{
 			Title: "first",
 			Value: "hello",
@@ -221,7 +219,7 @@ actions:
     ok_text: yes
     dismiss_text: no
 `
-	expected := []*config.SlackAction{
+	expected := []*SlackAction{
 		{
 			Type:  "button",
 			Text:  "hello",
@@ -233,7 +231,7 @@ actions:
 			Text:  "hello",
 			Name:  "something",
 			Style: "default",
-			ConfirmField: &config.SlackConfirmationField{
+			ConfirmField: &SlackConfirmationField{
 				Title:       "please confirm",
 				Text:        "are you sure?",
 				OkText:      "yes",

--- a/receivers/slack/v0mimir1/slack.go
+++ b/receivers/slack/v0mimir1/slack.go
@@ -27,11 +27,11 @@ import (
 	"github.com/go-kit/log/level"
 	commoncfg "github.com/prometheus/common/config"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
 
 // https://api.slack.com/reference/messaging/attachments#legacy_fields - 1024, no units given, assuming runes or characters.
@@ -77,19 +77,19 @@ type request struct {
 
 // attachment is used to display a richly-formatted message block.
 type attachment struct {
-	Title      string               `json:"title,omitempty"`
-	TitleLink  string               `json:"title_link,omitempty"`
-	Pretext    string               `json:"pretext,omitempty"`
-	Text       string               `json:"text"`
-	Fallback   string               `json:"fallback"`
-	CallbackID string               `json:"callback_id"`
-	Fields     []config.SlackField  `json:"fields,omitempty"`
-	Actions    []config.SlackAction `json:"actions,omitempty"`
-	ImageURL   string               `json:"image_url,omitempty"`
-	ThumbURL   string               `json:"thumb_url,omitempty"`
-	Footer     string               `json:"footer"`
-	Color      string               `json:"color,omitempty"`
-	MrkdwnIn   []string             `json:"mrkdwn_in,omitempty"`
+	Title      string        `json:"title,omitempty"`
+	TitleLink  string        `json:"title_link,omitempty"`
+	Pretext    string        `json:"pretext,omitempty"`
+	Text       string        `json:"text"`
+	Fallback   string        `json:"fallback"`
+	CallbackID string        `json:"callback_id"`
+	Fields     []SlackField  `json:"fields,omitempty"`
+	Actions    []SlackAction `json:"actions,omitempty"`
+	ImageURL   string        `json:"image_url,omitempty"`
+	ThumbURL   string        `json:"thumb_url,omitempty"`
+	Footer     string        `json:"footer"`
+	Color      string        `json:"color,omitempty"`
+	MrkdwnIn   []string      `json:"mrkdwn_in,omitempty"`
 }
 
 // Notify implements the Notifier interface.
@@ -131,7 +131,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	numFields := len(n.conf.Fields)
 	if numFields > 0 {
-		fields := make([]config.SlackField, numFields)
+		fields := make([]SlackField, numFields)
 		for index, field := range n.conf.Fields {
 			// Check if short was defined for the field otherwise fallback to the global setting
 			var short bool
@@ -142,7 +142,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			}
 
 			// Rebuild the field by executing any templates and setting the new value for short
-			fields[index] = config.SlackField{
+			fields[index] = SlackField{
 				Title: tmplText(field.Title),
 				Value: tmplText(field.Value),
 				Short: &short,
@@ -153,9 +153,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	numActions := len(n.conf.Actions)
 	if numActions > 0 {
-		actions := make([]config.SlackAction, numActions)
+		actions := make([]SlackAction, numActions)
 		for index, action := range n.conf.Actions {
-			slackAction := config.SlackAction{
+			slackAction := SlackAction{
 				Type:  tmplText(action.Type),
 				Text:  tmplText(action.Text),
 				URL:   tmplText(action.URL),
@@ -165,7 +165,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			}
 
 			if action.ConfirmField != nil {
-				slackAction.ConfirmField = &config.SlackConfirmationField{
+				slackAction.ConfirmField = &SlackConfirmationField{
 					Title:       tmplText(action.ConfirmField.Title),
 					Text:        tmplText(action.ConfirmField.Text),
 					OkText:      tmplText(action.ConfirmField.OkText),

--- a/receivers/slack/v0mimir1/slack_test.go
+++ b/receivers/slack/v0mimir1/slack_test.go
@@ -29,7 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
+
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
@@ -57,7 +58,7 @@ func TestSlackRedactedURL(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.SecretURL{URL: u},
+			APIURL:     &receivers.SecretURL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -192,9 +193,9 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 			apiurl, _ := url.Parse("https://slack.com/post.Message")
 			notifier, err := New(
 				&Config{
-					NotifierConfig: config.NotifierConfig{},
+					NotifierConfig: receivers.NotifierConfig{},
 					HTTPConfig:     &httpcfg.HTTPClientConfig{},
-					APIURL:         &config.SecretURL{URL: apiurl},
+					APIURL:         &receivers.SecretURL{URL: apiurl},
 					Channel:        "channelname",
 				},
 				test.CreateTmpl(t),

--- a/receivers/sns/v0mimir1/config.go
+++ b/receivers/sns/v0mimir1/config.go
@@ -17,8 +17,9 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/common/sigv4"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -28,7 +29,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for SNS configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Subject: `{{ template "sns.default.subject" . }}`,
@@ -37,7 +38,7 @@ var DefaultConfig = Config{
 
 // Config configures notifications via SNS.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 

--- a/receivers/teams/v0mimir1/config.go
+++ b/receivers/teams/v0mimir1/config.go
@@ -17,7 +17,7 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -27,7 +27,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for MS Teams configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Title:   `{{ template "msteams.default.title" . }}`,
@@ -37,10 +37,10 @@ var DefaultConfig = Config{
 
 // Config configures notifications via MS Teams.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *config.SecretURL         `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *receivers.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                    `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title   string `yaml:"title,omitempty" json:"title,omitempty"`

--- a/receivers/teams/v0mimir1/teams.go
+++ b/receivers/teams/v0mimir1/teams.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -50,7 +51,7 @@ type Notifier struct {
 	logger       log.Logger
 	client       *http.Client
 	retrier      *notify.Retrier
-	webhookURL   *config.SecretURL
+	webhookURL   *receivers.SecretURL
 	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
 }
 

--- a/receivers/teams/v0mimir1/teams_test.go
+++ b/receivers/teams/v0mimir1/teams_test.go
@@ -26,12 +26,13 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -42,7 +43,7 @@ var testWebhookURL, _ = url.Parse("https://example.webhook.office.com/webhookb2/
 func TestMSTeamsRetry(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &receivers.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -110,7 +111,7 @@ func TestMSTeamsTemplating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &receivers.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)
@@ -266,7 +267,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier, err := New(
 				&Config{
-					WebhookURL: &config.SecretURL{URL: testWebhookURL},
+					WebhookURL: &receivers.SecretURL{URL: testWebhookURL},
 					HTTPConfig: &httpcfg.HTTPClientConfig{},
 				},
 				test.CreateTmpl(t),
@@ -326,7 +327,7 @@ func TestMSTeamsRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&Config{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &receivers.SecretURL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/receivers/teams/v0mimir2/config.go
+++ b/receivers/teams/v0mimir2/config.go
@@ -17,7 +17,7 @@ package v0mimir2
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -27,7 +27,7 @@ const Version = schema.V0mimir2
 
 // DefaultConfig defines default values for MS Teams V2 configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Title: `{{ template "msteamsv2.default.title" . }}`,
@@ -36,10 +36,10 @@ var DefaultConfig = Config{
 
 // Config configures notifications via MS Teams V2.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *config.SecretURL         `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *receivers.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                    `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title string `yaml:"title,omitempty" json:"title,omitempty"`

--- a/receivers/teams/v0mimir2/teams.go
+++ b/receivers/teams/v0mimir2/teams.go
@@ -28,10 +28,11 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -48,7 +49,7 @@ type Notifier struct {
 	logger       log.Logger
 	client       *http.Client
 	retrier      *notify.Retrier
-	webhookURL   *config.SecretURL
+	webhookURL   *receivers.SecretURL
 	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
 }
 

--- a/receivers/teams/v0mimir2/teams_test.go
+++ b/receivers/teams/v0mimir2/teams_test.go
@@ -30,10 +30,11 @@ import (
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
+
+	"github.com/grafana/alerting/receivers"
 )
 
 // This is a test URL that has been modified to not be valid.
@@ -42,7 +43,7 @@ var testWebhookURL, _ = url.Parse("https://example.westeurope.logic.azure.com:44
 func TestMSTeamsV2Retry(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &receivers.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -75,7 +76,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier, err := New(
 				&Config{
-					WebhookURL: &config.SecretURL{URL: testWebhookURL},
+					WebhookURL: &receivers.SecretURL{URL: testWebhookURL},
 					HTTPConfig: &httpcfg.HTTPClientConfig{},
 				},
 				test.CreateTmpl(t),
@@ -154,7 +155,7 @@ func TestMSTeamsV2Templating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &receivers.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)
@@ -191,7 +192,7 @@ func TestMSTeamsV2RedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&Config{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &receivers.SecretURL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/receivers/telegram/v0mimir1/config.go
+++ b/receivers/telegram/v0mimir1/config.go
@@ -17,7 +17,7 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -27,7 +27,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for Telegram configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	DisableNotifications: false,
@@ -37,17 +37,17 @@ var DefaultConfig = Config{
 
 // Config configures notifications via Telegram.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIUrl               *config.URL   `yaml:"api_url" json:"api_url,omitempty"`
-	BotToken             config.Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
-	BotTokenFile         string        `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
-	ChatID               int64         `yaml:"chat_id,omitempty" json:"chat,omitempty"`
-	Message              string        `yaml:"message,omitempty" json:"message,omitempty"`
-	DisableNotifications bool          `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
-	ParseMode            string        `yaml:"parse_mode,omitempty" json:"parse_mode,omitempty"`
+	APIUrl               *receivers.URL   `yaml:"api_url" json:"api_url,omitempty"`
+	BotToken             receivers.Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
+	BotTokenFile         string           `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
+	ChatID               int64            `yaml:"chat_id,omitempty" json:"chat,omitempty"`
+	Message              string           `yaml:"message,omitempty" json:"message,omitempty"`
+	DisableNotifications bool             `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
+	ParseMode            string           `yaml:"parse_mode,omitempty" json:"parse_mode,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/receivers/telegram/v0mimir1/telegram_test.go
+++ b/receivers/telegram/v0mimir1/telegram_test.go
@@ -28,16 +28,17 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestTelegramRetry(t *testing.T) {
 	// Fake url for testing purposes
-	fakeURL := config.URL{
+	fakeURL := receivers.URL{
 		URL: &url.URL{
 			Scheme: "https",
 			Host:   "FAKE_API",
@@ -77,7 +78,7 @@ func TestTelegramNotify(t *testing.T) {
 			cfg: Config{
 				Message:    "<code>x < y</code>",
 				HTTPConfig: &httpcfg.HTTPClientConfig{},
-				BotToken:   config.Secret(token),
+				BotToken:   receivers.Secret(token),
 			},
 			expText: "<code>x < y</code>",
 		},
@@ -87,7 +88,7 @@ func TestTelegramNotify(t *testing.T) {
 				ParseMode:  "HTML",
 				Message:    "<code>x < y</code>",
 				HTTPConfig: &httpcfg.HTTPClientConfig{},
-				BotToken:   config.Secret(token),
+				BotToken:   receivers.Secret(token),
 			},
 			expText: "<code>x &lt; y</code>",
 		},
@@ -113,7 +114,7 @@ func TestTelegramNotify(t *testing.T) {
 			defer srv.Close()
 			u, _ := url.Parse(srv.URL)
 
-			tc.cfg.APIUrl = &config.URL{URL: u}
+			tc.cfg.APIUrl = &receivers.URL{URL: u}
 
 			notifier, err := New(&tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)

--- a/receivers/v0mimir.go
+++ b/receivers/v0mimir.go
@@ -149,7 +149,7 @@ func (s *SecretURL) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, (*URL)(s))
 }
 
-func mustParseURL(s string) *URL {
+func MustParseURL(s string) *URL {
 	u, err := parseURL(s)
 	if err != nil {
 		panic(err)

--- a/receivers/v0mimir.go
+++ b/receivers/v0mimir.go
@@ -1,0 +1,239 @@
+package receivers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+)
+
+type NotifierConfig struct {
+	VSendResolved bool `yaml:"send_resolved" json:"send_resolved"`
+}
+
+func (nc *NotifierConfig) SendResolved() bool {
+	return nc.VSendResolved
+}
+
+const secretToken = "<secret>"
+
+var secretTokenJSON string
+
+func init() {
+	b, err := json.Marshal(secretToken)
+	if err != nil {
+		panic(err)
+	}
+	secretTokenJSON = string(b)
+}
+
+// Secret is a string that must not be revealed on marshaling.
+type Secret string
+
+// MarshalYAML implements the yaml.Marshaler interface for Secret.
+func (s Secret) MarshalYAML() (interface{}, error) {
+	if s != "" {
+		return secretToken, nil
+	}
+	return nil, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Secret.
+func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain Secret
+	return unmarshal((*plain)(s))
+}
+
+// MarshalJSON implements the json.Marshaler interface for Secret.
+func (s Secret) MarshalJSON() ([]byte, error) {
+	return json.Marshal(secretToken)
+}
+
+// URL is a custom type that represents an HTTP or HTTPS URL and allows validation at configuration load time.
+type URL struct {
+	*url.URL
+}
+
+// Copy makes a deep-copy of the struct.
+func (u *URL) Copy() *URL {
+	v := *u.URL
+	return &URL{&v}
+}
+
+// MarshalYAML implements the yaml.Marshaler interface for URL.
+func (u URL) MarshalYAML() (interface{}, error) {
+	if u.URL != nil {
+		return u.String(), nil
+	}
+	return nil, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for URL.
+func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	urlp, err := parseURL(s)
+	if err != nil {
+		return err
+	}
+	u.URL = urlp.URL
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for URL.
+func (u URL) MarshalJSON() ([]byte, error) {
+	if u.URL != nil {
+		return json.Marshal(u.String())
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements the json.Marshaler interface for URL.
+func (u *URL) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	urlp, err := parseURL(s)
+	if err != nil {
+		return err
+	}
+	u.URL = urlp.URL
+	return nil
+}
+
+// SecretURL is a URL that must not be revealed on marshaling.
+type SecretURL URL
+
+// MarshalYAML implements the yaml.Marshaler interface for SecretURL.
+func (s SecretURL) MarshalYAML() (interface{}, error) {
+	if s.URL != nil {
+		return secretToken, nil
+	}
+	return nil, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for SecretURL.
+func (s *SecretURL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	// In order to deserialize a previously serialized configuration (eg from
+	// the Alertmanager API with amtool), `<secret>` needs to be treated
+	// specially, as it isn't a valid URL.
+	if str == secretToken {
+		s.URL = &url.URL{}
+		return nil
+	}
+	return unmarshal((*URL)(s))
+}
+
+// MarshalJSON implements the json.Marshaler interface for SecretURL.
+func (s SecretURL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(secretToken)
+}
+
+// UnmarshalJSON implements the json.Marshaler interface for SecretURL.
+func (s *SecretURL) UnmarshalJSON(data []byte) error {
+	// In order to deserialize a previously serialized configuration (eg from
+	// the Alertmanager API with amtool), `<secret>` needs to be treated
+	// specially, as it isn't a valid URL.
+	if string(data) == secretToken || string(data) == secretTokenJSON {
+		s.URL = &url.URL{}
+		return nil
+	}
+	return json.Unmarshal(data, (*URL)(s))
+}
+
+func mustParseURL(s string) *URL {
+	u, err := parseURL(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func parseURL(s string) (*URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q for URL", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, errors.New("missing host for URL")
+	}
+	return &URL{u}, nil
+}
+
+// HostPort represents a "host:port" network address.
+type HostPort struct {
+	Host string
+	Port string
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for HostPort.
+func (hp *HostPort) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var (
+		s   string
+		err error
+	)
+	if err = unmarshal(&s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	hp.Host, hp.Port, err = net.SplitHostPort(s)
+	if err != nil {
+		return err
+	}
+	if hp.Port == "" {
+		return fmt.Errorf("address %q: port cannot be empty", s)
+	}
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for HostPort.
+func (hp *HostPort) UnmarshalJSON(data []byte) error {
+	var (
+		s   string
+		err error
+	)
+	if err = json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	hp.Host, hp.Port, err = net.SplitHostPort(s)
+	if err != nil {
+		return err
+	}
+	if hp.Port == "" {
+		return fmt.Errorf("address %q: port cannot be empty", s)
+	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface for HostPort.
+func (hp HostPort) MarshalYAML() (interface{}, error) {
+	return hp.String(), nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for HostPort.
+func (hp HostPort) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hp.String())
+}
+
+func (hp HostPort) String() string {
+	if hp.Host == "" && hp.Port == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s", hp.Host, hp.Port)
+}

--- a/receivers/v0mimir_test.go
+++ b/receivers/v0mimir_test.go
@@ -1,0 +1,229 @@
+package receivers
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestJSONMarshalSecret(t *testing.T) {
+	test := struct {
+		S Secret
+	}{
+		S: Secret("test"),
+	}
+
+	c, err := json.Marshal(test)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"S":"<secret>"}`, string(c), "Secret not properly elided.")
+}
+
+func TestJSONMarshalHideSecretURL(t *testing.T) {
+	urlp, err := url.Parse("http://example.com/")
+	require.NoError(t, err)
+	u := &SecretURL{urlp}
+
+	c, err := json.Marshal(u)
+	require.NoError(t, err)
+	// u003c -> "<"
+	// u003e -> ">"
+	require.Equal(t, "\"\\u003csecret\\u003e\"", string(c), "SecretURL not properly elided in JSON.")
+	// Check that the marshaled data can be unmarshaled again.
+	out := &SecretURL{}
+	err = json.Unmarshal(c, out)
+	require.NoError(t, err)
+
+	c, err = yaml.Marshal(u)
+	require.NoError(t, err)
+	require.Equal(t, "<secret>\n", string(c), "SecretURL not properly elided in YAML.")
+	// Check that the marshaled data can be unmarshaled again.
+	out = &SecretURL{}
+	err = yaml.Unmarshal(c, &out)
+	require.NoError(t, err)
+}
+
+func TestUnmarshalSecretURL(t *testing.T) {
+	b := []byte(`"http://example.com/se cret"`)
+	var u SecretURL
+
+	err := json.Unmarshal(b, &u)
+	require.NoError(t, err)
+	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in JSON.")
+
+	err = yaml.Unmarshal(b, &u)
+	require.NoError(t, err)
+	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in YAML.")
+}
+
+func TestMarshalURL(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input        *URL
+		expectedJSON string
+		expectedYAML string
+	}{
+		"url": {
+			input:        MustParseURL("http://example.com/"),
+			expectedJSON: "\"http://example.com/\"",
+			expectedYAML: "http://example.com/\n",
+		},
+
+		"wrapped nil value": {
+			input:        &URL{},
+			expectedJSON: "null",
+			expectedYAML: "null\n",
+		},
+
+		"wrapped empty URL": {
+			input:        &URL{&url.URL{}},
+			expectedJSON: "\"\"",
+			expectedYAML: "\"\"\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			j, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedJSON, string(j), "URL not properly marshaled into JSON.")
+
+			y, err := yaml.Marshal(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedYAML, string(y), "URL not properly marshaled into YAML.")
+		})
+	}
+}
+
+func TestUnmarshalNilURL(t *testing.T) {
+	b := []byte(`null`)
+
+	{
+		var u URL
+		err := json.Unmarshal(b, &u)
+		require.Error(t, err, "unsupported scheme \"\" for URL")
+	}
+
+	{
+		var u URL
+		err := yaml.Unmarshal(b, &u)
+		require.NoError(t, err)
+	}
+}
+
+func TestUnmarshalEmptyURL(t *testing.T) {
+	b := []byte(`""`)
+
+	{
+		var u URL
+		err := json.Unmarshal(b, &u)
+		require.Error(t, err, "unsupported scheme \"\" for URL")
+		require.Equal(t, (*url.URL)(nil), u.URL)
+	}
+
+	{
+		var u URL
+		err := yaml.Unmarshal(b, &u)
+		require.Error(t, err, "unsupported scheme \"\" for URL")
+		require.Equal(t, (*url.URL)(nil), u.URL)
+	}
+}
+
+func TestUnmarshalURL(t *testing.T) {
+	b := []byte(`"http://example.com/a b"`)
+	var u URL
+
+	err := json.Unmarshal(b, &u)
+	require.NoError(t, err)
+	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshaled in JSON.")
+
+	err = yaml.Unmarshal(b, &u)
+	require.NoError(t, err)
+	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshaled in YAML.")
+}
+
+func TestUnmarshalInvalidURL(t *testing.T) {
+	for _, b := range [][]byte{
+		[]byte(`"://example.com"`),
+		[]byte(`"http:example.com"`),
+		[]byte(`"telnet://example.com"`),
+	} {
+		var u URL
+
+		err := json.Unmarshal(b, &u)
+		require.Error(t, err, "Expected an error unmarshaling %q from JSON", string(b))
+
+		err = yaml.Unmarshal(b, &u)
+		require.Error(t, err, "Expected an error unmarshaling %q from YAML", string(b))
+	}
+}
+
+func TestUnmarshalRelativeURL(t *testing.T) {
+	b := []byte(`"/home"`)
+	var u URL
+
+	err := json.Unmarshal(b, &u)
+	require.Error(t, err, "Expected an error parsing relative URL from JSON")
+
+	err = yaml.Unmarshal(b, &u)
+	require.Error(t, err, "Expected an error parsing relative URL from YAML")
+}
+
+func TestUnmarshalHostPort(t *testing.T) {
+	for _, tc := range []struct {
+		in string
+
+		exp     HostPort
+		jsonOut string
+		yamlOut string
+		err     bool
+	}{
+		{
+			in:  `""`,
+			exp: HostPort{},
+			yamlOut: `""
+`,
+			jsonOut: `""`,
+		},
+		{
+			in:  `"localhost:25"`,
+			exp: HostPort{Host: "localhost", Port: "25"},
+			yamlOut: `localhost:25
+`,
+			jsonOut: `"localhost:25"`,
+		},
+		{
+			in:  `":25"`,
+			exp: HostPort{Host: "", Port: "25"},
+			yamlOut: `:25
+`,
+			jsonOut: `":25"`,
+		},
+		{
+			in:  `"localhost"`,
+			err: true,
+		},
+		{
+			in:  `"localhost:"`,
+			err: true,
+		},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			hp := HostPort{}
+			err := yaml.Unmarshal([]byte(tc.in), &hp)
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, hp)
+
+			b, err := yaml.Marshal(&hp)
+			require.NoError(t, err)
+			require.Equal(t, tc.yamlOut, string(b))
+
+			b, err = json.Marshal(&hp)
+			require.NoError(t, err)
+			require.Equal(t, tc.jsonOut, string(b))
+		})
+	}
+}

--- a/receivers/victorops/v0mimir1/config.go
+++ b/receivers/victorops/v0mimir1/config.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/prometheus/alertmanager/config"
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -28,7 +28,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for VictorOps configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	MessageType:       `CRITICAL`,
@@ -39,13 +39,13 @@ var DefaultConfig = Config{
 
 // Config configures notifications via VictorOps.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIKey            config.Secret     `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKey            receivers.Secret  `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile        string            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
-	APIURL            *config.URL       `yaml:"api_url" json:"api_url"`
+	APIURL            *receivers.URL    `yaml:"api_url" json:"api_url"`
 	RoutingKey        string            `yaml:"routing_key" json:"routing_key"`
 	MessageType       string            `yaml:"message_type" json:"message_type"`
 	StateMessage      string            `yaml:"state_message" json:"state_message"`

--- a/receivers/victorops/v0mimir1/victorops_test.go
+++ b/receivers/victorops/v0mimir1/victorops_test.go
@@ -24,12 +24,13 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -44,7 +45,7 @@ func TestVictorOpsCustomFields(t *testing.T) {
 
 	conf := &Config{
 		APIKey:            `12345`,
-		APIURL:            &config.URL{URL: url},
+		APIURL:            &receivers.URL{URL: url},
 		EntityDisplayName: `{{ .CommonLabels.Message }}`,
 		StateMessage:      `{{ .CommonLabels.Message }}`,
 		RoutingKey:        `test`,
@@ -87,7 +88,7 @@ func TestVictorOpsCustomFields(t *testing.T) {
 func TestVictorOpsRetry(t *testing.T) {
 	notifier, err := New(
 		&Config{
-			APIKey:     config.Secret("secret"),
+			APIKey:     receivers.Secret("secret"),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -107,8 +108,8 @@ func TestVictorOpsRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.URL{URL: u},
-			APIKey:     config.Secret(secret),
+			APIURL:     &receivers.URL{URL: u},
+			APIKey:     receivers.Secret(secret),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -131,7 +132,7 @@ func TestVictorOpsReadingApiKeyFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &receivers.URL{URL: u},
 			APIKeyFile: f.Name(),
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
@@ -204,7 +205,7 @@ func TestVictorOpsTemplating(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.cfg.HTTPConfig = &httpcfg.HTTPClientConfig{}
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &receivers.URL{URL: u}
 			tc.cfg.APIKey = "test"
 			vo, err := New(tc.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)

--- a/receivers/webex/v0mimir1/config.go
+++ b/receivers/webex/v0mimir1/config.go
@@ -17,9 +17,8 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
-
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 )
 
@@ -27,7 +26,7 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for Webex configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 	Message: `{{ template "webex.default.message" . }}`,
@@ -35,11 +34,11 @@ var DefaultConfig = Config{
 
 // Config configures notifications via Webex.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig            *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	APIURL                *config.URL               `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	Message               string                    `yaml:"message,omitempty" json:"message,omitempty"`
-	RoomID                string                    `yaml:"room_id" json:"room_id"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig               *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	APIURL                   *receivers.URL            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	Message                  string                    `yaml:"message,omitempty" json:"message,omitempty"`
+	RoomID                   string                    `yaml:"room_id" json:"room_id"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/receivers/webex/v0mimir1/webex_test.go
+++ b/receivers/webex/v0mimir1/webex_test.go
@@ -26,11 +26,12 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestWebexRetry(t *testing.T) {
@@ -40,7 +41,7 @@ func TestWebexRetry(t *testing.T) {
 	notifier, err := New(
 		&Config{
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
-			APIURL:     &config.URL{URL: testWebhookURL},
+			APIURL:     &receivers.URL{URL: testWebhookURL},
 		},
 		test.CreateTmpl(t),
 		log.NewNopLogger(),
@@ -102,7 +103,7 @@ func TestWebexTemplating(t *testing.T) {
 			defer srv.Close()
 			u, _ := url.Parse(srv.URL)
 
-			tt.cfg.APIURL = &config.URL{URL: u}
+			tt.cfg.APIURL = &receivers.URL{URL: u}
 			tt.cfg.HTTPConfig = tt.commonCfg
 			notifierWebex, err := New(tt.cfg, test.CreateTmpl(t), log.NewNopLogger())
 			require.NoError(t, err)

--- a/receivers/webhook/v0mimir1/config.go
+++ b/receivers/webhook/v0mimir1/config.go
@@ -17,8 +17,9 @@ package v0mimir1
 import (
 	"errors"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -28,20 +29,20 @@ const Version = schema.V0mimir1
 
 // DefaultConfig defines default values for Webhook configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: true,
 	},
 }
 
 // Config configures notifications via a generic webhook.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	// URL to send POST request to.
-	URL     *config.SecretURL `yaml:"url" json:"url"`
-	URLFile string            `yaml:"url_file" json:"url_file"`
+	URL     *receivers.SecretURL `yaml:"url" json:"url"`
+	URLFile string               `yaml:"url_file" json:"url_file"`
 
 	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
 	// Alerts exceeding this threshold will be truncated. Setting this to 0

--- a/receivers/webhook/v0mimir1/webhook_test.go
+++ b/receivers/webhook/v0mimir1/webhook_test.go
@@ -25,10 +25,11 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
-	httpcfg "github.com/grafana/alerting/http/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 )
 
 func TestWebhookRetry(t *testing.T) {
@@ -38,7 +39,7 @@ func TestWebhookRetry(t *testing.T) {
 	}
 	notifier, err := New(
 		&Config{
-			URL:        &config.SecretURL{URL: u},
+			URL:        &receivers.SecretURL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -107,7 +108,7 @@ func TestWebhookRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&Config{
-			URL:        &config.SecretURL{URL: u},
+			URL:        &receivers.SecretURL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/receivers/wechat/v0mimir1/config.go
+++ b/receivers/wechat/v0mimir1/config.go
@@ -18,9 +18,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/prometheus/alertmanager/config"
-
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 )
 
@@ -32,7 +31,7 @@ var wechatTypeMatcher = regexp.MustCompile(wechatValidTypesRe)
 
 // DefaultConfig defines default values for wechat configurations.
 var DefaultConfig = Config{
-	NotifierConfig: config.NotifierConfig{
+	NotifierConfig: receivers.NotifierConfig{
 		VSendResolved: false,
 	},
 	Message: `{{ template "wechat.default.message" . }}`,
@@ -44,19 +43,19 @@ var DefaultConfig = Config{
 
 // Config configures notifications via Wechat.
 type Config struct {
-	config.NotifierConfig `yaml:",inline" json:",inline"`
+	receivers.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *httpcfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APISecret   config.Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
-	CorpID      string        `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
-	Message     string        `yaml:"message,omitempty" json:"message,omitempty"`
-	APIURL      *config.URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	ToUser      string        `yaml:"to_user,omitempty" json:"to_user,omitempty"`
-	ToParty     string        `yaml:"to_party,omitempty" json:"to_party,omitempty"`
-	ToTag       string        `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
-	AgentID     string        `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
-	MessageType string        `yaml:"message_type,omitempty" json:"message_type,omitempty"`
+	APISecret   receivers.Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
+	CorpID      string           `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
+	Message     string           `yaml:"message,omitempty" json:"message,omitempty"`
+	APIURL      *receivers.URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	ToUser      string           `yaml:"to_user,omitempty" json:"to_user,omitempty"`
+	ToParty     string           `yaml:"to_party,omitempty" json:"to_party,omitempty"`
+	ToTag       string           `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
+	AgentID     string           `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
+	MessageType string           `yaml:"message_type,omitempty" json:"message_type,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -106,7 +105,7 @@ var Schema = schema.IntegrationSchemaVersion{
 		{
 			Label:        "Message",
 			Description:  "API request data as defined by the WeChat API",
-			Placeholder:  config.DefaultWechatConfig.Message,
+			Placeholder:  DefaultConfig.Message,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "message",
@@ -124,28 +123,28 @@ var Schema = schema.IntegrationSchemaVersion{
 		},
 		{
 			Label:        "Agent ID",
-			Placeholder:  config.DefaultWechatConfig.AgentID,
+			Placeholder:  DefaultConfig.AgentID,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "agent_id",
 		},
 		{
 			Label:        "To User",
-			Placeholder:  config.DefaultWechatConfig.ToUser,
+			Placeholder:  DefaultConfig.ToUser,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "to_user",
 		},
 		{
 			Label:        "To Party",
-			Placeholder:  config.DefaultWechatConfig.ToParty,
+			Placeholder:  DefaultConfig.ToParty,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "to_party",
 		},
 		{
 			Label:        "To Tag",
-			Placeholder:  config.DefaultWechatConfig.ToTag,
+			Placeholder:  DefaultConfig.ToTag,
 			Element:      schema.ElementTypeInput,
 			InputType:    schema.InputTypeText,
 			PropertyName: "to_tag",

--- a/receivers/wechat/v0mimir1/wechat_test.go
+++ b/receivers/wechat/v0mimir1/wechat_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir1"
 )
@@ -33,10 +34,10 @@ func TestWechatRedactedURLOnInitialAuthentication(t *testing.T) {
 	secret := "secret_key"
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &receivers.URL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 			CorpID:     "corpid",
-			APISecret:  config.Secret(secret),
+			APISecret:  receivers.Secret(secret),
 		},
 		test.CreateTmpl(t),
 		log.NewNopLogger(),
@@ -55,10 +56,10 @@ func TestWechatRedactedURLOnNotify(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &receivers.URL{URL: u},
 			HTTPConfig: &httpcfg.HTTPClientConfig{},
 			CorpID:     "corpid",
-			APISecret:  config.Secret(secret),
+			APISecret:  receivers.Secret(secret),
 		},
 		test.CreateTmpl(t),
 		log.NewNopLogger(),
@@ -77,10 +78,10 @@ func TestWechatMessageTypeSelector(t *testing.T) {
 
 	notifier, err := New(
 		&Config{
-			APIURL:      &config.URL{URL: u},
+			APIURL:      &receivers.URL{URL: u},
 			HTTPConfig:  &httpcfg.HTTPClientConfig{},
 			CorpID:      "corpid",
-			APISecret:   config.Secret(secret),
+			APISecret:   receivers.Secret(secret),
 			MessageType: "markdown",
 		},
 		test.CreateTmpl(t),


### PR DESCRIPTION
## Summary

This PR continues the work from #484 by copying second-level type dependencies from `github.com/prometheus/alertmanager/config` into the local codebase. This decouples legacy (v0mimir) receiver configurations from the upstream Alertmanager config package, giving us full ownership of these types.

## What changed

### New file: `receivers/v0mimir.go`

Copied the following foundational types from `prometheus/alertmanager/config` into the `receivers` package:

- **`NotifierConfig`** — base config struct with `SendResolved` support
- **`Secret`** — string type with masked YAML/JSON marshaling
- **`URL`** — validated HTTP/HTTPS URL with custom marshal/unmarshal
- **`SecretURL`** — URL type with masked marshaling (like `Secret` but for URLs)
- **`HostPort`** — `"host:port"` network address type
- Helper functions: `parseURL`, `mustParseURL`

### Integration-specific types moved locally

Types that are only used by a single integration were placed in that integration's package rather than in the shared `receivers` package:

- **`PagerdutyImage`, `PagerdutyLink`** → `receivers/pagerduty/v0mimir1/config.go`
- **`SlackField`, `SlackAction`, `SlackConfirmationField`** → `receivers/slack/v0mimir1/config.go`

### All v0mimir receiver configs updated

Every legacy integration (`receivers/*/v0mimir1/` and `receivers/*/v0mimir2/`) was updated to use the local types instead of importing from `github.com/prometheus/alertmanager/config`. This affects config structs, tests, and notifier implementations across 14 integrations: discord, email, jira, opsgenie, pagerduty, pushover, slack, sns, teams (v1+v2), telegram, victorops, webex, webhook, wechat.

### Default config references inlined

References to upstream defaults were replaced with the local `DefaultConfig`:
- `config.DefaultWechatConfig.X` → `DefaultConfig.X` in wechat
- `config.DefaultJiraConfig.X` → `DefaultConfig.X` in jira

### Compat layer updated (`definition/`)

The compatibility layer that bridges between upstream `config.Receiver` and local `definition.Receiver` was updated with explicit type conversions:

- **`definition/compat.go`** — Added casts (`receivers.Secret()`, `(*receivers.URL)()`, etc.) when propagating `GlobalConfig` fields to receiver configs
- **`definition/compat/receiver_compat.go`** — Updated both `UpstreamReceiverToDefinitionReceiver` and `DefinitionReceiverToUpstreamReceiver` with explicit conversions between `config.*` ↔ `receivers.*` types. Added helper functions for slice conversions (pagerduty images/links, slack fields/actions)
- **`definition/json.go`** — Registered `receivers.Secret` and `receivers.SecretURL` in the custom JSON encoder so `MarshalJSONWithSecrets` handles both upstream and local secret types
- **`definition/json_test.go`** — Extended `TestSecretOmitempty` to cover all three type families: `receivers.*`, `config.*`, and `commoncfg.*`

## Why

The upstream `config` package couples our receiver implementations to Prometheus Alertmanager's type system. By owning these types locally we can:

1. Evolve receiver configs independently of upstream releases
2. Reduce the public API surface exposed to consumers
3. Prepare for further decoupling in future versions

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./definition/...` passes
- [x] `go test ./receivers/...` compiles and key integration tests pass
- [x] No remaining `github.com/prometheus/alertmanager/config` imports in any `v0mimir*` package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many legacy receiver integrations and the compat/serialization layer; risk is mainly in subtle type-conversion or marshaling/unmarshaling behavior changes for secrets/URLs and receiver config fields.
> 
> **Overview**
> Decouples legacy `v0mimir` receiver configs from `github.com/prometheus/alertmanager/config` by introducing local foundational types in `receivers` (`NotifierConfig`, `Secret`, `URL`, `SecretURL`, `HostPort`) and migrating integrations to use them.
> 
> Updates the definition compat layer to explicitly cast between upstream `config.*` and local `receivers.*` types (including new helper conversions for PagerDuty images/links and Slack fields/actions), and extends `MarshalJSONWithSecrets` to handle `receivers.Secret`/`receivers.SecretURL` in addition to upstream/common secret types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a90e70d66d0729300bf89a5fcaab92dc62dab3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->