### PR TITLE
Notify: Add folder UIDs to historian entries.

### DIFF
--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -158,7 +158,7 @@ func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryE
 		ts := now.Add(time.Nanosecond * time.Duration(i))
 
 		ruleUID := entryAlert.Labels[models.RuleUIDLabel]
-		folderUID := entryAlert.Labels[models.NamespaceUIDLabel]
+		folderUID := entryAlert.Annotations[models.NamespaceUIDLabel]
 		alertsValues[i] = lokiclient.Sample{
 			T: ts,
 			V: string(entryAlertJSON),

--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -36,6 +36,7 @@ type NotificationHistoryLokiEntry struct {
 	SchemaVersion  int               `json:"schemaVersion"`
 	UUID           string            `json:"uuid"`
 	RuleUIDs       []string          `json:"ruleUIDs"`
+	FolderUIDs     []string          `json:"folderUIDs"`
 	Receiver       string            `json:"receiver"`
 	Integration    string            `json:"integration"`
 	IntegrationIdx int               `json:"integrationIdx"`
@@ -130,6 +131,7 @@ func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryE
 	now := time.Now()
 	alertsValues := make([]lokiclient.Sample, len(nhe.Alerts))
 	ruleUIDsMap := make(map[string]struct{})
+	folderUIDsMap := make(map[string]struct{})
 	for i, alert := range nhe.Alerts {
 		labels := prepareLabels(alert.Labels)
 		annotations := prepareLabels(alert.Annotations)
@@ -156,16 +158,19 @@ func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryE
 		ts := now.Add(time.Nanosecond * time.Duration(i))
 
 		ruleUID := entryAlert.Labels[models.RuleUIDLabel]
+		folderUID := entryAlert.Labels[models.NamespaceUIDLabel]
 		alertsValues[i] = lokiclient.Sample{
 			T: ts,
 			V: string(entryAlertJSON),
 			Metadata: map[string]string{
-				"uuid":     nhe.UUID,
-				"rule_uid": ruleUID,
+				"uuid":       nhe.UUID,
+				"rule_uid":   ruleUID,
+				"folder_uid": folderUID,
 			},
 		}
 
 		ruleUIDsMap[ruleUID] = struct{}{}
+		folderUIDsMap[folderUID] = struct{}{}
 	}
 
 	notificationErrStr := ""
@@ -179,11 +184,13 @@ func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryE
 	}
 
 	ruleUIDs := slices.Sorted(maps.Keys(ruleUIDsMap))
+	folderUIDs := slices.Sorted(maps.Keys(folderUIDsMap))
 
 	entry := NotificationHistoryLokiEntry{
 		SchemaVersion:  SchemaVersion,
 		UUID:           nhe.UUID,
 		RuleUIDs:       ruleUIDs,
+		FolderUIDs:     folderUIDs,
 		Receiver:       nhe.ReceiverName,
 		Integration:    nhe.IntegrationName,
 		IntegrationIdx: nhe.IntegrationIdx,
@@ -209,9 +216,10 @@ func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryE
 		T: now,
 		V: string(entryJSON),
 		Metadata: map[string]string{
-			"uuid":      nhe.UUID,
-			"receiver":  nhe.ReceiverName,
-			"rule_uids": strings.Join(ruleUIDs, ","),
+			"uuid":        nhe.UUID,
+			"receiver":    nhe.ReceiverName,
+			"rule_uids":   strings.Join(ruleUIDs, ","),
+			"folder_uids": strings.Join(folderUIDs, ","),
 		},
 	}
 

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -39,7 +39,7 @@ var (
 	testAlerts       = []nfstatus.NotificationHistoryAlert{{
 		Alert: &types.Alert{
 			Alert: model.Alert{
-				Labels:       model.LabelSet{"alertname": "Alert1", alertingModels.RuleUIDLabel: "testRuleUID"},
+				Labels:       model.LabelSet{"alertname": "Alert1", alertingModels.RuleUIDLabel: "testRuleUID", alertingModels.NamespaceUIDLabel: "testFolderUID"},
 				Annotations:  model.LabelSet{"foo": "bar", "__private__": "baz"},
 				StartsAt:     testPipelineTime,
 				EndsAt:       testPipelineTime,
@@ -71,8 +71,8 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","ruleUIDs":["testRuleUID"],"receiver":"testReceiverName","integration":"testIntegrationName","integrationIdx":42,"groupKey":"testGroupKey","status":"resolved","groupLabels":{"foo":"bar"},"alertCount":1,"retry":false,"duration":1000000000,"pipelineTime":"2025-07-15T16:55:00Z"}`,
-								Metadata: map[string]string{"uuid": testUUID, "receiver": testReceiverName, "rule_uids": "testRuleUID"},
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","ruleUIDs":["testRuleUID"],"folderUIDs":["testFolderUID"],"receiver":"testReceiverName","integration":"testIntegrationName","integrationIdx":42,"groupKey":"testGroupKey","status":"resolved","groupLabels":{"foo":"bar"},"alertCount":1,"retry":false,"duration":1000000000,"pipelineTime":"2025-07-15T16:55:00Z"}`,
+								Metadata: map[string]string{"uuid": testUUID, "receiver": testReceiverName, "rule_uids": "testRuleUID", "folder_uids": "testFolderUID"},
 							},
 						},
 					},
@@ -84,8 +84,8 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
-								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID"},
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_namespace_uid__":"testFolderUID","__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
+								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID", "folder_uid": "testFolderUID"},
 							},
 						},
 					},
