### PR TITLE
Notify: Add step parameter to lokiclient metrics range query function.

### DIFF
--- a/notify/historian/lokiclient/client.go
+++ b/notify/historian/lokiclient/client.go
@@ -337,7 +337,7 @@ func (c *HTTPLokiClient) MetricsRangeQuery(ctx context.Context, logQL string, st
 	values.Set("end", fmt.Sprintf("%d", end))
 	values.Set("limit", fmt.Sprintf("%d", limit))
 	if step > 0 {
-		values.Set("step", fmt.Sprintf("%d", step))
+		values.Set("step", fmt.Sprintf("%d", step/int64(time.Second)))
 	}
 
 	queryURL.RawQuery = values.Encode()

--- a/notify/historian/lokiclient/client.go
+++ b/notify/historian/lokiclient/client.go
@@ -317,7 +317,7 @@ func (c *HTTPLokiClient) MetricsQuery(ctx context.Context, logQL string, ts int6
 	return result, nil
 }
 
-func (c *HTTPLokiClient) MetricsRangeQuery(ctx context.Context, logQL string, start, end, limit int64) (MetricsRangeQueryRes, error) {
+func (c *HTTPLokiClient) MetricsRangeQuery(ctx context.Context, logQL string, start, end, limit, step int64) (MetricsRangeQueryRes, error) {
 	if start > end {
 		return MetricsRangeQueryRes{}, fmt.Errorf("start time cannot be after end time")
 	}
@@ -336,9 +336,12 @@ func (c *HTTPLokiClient) MetricsRangeQuery(ctx context.Context, logQL string, st
 	values.Set("start", fmt.Sprintf("%d", start))
 	values.Set("end", fmt.Sprintf("%d", end))
 	values.Set("limit", fmt.Sprintf("%d", limit))
+	if step > 0 {
+		values.Set("step", fmt.Sprintf("%d", step))
+	}
 
 	queryURL.RawQuery = values.Encode()
-	level.Debug(c.logger).Log("msg", "Sending metrics range query request", "query", logQL, "start", start, "end", end, "limit", limit)
+	level.Debug(c.logger).Log("msg", "Sending metrics range query request", "query", logQL, "start", start, "end", end, "limit", limit, "step", step)
 	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
 	if err != nil {
 		return MetricsRangeQueryRes{}, fmt.Errorf("error creating request: %w", err)

--- a/notify/historian/lokiclient/client.go
+++ b/notify/historian/lokiclient/client.go
@@ -337,7 +337,7 @@ func (c *HTTPLokiClient) MetricsRangeQuery(ctx context.Context, logQL string, st
 	values.Set("end", fmt.Sprintf("%d", end))
 	values.Set("limit", fmt.Sprintf("%d", limit))
 	if step > 0 {
-		values.Set("step", fmt.Sprintf("%d", step/int64(time.Second)))
+		values.Set("step", fmt.Sprintf("%d", step))
 	}
 
 	queryURL.RawQuery = values.Encode()

--- a/notify/historian/lokiclient/client_test.go
+++ b/notify/historian/lokiclient/client_test.go
@@ -385,7 +385,7 @@ func TestLokiHTTPClient_MetricsRangeQuery(t *testing.T) {
 		require.ErrorContains(t, err, "start time cannot be after end time")
 	})
 
-	t.Run("passes along step parameter", func(t *testing.T) {
+	t.Run("passes along step parameter converted to seconds", func(t *testing.T) {
 		resp := okResponse()
 		t.Cleanup(func() { resp.Body.Close() })
 		req := instrumenttest.NewFakeRequester().WithResponse(resp)
@@ -398,7 +398,7 @@ func TestLokiHTTPClient_MetricsRangeQuery(t *testing.T) {
 		require.NoError(t, err)
 		params := req.LastRequest.URL.Query()
 		require.True(t, params.Has("step"), "query params did not contain 'step': %#v", params)
-		require.Equal(t, fmt.Sprint(step), params.Get("step"))
+		require.Equal(t, "30", params.Get("step"))
 	})
 
 	t.Run("omits step parameter when zero", func(t *testing.T) {

--- a/notify/historian/lokiclient/client_test.go
+++ b/notify/historian/lokiclient/client_test.go
@@ -385,13 +385,13 @@ func TestLokiHTTPClient_MetricsRangeQuery(t *testing.T) {
 		require.ErrorContains(t, err, "start time cannot be after end time")
 	})
 
-	t.Run("passes along step parameter converted to seconds", func(t *testing.T) {
+	t.Run("passes along step parameter", func(t *testing.T) {
 		resp := okResponse()
 		t.Cleanup(func() { resp.Body.Close() })
 		req := instrumenttest.NewFakeRequester().WithResponse(resp)
 		client := createTestLokiClient(req)
 		now := time.Now().UTC().UnixNano()
-		step := int64(30 * time.Second)
+		step := int64(30)
 
 		_, err := client.MetricsRangeQuery(context.Background(), `rate({from="state-history"}[5m])`, now-100, now, defaultPageSize, step)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `MetricsRangeQuery` method signature and request construction, which can break callers and alter query resolution when `step` is provided. Behavior is otherwise unchanged when `step` is `0` (omitted).
> 
> **Overview**
> `HTTPLokiClient.MetricsRangeQuery` now accepts a `step` argument and, when non-zero, sends it to Loki as the `step` query parameter (converted from nanoseconds to seconds). The debug log for this request now includes `step`.
> 
> Tests were updated for the new function signature and extended to verify `step` is correctly encoded and omitted when zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b1a8380f382abb6af76185094fe2bc2b643fd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->