### PR TITLE
Add testing config for DingDing secrets

### DIFF
--- a/notify/notifytest/grafana_integrations.go
+++ b/notify/notifytest/grafana_integrations.go
@@ -68,6 +68,7 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		NotifierType: dingding.Type,
 		Version:      schema.V1,
 		Config:       dingdingv1.FullValidConfigForTesting,
+		Secrets:      dingdingv1.FullValidSecretsForTesting,
 	},
 	discord.Type: {
 		NotifierType: discord.Type,

--- a/receivers/dingding/v1/config_test.go
+++ b/receivers/dingding/v1/config_test.go
@@ -76,6 +76,18 @@ func TestNewConfig(t *testing.T) {
 				Message:     "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
 			},
 		},
+
+		{
+			name:     "Extracts all fields + override from secrets",
+			settings: FullValidConfigForTesting,
+			secrets:  receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
+			expectedConfig: Config{
+				URL:         "http://localhostsecret",
+				MessageType: "actionCard",
+				Title:       "Alerts firing: {{ len .Alerts.Firing }}",
+				Message:     "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/receivers/dingding/v1/testing.go
+++ b/receivers/dingding/v1/testing.go
@@ -7,3 +7,8 @@ const FullValidConfigForTesting = `{
     "title": "Alerts firing: {{ len .Alerts.Firing }}",
 	"msgType": "actionCard"
 }`
+
+// FullValidSecretsForTesting is a string representation of JSON object that contains all fields that can be overridden from secrets
+const FullValidSecretsForTesting = `{
+	"url": "http://localhostsecret"
+}`


### PR DESCRIPTION
No-op functionally, just adds some missing helpful testing constructs to fulfill dingding's schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test fixtures and test cases and do not affect runtime notifier behavior.
> 
> **Overview**
> Adds `dingdingv1.FullValidSecretsForTesting` and wires it into `notifytest.AllKnownV1ConfigsForTesting` so DingDing test integrations include representative secure settings.
> 
> Extends `receivers/dingding/v1` tests with a new case verifying `NewConfig` correctly overrides fields (e.g., `url`) from decrypted secrets when both settings and secrets are provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fef0351d96e7260d5d7e8cff3b7811ee56a0c9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->