@@ -104,8 +104,8 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","ruleUIDs":["testRuleUID"],"receiver":"testReceiverName","integration":"testIntegrationName","integrationIdx":42,"groupKey":"testGroupKey","status":"resolved","groupLabels":{"foo":"bar"},"alertCount":1,"retry":true,"error":"test notification error","duration":1000000000,"pipelineTime":"2025-07-15T16:55:00Z"}`,
-								Metadata: map[string]string{"uuid": testUUID, "receiver": testReceiverName, "rule_uids": "testRuleUID"},
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","ruleUIDs":["testRuleUID"],"folderUIDs":["testFolderUID"],"receiver":"testReceiverName","integration":"testIntegrationName","integrationIdx":42,"groupKey":"testGroupKey","status":"resolved","groupLabels":{"foo":"bar"},"alertCount":1,"retry":true,"error":"test notification error","duration":1000000000,"pipelineTime":"2025-07-15T16:55:00Z"}`,
+								Metadata: map[string]string{"uuid": testUUID, "receiver": testReceiverName, "rule_uids": "testRuleUID", "folder_uids": "testFolderUID"},
 							},
 						},
 					},
@@ -117,8 +117,8 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
-								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID"},
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_namespace_uid__":"testFolderUID","__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
+								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID", "folder_uid": "testFolderUID"},
 							},
 						},
 					},

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -39,8 +39,8 @@ var (
 	testAlerts       = []nfstatus.NotificationHistoryAlert{{
 		Alert: &types.Alert{
 			Alert: model.Alert{
-				Labels:       model.LabelSet{"alertname": "Alert1", alertingModels.RuleUIDLabel: "testRuleUID", alertingModels.NamespaceUIDLabel: "testFolderUID"},
-				Annotations:  model.LabelSet{"foo": "bar", "__private__": "baz"},
+				Labels:       model.LabelSet{"alertname": "Alert1", alertingModels.RuleUIDLabel: "testRuleUID"},
+				Annotations:  model.LabelSet{"foo": "bar", "__private__": "baz", alertingModels.NamespaceUIDLabel: "testFolderUID"},
 				StartsAt:     testPipelineTime,
 				EndsAt:       testPipelineTime,
 				GeneratorURL: "http://localhost/test",
@@ -84,7 +84,7 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_namespace_uid__":"testFolderUID","__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__alert_rule_namespace_uid__":"testFolderUID","__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
 								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID", "folder_uid": "testFolderUID"},
 							},
 						},
@@ -117,7 +117,7 @@ func TestRecord(t *testing.T) {
 						Values: []lokiclient.Sample{
 							{
 								T:        testNow,
-								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_namespace_uid__":"testFolderUID","__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
+								V:        `{"schemaVersion":2,"uuid":"00000000-0000-0000-0000-000000000001","alertIndex":0,"status":"resolved","labels":{"__alert_rule_uid__":"testRuleUID","alertname":"Alert1"},"annotations":{"__alert_rule_namespace_uid__":"testFolderUID","__private__":"baz","foo":"bar"},"startsAt":"2025-07-15T16:55:00Z","endsAt":"2025-07-15T16:55:00Z","enrichments":{"things":["foo","bar"]}}`,
 								Metadata: map[string]string{"uuid": testUUID, "rule_uid": "testRuleUID", "folder_uid": "testFolderUID"},
 							},
 						},


### PR DESCRIPTION
Adds it to both the notification stream and alerts stream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata/serialization change that only affects what gets written to Loki; main risk is downstream consumers relying on the old log/metadata shape.
> 
> **Overview**
> Adds folder (namespace) UID attribution to notification history written to Loki.
> 
> `NotificationHistoryLokiEntry` now includes `folderUIDs`, and `prepareStreams` extracts `__alert_rule_namespace_uid__` from alert annotations to populate both per-alert metadata (`folder_uid`) and per-notification metadata (`folder_uids`). Tests are updated to assert the new JSON fields and metadata keys in both the notification and alert streams.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a1ab614a377e3298ac9845704f1363b968026af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->