### PR TITLE
Notify: Pass a notification ID to receivers via template data

### DIFF
--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -128,7 +128,7 @@ func (h *NotificationHistorian) Record(ctx context.Context, nhe nfstatus.Notific
 // 1. Contains a log line per notification, and contains metadata about the notification as a whole.
 // 2. Contains a log line per alert per notification, and a UUID linking back to the notification.
 func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryEntry) ([]lokiclient.Stream, error) {
-	now := time.Now()
+	now := nhe.Timestamp
 	alertsValues := make([]lokiclient.Sample, len(nhe.Alerts))
 	ruleUIDsMap := make(map[string]struct{})
 	folderUIDsMap := make(map[string]struct{})

--- a/notify/historian/historian_test.go
+++ b/notify/historian/historian_test.go
@@ -134,6 +134,7 @@ func TestRecord(t *testing.T) {
 				h := createTestNotificationHistorian(req, writesTotal, writesFailed)
 				h.Record(context.Background(), nfstatus.NotificationHistoryEntry{
 					UUID:            testUUID,
+					Timestamp:       testNow,
 					Alerts:          testAlerts,
 					GroupKey:        testGroupKey,
 					Retry:           tc.retry,
@@ -176,6 +177,7 @@ func TestRecord(t *testing.T) {
 
 		nhe := nfstatus.NotificationHistoryEntry{
 			UUID:            testUUID,
+			Timestamp:       testNow,
 			Alerts:          testAlerts,
 			GroupKey:        testGroupKey,
 			Retry:           false,

--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alerting/receivers"
 )
 
 var (
@@ -26,6 +29,7 @@ type NotificationHistoryAlert struct {
 
 type NotificationHistoryEntry struct {
 	UUID            string
+	Timestamp       time.Time
 	Alerts          []NotificationHistoryAlert
 	GroupKey        string
 	Retry           bool
@@ -43,6 +47,9 @@ func (e NotificationHistoryEntry) Validate() error {
 
 	if e.UUID == "" {
 		errs = append(errs, errors.New("missing UUID"))
+	}
+	if e.Timestamp.IsZero() {
+		errs = append(errs, errors.New("missing timestamp"))
 	}
 	if e.ReceiverName == "" {
 		errs = append(errs, errors.New("missing receiver name"))
@@ -179,11 +186,18 @@ type statusCaptureNotifier struct {
 
 // Notify implements the Notifier interface.
 func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+	// Generate a notification ID so the receiver can link back to the history entry.
+	// The ID is a composite of UUID and timestamp.
+	nfUUID := newUUID()
+	nfTimestamp := time.Now()
+	notificationID := fmt.Sprintf("%s?ts=%d", nfUUID, nfTimestamp.UnixMilli())
+	ctx = context.WithValue(ctx, receivers.NotificationIDKey, notificationID)
+
 	start := time.Now()
 	info, retry, err := n.upstream.Notify(ctx, alerts...)
 	duration := time.Since(start)
 
-	go n.recordNotificationHistory(ctx, alerts, retry, err, duration, info)
+	go n.recordNotificationHistory(ctx, nfUUID, nfTimestamp, alerts, retry, err, duration, info)
 
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
@@ -195,7 +209,7 @@ func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Ale
 	return retry, err
 }
 
-func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, alerts []*types.Alert, retry bool, err error, duration time.Duration, info NotifyInfo) {
+func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, nfUUID string, nfTimestamp time.Time, alerts []*types.Alert, retry bool, err error, duration time.Duration, info NotifyInfo) {
 	if n.notificationHistorian == nil {
 		return
 	}
@@ -219,7 +233,8 @@ func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, a
 	}
 
 	entry := NotificationHistoryEntry{
-		UUID:            newUUID(),
+		UUID:            nfUUID,
+		Timestamp:       nfTimestamp,
 		Alerts:          entryAlerts,
 		GroupKey:        groupKey,
 		Retry:           retry,

--- a/notify/nfstatus/integration_test.go
+++ b/notify/nfstatus/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -144,6 +145,11 @@ func TestIntegrationWithNotificationHistorian(t *testing.T) {
 
 	actual := notificationHistorian.Calls[0].Arguments.Get(1).(NotificationHistoryEntry)
 	actual.Duration = 0 // Zero out duration to make comparison easier.
+
+	assert.False(t, actual.Timestamp.IsZero(), "Timestamp should be set")
+	nfTimestamp := actual.Timestamp
+	actual.Timestamp = time.Time{} // Zero out for comparison.
+
 	expected := NotificationHistoryEntry{
 		UUID: "my-uuid",
 		Alerts: []NotificationHistoryAlert{{
@@ -161,6 +167,12 @@ func TestIntegrationWithNotificationHistorian(t *testing.T) {
 		PipelineTime:    testPipelineTime,
 	}
 	assert.Equal(t, expected, actual)
+
+	// Verify that the notification ID in context was the composite of UUID and timestamp.
+	capturedCtx := notificationHistorian.Calls[0].Arguments.Get(0).(context.Context)
+	notificationID, ok := receivers.GetNotificationIDFromContext(capturedCtx)
+	assert.True(t, ok)
+	assert.Equal(t, fmt.Sprintf("my-uuid?ts=%d", nfTimestamp.UnixMilli()), notificationID)
 }
 
 func TestNotificationHistoryEntry_Validate(t *testing.T) {
@@ -176,6 +188,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "valid entry passes validation",
 			entry: NotificationHistoryEntry{
 				UUID:         "test-uuid",
+				Timestamp:    now,
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
@@ -187,6 +200,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "empty group labels is valid",
 			entry: NotificationHistoryEntry{
 				UUID:         "test-uuid",
+				Timestamp:    now,
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{},
 				PipelineTime: now,
@@ -198,6 +212,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "missing UUID",
 			entry: NotificationHistoryEntry{
 				UUID:         "",
+				Timestamp:    now,
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
@@ -207,9 +222,23 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			expectedErrSubstr: []string{"missing UUID"},
 		},
 		{
+			name: "missing timestamp",
+			entry: NotificationHistoryEntry{
+				UUID:         "test-uuid",
+				Timestamp:    time.Time{},
+				ReceiverName: "test-receiver",
+				GroupLabels:  model.LabelSet{"foo": "bar"},
+				PipelineTime: now,
+				GroupKey:     "test-group-key",
+			},
+			wantErr:           true,
+			expectedErrSubstr: []string{"missing timestamp"},
+		},
+		{
 			name: "missing receiver name",
 			entry: NotificationHistoryEntry{
 				UUID:         "test-uuid",
+				Timestamp:    now,
 				ReceiverName: "",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
@@ -222,6 +251,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "missing group labels",
 			entry: NotificationHistoryEntry{
 				UUID:         "test-uuid",
+				Timestamp:    now,
 				ReceiverName: "test-receiver",
 				GroupLabels:  nil,
 				PipelineTime: now,
@@ -234,6 +264,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "missing pipeline time",
 			entry: NotificationHistoryEntry{
 				UUID:         "test-uuid",
+				Timestamp:    now,
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: time.Time{},
@@ -246,6 +277,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "missing group key",
 			entry: NotificationHistoryEntry{
 				UUID:         "test-uuid",
+				Timestamp:    now,
 				ReceiverName: "test-receiver",
 				GroupLabels:  model.LabelSet{"foo": "bar"},
 				PipelineTime: now,
@@ -258,6 +290,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			name: "multiple validation errors are joined",
 			entry: NotificationHistoryEntry{
 				UUID:         "",
+				Timestamp:    time.Time{},
 				ReceiverName: "",
 				GroupLabels:  nil,
 				PipelineTime: time.Time{},
@@ -266,6 +299,7 @@ func TestNotificationHistoryEntry_Validate(t *testing.T) {
 			wantErr: true,
 			expectedErrSubstr: []string{
 				"missing UUID",
+				"missing timestamp",
 				"missing receiver name",
 				"missing group labels",
 				"missing pipeline time",

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -226,10 +226,17 @@ func (s *defaultSender) SendHTTPRequest(ctx context.Context, url *url.URL, cfg H
 }
 
 type extraDataKey int
+type notificationIDKey int
 
 const (
-	ExtraDataKey extraDataKey = iota
+	ExtraDataKey      extraDataKey      = iota
+	NotificationIDKey notificationIDKey = iota
 )
+
+func GetNotificationIDFromContext(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(NotificationIDKey).(string)
+	return v, ok
+}
 
 func GetExtraDataFromContext(ctx context.Context) ([]json.RawMessage, bool) {
 	v, ok := ctx.Value(ExtraDataKey).([]json.RawMessage)

--- a/receivers/webhook/v1/webhook_test.go
+++ b/receivers/webhook/v1/webhook_test.go
@@ -1176,3 +1176,57 @@ func TestNotify_ExtraData(t *testing.T) {
 	// Check second alert's extra data
 	require.JSONEq(t, string(extraData2), string(webhookMsg.ExtendedData.Alerts[1].ExtraData))
 }
+
+func TestNotify_NotificationID(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	orgID := int64(1)
+
+	settings := Config{
+		URL:        "http://localhost/test",
+		HTTPMethod: http.MethodPost,
+		Title:      templates.DefaultMessageTitleEmbed,
+		Message:    templates.DefaultMessageEmbed,
+	}
+
+	webhookSender := receivers.MockNotificationService()
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images.UnavailableProvider{},
+		orgID:    orgID,
+	}
+
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				GeneratorURL: "http://localhost/test",
+				Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations:  model.LabelSet{"ann1": "annv1", models.OrgIDAnnotation: model.LabelValue(fmt.Sprint(orgID))},
+			},
+		},
+	}
+
+	notificationID := "test-uuid-1234?ts=1741693512463"
+
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = notify.WithReceiverName(ctx, "my_receiver")
+	ctx = context.WithValue(ctx, receivers.NotificationIDKey, notificationID)
+
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var webhookMsg webhookMessage
+	err = json.Unmarshal([]byte(webhookSender.Webhook.Body), &webhookMsg)
+	require.NoError(t, err)
+
+	require.Equal(t, notificationID, webhookMsg.NotificationID)
+}

--- a/templates/template_data.go
+++ b/templates/template_data.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates/gomplate"
 	"github.com/grafana/alerting/utils"
 )
@@ -151,6 +152,11 @@ type ExtendedData struct {
 
 	// Most notifiers don't truncate alerts, but a nil or zero default is safe in those cases.
 	TruncatedAlerts *int `json:"truncatedAlerts,omitempty"`
+
+	// NotificationID uniquely identifies this notification attempt. It is a composite
+	// of UUID and timestamp in the form "<uuid>?ts=<unix_millis>", which can be used to
+	// link back to the notification history entry.
+	NotificationID string `json:"notificationID,omitempty"`
 
 	// Optional variables for templating, currently only used for webhook custom payloads.
 	Vars map[string]string `json:"-"`
@@ -382,6 +388,10 @@ func TmplText(ctx context.Context, tmpl *Template, alerts []*types.Alert, l log.
 		data.GroupKey = groupKey.String()
 	} else {
 		level.Debug(l).Log("msg", "failed to extract group key from context", "err", err.Error())
+	}
+
+	if notificationID, ok := receivers.GetNotificationIDFromContext(ctx); ok {
+		data.NotificationID = notificationID
 	}
 
 	return func(name string) (s string) {


### PR DESCRIPTION
Passes the UUID generated for notification history to notifiers, more
specifically, pass the uuid and timestamp of the notification in a composite
form suitable for use in a URL (`<uuid>?ts=<unix_millis>`). This allows
creation of a linkable reference back to the notification history entry.

The timestamp is not needed strictly, but is a very useful optimization for
finding the data in Loki.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the notification send path and notification-history persistence by introducing a new required timestamp and propagating a new context value; mistakes could break history writes or alter webhook payloads.
> 
> **Overview**
> Adds a **linkable `notificationID`** (formatted as `<uuid>?ts=<unix_millis>`) that is generated per notification attempt, stored on the `context`, and exposed to receiver templates via `templates.ExtendedData.NotificationID`.
> 
> Notification history entries now carry an explicit `Timestamp` (validated as required) and Loki historian writes use this timestamp instead of `time.Now()`, aligning stored history with the ID’s timestamp and enabling faster lookup. Tests are updated/added to assert the new timestamp requirement and that webhook payloads include `notificationID` when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870c4aea1f79a578072fab8eff3a02e7c2e08b88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->