### PR TITLE
Refactor decrypt function for consistent receiver configurations

### DIFF
--- a/http/config.go
+++ b/http/config.go
@@ -32,14 +32,14 @@ func (c *HTTPClientConfig) Decrypt(decryptFn receivers.DecryptFunc) {
 	if c.OAuth2 == nil {
 		return
 	}
-	c.OAuth2.ClientSecret = decryptFn("http_config.oauth2.client_secret", c.OAuth2.ClientSecret)
+	c.OAuth2.ClientSecret = decryptFn.Get("http_config.oauth2.client_secret", c.OAuth2.ClientSecret)
 
 	if c.OAuth2.TLSConfig == nil {
 		return
 	}
-	c.OAuth2.TLSConfig.CACertificate = decryptFn("http_config.oauth2.tls_config.caCertificate", c.OAuth2.TLSConfig.CACertificate)
-	c.OAuth2.TLSConfig.ClientCertificate = decryptFn("http_config.oauth2.tls_config.clientCertificate", c.OAuth2.TLSConfig.ClientCertificate)
-	c.OAuth2.TLSConfig.ClientKey = decryptFn("http_config.oauth2.tls_config.clientKey", c.OAuth2.TLSConfig.ClientKey)
+	c.OAuth2.TLSConfig.CACertificate = decryptFn.Get("http_config.oauth2.tls_config.caCertificate", c.OAuth2.TLSConfig.CACertificate)
+	c.OAuth2.TLSConfig.ClientCertificate = decryptFn.Get("http_config.oauth2.tls_config.clientCertificate", c.OAuth2.TLSConfig.ClientCertificate)
+	c.OAuth2.TLSConfig.ClientKey = decryptFn.Get("http_config.oauth2.tls_config.clientKey", c.OAuth2.TLSConfig.ClientKey)
 }
 
 func ValidateHTTPClientConfig(cfg *HTTPClientConfig) error {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -264,8 +264,11 @@ func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver 
 		return err
 	}
 
