### PR TITLE
Notify: Add support for metrics range queries to lokiclient

### DIFF
--- a/notify/historian/lokiclient/client_test.go
+++ b/notify/historian/lokiclient/client_test.go
@@ -288,6 +288,129 @@ func TestLokiHTTPClient_MetricsQuery(t *testing.T) {
 	})
 }
 
+func TestLokiHTTPClient_MetricsRangeQuery(t *testing.T) {
+	okResponse := func() *http.Response {
+		return &http.Response{
+			Status:        "200 OK",
+			StatusCode:    200,
+			Body:          io.NopCloser(bytes.NewBufferString(`{}`)),
+			ContentLength: int64(0),
+			Header:        make(http.Header, 0),
+		}
+	}
+
+	t.Run("hits query_range endpoint", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, now-100, now, defaultPageSize)
+
+		require.NoError(t, err)
+		require.Contains(t, req.LastRequest.URL.Path, "/loki/api/v1/query_range")
+	})
+
+	t.Run("passes along start and end parameters", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+		start := now - 100
+
+		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, start, now, defaultPageSize)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.True(t, params.Has("start"), "query params did not contain 'start': %#v", params)
+		require.True(t, params.Has("end"), "query params did not contain 'end': %#v", params)
+		require.Equal(t, fmt.Sprint(start), params.Get("start"))
+		require.Equal(t, fmt.Sprint(now), params.Get("end"))
+		require.False(t, params.Has("time"), "metrics range query should not have 'time' param")
+	})
+
+	t.Run("passes along page size", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, now-100, now, 1100)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.True(t, params.Has("limit"), "query params did not contain 'limit': %#v", params)
+		require.Equal(t, fmt.Sprint(1100), params.Get("limit"))
+	})
+
+	t.Run("uses default page size if limit not provided", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, now-100, now, 0)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.Equal(t, fmt.Sprint(defaultPageSize), params.Get("limit"))
+	})
+
+	t.Run("uses maximum page size if limit too big", func(t *testing.T) {
+		resp := okResponse()
+		t.Cleanup(func() { resp.Body.Close() })
+		req := instrumenttest.NewFakeRequester().WithResponse(resp)
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, now-100, now, maximumPageSize+1000)
+
+		require.NoError(t, err)
+		params := req.LastRequest.URL.Query()
+		require.Equal(t, fmt.Sprint(maximumPageSize), params.Get("limit"))
+	})
+
+	t.Run("returns error if start is after end", func(t *testing.T) {
+		req := instrumenttest.NewFakeRequester()
+		client := createTestLokiClient(req)
+		now := time.Now().UTC().UnixNano()
+
+		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, now, now-100, defaultPageSize)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "start time cannot be after end time")
+	})
+
+	t.Run("parses metric range sample response", func(t *testing.T) {
+		body := `{"data":{"result":[{"metric":{"job":"my-app"},"values":[[1700000000.0,"1.5"],[1700000060.0,"2.0"]]}]}}`
+		req := instrumenttest.NewFakeRequester().WithResponse(&http.Response{
+			Status:     "200 OK",
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+			Header:     make(http.Header, 0),
+		})
+		client := createTestLokiClient(req)
+		now := time.Now().UnixNano()
+
+		res, err := client.MetricsRangeQuery(context.Background(), `rate({job="my-app"}[5m])`, now-int64(time.Minute), now, defaultPageSize)
+
+		require.NoError(t, err)
+		require.Len(t, res.Data.Result, 1)
+		require.Equal(t, map[string]string{"job": "my-app"}, res.Data.Result[0].Metric)
+		require.Len(t, res.Data.Result[0].Values, 2)
+		ts, err := res.Data.Result[0].Values[0].Timestamp()
+		require.NoError(t, err)
+		require.InDelta(t, 1700000000.0, ts, 0.001)
+		val, err := res.Data.Result[0].Values[0].Value()
+		require.NoError(t, err)
+		require.Equal(t, "1.5", val)
+	})
+}
+
 func TestRow(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		row := Sample{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new Loki read-path API call and response types; changes are additive and covered by unit tests, with low likelihood of impacting existing query paths.
> 
> **Overview**
> Adds `HTTPLokiClient.MetricsRangeQuery` to perform Loki metrics *range* queries via `/loki/api/v1/query_range`, including start/end validation, range clamping, and limit defaulting/capping.
> 
> Introduces new response structs (`MetricsRangeQueryRes`, `MetricRangeSample`) to decode matrix-style `values` results, and adds unit tests verifying endpoint/params/limit behavior plus JSON parsing and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b07ef9eb845a003e5c367cc7191e74ec409ebcce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->