-	decryptFn := func(key string, fallback string) string {
-		return decrypt(ctx, secureSettings, key, fallback)
+	decryptFn := func(key string, fallback string) (string, bool) {
+		if _, ok := secureSettings[key]; !ok {
+			return fallback, false
+		}
+		return decrypt(ctx, secureSettings, key, fallback), true
 	}
 
 	switch strings.ToLower(receiver.Type) {
@@ -516,7 +519,7 @@ func GetActiveReceiversMap(r *dispatch.Route) map[string]struct{} {
 	return receiversMap
 }
 
-func parseHTTPConfig(integration *models.IntegrationConfig, decryptFn func(key string, fallback string) string) (*http.HTTPClientConfig, error) {
+func parseHTTPConfig(integration *models.IntegrationConfig, decryptFn receivers.DecryptFunc) (*http.HTTPClientConfig, error) {
 	httpConfigSettings := struct {
 		HTTPConfig *http.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	}{}
@@ -535,7 +538,7 @@ func parseHTTPConfig(integration *models.IntegrationConfig, decryptFn func(key s
 	return httpConfigSettings.HTTPConfig, nil
 }
 
-func newNotifierConfig[T interface{}](integration *models.IntegrationConfig, idx int, settings T, decryptFn func(key string, fallback string) string) (*NotifierConfig[T], error) {
+func newNotifierConfig[T interface{}](integration *models.IntegrationConfig, idx int, settings T, decryptFn receivers.DecryptFunc) (*NotifierConfig[T], error) {
 	httpClientConfig, err := parseHTTPConfig(integration, decryptFn)
 	if err != nil {
 		return nil, err

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -95,7 +95,8 @@ func (f *fakeNotifier) SendResolved() bool {
 }
 
 func GetDecryptedValueFnForTesting(_ context.Context, sjd map[string][]byte, key string, fallback string) string {
-	return receiversTesting.DecryptForTesting(sjd)(key, fallback)
+	v, _ := receiversTesting.DecryptForTesting(sjd)(key, fallback)
+	return v
 }
 
 func MergeSettings(a []byte, b []byte) ([]byte, error) {

--- a/receivers/alertmanager/v1/config.go
+++ b/receivers/alertmanager/v1/config.go
@@ -46,7 +46,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if len(settings.URL) == 0 || len(urls) == 0 {
 		return Config{}, errors.New("could not find url property in settings")
 	}
-	settings.Password = decryptFn("basicAuthPassword", settings.Password)
+	settings.Password = decryptFn.Get("basicAuthPassword", settings.Password)
 	return Config{
 		URLs:     urls,
 		User:     settings.User,

--- a/receivers/config_util.go
+++ b/receivers/config_util.go
@@ -7,7 +7,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type DecryptFunc func(key string, fallback string) string
+type DecryptFunc func(key string, fallback string) (string, bool)
+
+// Get calls the DecryptFunc and returns only the decrypted value, discarding the availability flag.
+func (fn DecryptFunc) Get(key string, fallback string) string {
+	v, _ := fn(key, fallback)
+	return v
+}
 
 type CommaSeparatedStrings []string
 

--- a/receivers/dingding/v1/config.go
+++ b/receivers/dingding/v1/config.go
@@ -27,7 +27,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.URL = decryptFn("url", settings.URL)
+	settings.URL = decryptFn.Get("url", settings.URL)
 	if settings.URL == "" {
 		return Config{}, errors.New("could not find url property in settings")
 	}

--- a/receivers/discord/v1/config.go
+++ b/receivers/discord/v1/config.go
@@ -26,7 +26,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.WebhookURL = decryptFn("url", settings.WebhookURL)
+	settings.WebhookURL = decryptFn.Get("url", settings.WebhookURL)
 	if settings.WebhookURL == "" {
 		return Config{}, errors.New("could not find webhook url property in settings")
 	}

--- a/receivers/googlechat/v1/config.go
+++ b/receivers/googlechat/v1/config.go
@@ -27,7 +27,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	settings.URL = decryptFn("url", settings.URL)
+	settings.URL = decryptFn.Get("url", settings.URL)
 	if settings.URL == "" {
 		return Config{}, errors.New("could not find url property in settings")
 	}

--- a/receivers/jira/v1/config.go
+++ b/receivers/jira/v1/config.go
@@ -107,9 +107,9 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.Priority = DefaultPriority
 	}
 
-	settings.User = decryptFn("user", settings.User)
-	settings.Password = decryptFn("password", settings.Password)
-	settings.Token = decryptFn("api_token", settings.Token)
+	settings.User = decryptFn.Get("user", settings.User)
+	settings.Password = decryptFn.Get("password", settings.Password)
+	settings.Token = decryptFn.Get("api_token", settings.Token)
 	if settings.Token == "" && (settings.User == "" || settings.Password == "") {
 		return Config{}, errors.New("either token or both user and password must be set")
 	}

--- a/receivers/kafka/v1/config.go
+++ b/receivers/kafka/v1/config.go
@@ -53,7 +53,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if settings.Details == "" {
 		settings.Details = templates.DefaultMessageEmbed
 	}
-	settings.Password = decryptFn("password", settings.Password)
+	settings.Password = decryptFn.Get("password", settings.Password)
 
 	if settings.APIVersion == "" {
 		settings.APIVersion = apiVersionV2

--- a/receivers/line/v1/config.go
+++ b/receivers/line/v1/config.go
@@ -24,7 +24,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.Token = decryptFn("token", settings.Token)
+	settings.Token = decryptFn.Get("token", settings.Token)
 	if settings.Token == "" {
 		return Config{}, errors.New("could not find token in settings")
 	}

--- a/receivers/mqtt/v1/config.go
+++ b/receivers/mqtt/v1/config.go
@@ -70,15 +70,15 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		return Config{}, fmt.Errorf("invalid QoS level: %d. Must be 0, 1 or 2", qos)
 	}
 
-	settings.Password = decryptFn("password", settings.Password)
+	settings.Password = decryptFn.Get("password", settings.Password)
 
 	if settings.TLSConfig == nil {
 		settings.TLSConfig = &receivers.TLSConfig{}
 	}
 
-	settings.TLSConfig.CACertificate = decryptFn("tlsConfig.caCertificate", settings.TLSConfig.CACertificate)
-	settings.TLSConfig.ClientCertificate = decryptFn("tlsConfig.clientCertificate", settings.TLSConfig.ClientCertificate)
-	settings.TLSConfig.ClientKey = decryptFn("tlsConfig.clientKey", settings.TLSConfig.ClientKey)
+	settings.TLSConfig.CACertificate = decryptFn.Get("tlsConfig.caCertificate", settings.TLSConfig.CACertificate)
+	settings.TLSConfig.ClientCertificate = decryptFn.Get("tlsConfig.clientCertificate", settings.TLSConfig.ClientCertificate)
+	settings.TLSConfig.ClientKey = decryptFn.Get("tlsConfig.clientKey", settings.TLSConfig.ClientKey)
 
 	parsedURL, err := url.Parse(settings.BrokerURL)
 	if err != nil {

--- a/receivers/oncall/v1/config.go
+++ b/receivers/oncall/v1/config.go
@@ -62,9 +62,9 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.MaxAlerts, _ = strconv.Atoi(rawSettings.MaxAlerts.String())
 	}
 
-	settings.User = decryptFn("username", rawSettings.User)
-	settings.Password = decryptFn("password", rawSettings.Password)
-	settings.AuthorizationCredentials = decryptFn("authorization_credentials", rawSettings.AuthorizationCredentials)
+	settings.User = decryptFn.Get("username", rawSettings.User)
+	settings.Password = decryptFn.Get("password", rawSettings.Password)
+	settings.AuthorizationCredentials = decryptFn.Get("authorization_credentials", rawSettings.AuthorizationCredentials)
 
 	if settings.AuthorizationCredentials != "" && settings.AuthorizationScheme == "" {
 		settings.AuthorizationScheme = "Bearer"

--- a/receivers/opsgenie/v1/config.go
+++ b/receivers/opsgenie/v1/config.go
@@ -60,7 +60,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	raw.APIKey = decryptFn("apiKey", raw.APIKey)
+	raw.APIKey = decryptFn.Get("apiKey", raw.APIKey)
 	if raw.APIKey == "" {
 		return Config{}, errors.New("could not find api key property in settings")
 	}

--- a/receivers/pagerduty/v1/config.go
+++ b/receivers/pagerduty/v1/config.go
@@ -66,7 +66,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	settings.Key = decryptFn("integrationKey", settings.Key)
+	settings.Key = decryptFn.Get("integrationKey", settings.Key)
 	if settings.Key == "" {
 		return Config{}, errors.New("could not find integration key property in settings")
 	}

--- a/receivers/pushover/v1/config.go
+++ b/receivers/pushover/v1/config.go
@@ -49,11 +49,11 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	settings.UserKey = decryptFn("userKey", rawSettings.UserKey)
+	settings.UserKey = decryptFn.Get("userKey", rawSettings.UserKey)
 	if settings.UserKey == "" {
 		return settings, errors.New("user key not found")
 	}
-	settings.APIToken = decryptFn("apiToken", rawSettings.APIToken)
+	settings.APIToken = decryptFn.Get("apiToken", rawSettings.APIToken)
 	if settings.APIToken == "" {
 		return settings, errors.New("API token not found")
 	}

--- a/receivers/sensugo/v1/config.go
+++ b/receivers/sensugo/v1/config.go
@@ -31,7 +31,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if settings.URL == "" {
 		return settings, errors.New("could not find URL property in settings")
 	}
-	settings.APIKey = decryptFn("apikey", settings.APIKey)
+	settings.APIKey = decryptFn.Get("apikey", settings.APIKey)
 	if settings.APIKey == "" {
 		return settings, errors.New("could not find the API key property in settings")
 	}

--- a/receivers/slack/v1/config.go
+++ b/receivers/slack/v1/config.go
@@ -41,7 +41,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if settings.EndpointURL == "" {
 		settings.EndpointURL = APIURL
 	}
-	slackURL := decryptFn("url", settings.URL)
+	slackURL := decryptFn.Get("url", settings.URL)
 	if slackURL == "" {
 		slackURL = settings.EndpointURL
 	}
@@ -59,7 +59,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if settings.MentionChannel != "" && settings.MentionChannel != "here" && settings.MentionChannel != "channel" {
 		return Config{}, fmt.Errorf("invalid value for mentionChannel: %q", settings.MentionChannel)
 	}
-	settings.Token = decryptFn("token", settings.Token)
+	settings.Token = decryptFn.Get("token", settings.Token)
 	if settings.Token == "" && settings.URL == APIURL {
 		return Config{}, errors.New("token must be specified when using the Slack chat API")
 	}

--- a/receivers/sns/v1/config.go
+++ b/receivers/sns/v1/config.go
@@ -64,8 +64,8 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
-	settings.Sigv4.AccessKey = decryptFn("sigv4.access_key", settings.Sigv4.AccessKey)
-	settings.Sigv4.SecretKey = decryptFn("sigv4.secret_key", settings.Sigv4.SecretKey)
+	settings.Sigv4.AccessKey = decryptFn.Get("sigv4.access_key", settings.Sigv4.AccessKey)
+	settings.Sigv4.SecretKey = decryptFn.Get("sigv4.secret_key", settings.Sigv4.SecretKey)
 	if settings.Sigv4.AccessKey == "" && settings.Sigv4.SecretKey != "" || settings.Sigv4.AccessKey != "" && settings.Sigv4.SecretKey == "" {
 		return Config{}, errors.New("must specify both access key and secret key")
 	}

--- a/receivers/telegram/v1/config.go
+++ b/receivers/telegram/v1/config.go
@@ -37,7 +37,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.BotToken = decryptFn("bottoken", settings.BotToken)
+	settings.BotToken = decryptFn.Get("bottoken", settings.BotToken)
 	if settings.BotToken == "" {
 		return settings, errors.New("could not find Bot Token in settings")
 	}

--- a/receivers/testing/testing.go
+++ b/receivers/testing/testing.go
@@ -16,12 +16,12 @@ func ParseURLUnsafe(s string) *url.URL {
 }
 
 func DecryptForTesting(sjd map[string][]byte) receivers.DecryptFunc {
-	return func(key string, fallback string) string {
+	return func(key string, fallback string) (string, bool) {
 		v, ok := sjd[key]
 		if !ok {
-			return fallback
+			return fallback, false
 		}
-		return string(v)
+		return string(v), true
 	}
 }
 

--- a/receivers/threema/v1/config.go
+++ b/receivers/threema/v1/config.go
@@ -45,7 +45,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if len(settings.RecipientID) != 8 {
 		return settings, errors.New("invalid Threema Recipient ID: Must be 8 characters long")
 	}
-	settings.APISecret = decryptFn("api_secret", settings.APISecret)
+	settings.APISecret = decryptFn.Get("api_secret", settings.APISecret)
 	if settings.APISecret == "" {
 		return settings, errors.New("could not find Threema API secret in settings")
 	}

--- a/receivers/victorops/v1/config.go
+++ b/receivers/victorops/v1/config.go
@@ -29,7 +29,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	if err != nil {
 		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.URL = decryptFn("url", settings.URL)
+	settings.URL = decryptFn.Get("url", settings.URL)
 	if settings.URL == "" {
 		return settings, errors.New("could not find victorops url property in settings")
 	}

--- a/receivers/webex/v1/config.go
+++ b/receivers/webex/v1/config.go
@@ -41,7 +41,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
-	settings.Token = decryptFn("bot_token", settings.Token)
+	settings.Token = decryptFn.Get("bot_token", settings.Token)
 
 	u, err := url.Parse(settings.APIURL)
 	if err != nil {

--- a/receivers/webhook/v1/config.go
+++ b/receivers/webhook/v1/config.go
@@ -85,9 +85,9 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.MaxAlerts, _ = strconv.Atoi(rawSettings.MaxAlerts.String())
 	}
 
-	settings.User = decryptFn("username", rawSettings.User)
-	settings.Password = decryptFn("password", rawSettings.Password)
-	settings.AuthorizationCredentials = decryptFn("authorization_credentials", rawSettings.AuthorizationCredentials)
+	settings.User = decryptFn.Get("username", rawSettings.User)
+	settings.Password = decryptFn.Get("password", rawSettings.Password)
+	settings.AuthorizationCredentials = decryptFn.Get("authorization_credentials", rawSettings.AuthorizationCredentials)
 
 	if settings.AuthorizationCredentials != "" && settings.AuthorizationScheme == "" {
 		settings.AuthorizationScheme = "Bearer"
@@ -110,17 +110,21 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	}
 
 	if tlsConfig := rawSettings.TLSConfig; tlsConfig != nil {
+		caCert := decryptFn.Get("tlsConfig.caCertificate", tlsConfig.CACertificate)
+		clientCert := decryptFn.Get("tlsConfig.clientCertificate", tlsConfig.ClientCertificate)
+		clientKey := decryptFn.Get("tlsConfig.clientKey", tlsConfig.ClientKey)
 		settings.TLSConfig = &receivers.TLSConfig{
 			InsecureSkipVerify: tlsConfig.InsecureSkipVerify,
-			CACertificate:      decryptFn("tlsConfig.caCertificate", tlsConfig.CACertificate),
-			ClientCertificate:  decryptFn("tlsConfig.clientCertificate", tlsConfig.ClientCertificate),
-			ClientKey:          decryptFn("tlsConfig.clientKey", tlsConfig.ClientKey),
+			CACertificate:      caCert,
+			ClientCertificate:  clientCert,
+			ClientKey:          clientKey,
 		}
 	}
 
 	if hmacConfig := rawSettings.HMACConfig; hmacConfig != nil {
+		hmacSecret := decryptFn.Get("hmacConfig.secret", hmacConfig.Secret)
 		settings.HMACConfig = &receivers.HMACConfig{
-			Secret:          decryptFn("hmacConfig.secret", hmacConfig.Secret),
+			Secret:          hmacSecret,
 			Header:          hmacConfig.Header,
 			TimestampHeader: hmacConfig.TimestampHeader,
 		}

--- a/receivers/wecom/v1/config.go
+++ b/receivers/wecom/v1/config.go
@@ -69,8 +69,8 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		settings.ToUser = DefaultToUser
 	}
 
-	settings.URL = decryptFn("url", settings.URL)
-	settings.Secret = decryptFn("secret", settings.Secret)
+	settings.URL = decryptFn.Get("url", settings.URL)
+	settings.Secret = decryptFn.Get("secret", settings.Secret)
 
 	if len(settings.URL) == 0 && len(settings.Secret) == 0 {
 		return settings, errors.New("either url or secret is required")


### PR DESCRIPTION
Refactored the `decrypt` function to ensure it uses `DecryptFunc.Get` consistently across all receiver configurations. This enhances code maintainability and standardizes decryption behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches decryption plumbing across many receiver configs; while intended as a behavior-preserving refactor, a signature change in `DecryptFunc` could cause subtle regressions if any call sites relied on the old semantics.
> 
> **Overview**
> **Standardizes receiver secret decryption** by changing `receivers.DecryptFunc` to return `(value, ok)` and adding a convenience helper `DecryptFunc.Get()` for value-only usage.
> 
> Updates `notify.parseNotifier` to expose the availability flag (fallback when a key is missing) and migrates all receiver `NewConfig` implementations plus `http.HTTPClientConfig.Decrypt` (and related notifier config wiring/tests) to call `decryptFn.Get(...)` consistently for secret fields (passwords, tokens, TLS/HMAC secrets, OAuth2 credentials).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f955d5442290d34a8e132f05c95a799fe657bc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->