### PR TITLE
Add NewConfig factory function to all legacy (v0mimir1/v0mimir2) receiver integrations

### DIFF
--- a/http/v0mimir/decrypt.go
+++ b/http/v0mimir/decrypt.go
@@ -1,0 +1,95 @@
+package v0mimir
+
+import (
+	"encoding/json"
+	"fmt"
+
+	commoncfg "github.com/prometheus/common/config"
+
+	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/receivers/schema"
+)
+
+// DecryptHTTPConfig populates secret fields of an HTTPClientConfig from the
+// decrypt function. Fields are only set when the decrypted value is non-empty.
+func DecryptHTTPConfig(prefix string, cfg *HTTPClientConfig, decrypt receivers.DecryptFunc) (*HTTPClientConfig, error) {
+	if cfg == nil {
+		def := DefaultHTTPClientConfig
+		cfg = &def
+	}
+	p := schema.NewIntegrationFieldPath
+	if secret, ok := decrypt.GetPath(p(prefix, "basic_auth", "password")); ok {
+		if cfg.BasicAuth == nil {
+			cfg.BasicAuth = &BasicAuth{}
+		}
+		cfg.BasicAuth.Password = commoncfg.Secret(secret)
+	}
+	if secret, ok := decrypt.GetPath(p(prefix, "authorization", "credentials")); ok {
+		if cfg.Authorization == nil {
+			cfg.Authorization = &Authorization{}
+		}
+		cfg.Authorization.Credentials = commoncfg.Secret(secret)
+	}
+	if secret, ok := decrypt.GetPath(p(prefix, "oauth2", "client_secret")); ok {
+		if cfg.OAuth2 == nil {
+			cfg.OAuth2 = &OAuth2{}
+		}
+		cfg.OAuth2.ClientSecret = commoncfg.Secret(secret)
+	}
+	if secret, ok := decrypt.GetPath(p(prefix, "bearer_token")); ok {
+		cfg.BearerToken = commoncfg.Secret(secret)
+	}
+	if secret, ok := decrypt.GetPath(p(prefix, "tls_config", "key")); ok {
+		cfg.TLSConfig.Key = commoncfg.Secret(secret)
+	}
+	if secret, ok := decrypt.GetPath(p(prefix, "oauth2", "tls_config", "key")); ok {
+		if cfg.OAuth2 == nil {
+			cfg.OAuth2 = &OAuth2{}
+		}
+		cfg.OAuth2.TLSConfig.Key = commoncfg.Secret(secret)
+	}
+	for name, header := range cfg.HTTPHeaders {
+		secrets, err := decryptSecretList(decrypt, p(prefix, "http_headers", name))
+		if err != nil {
+			return nil, err
+		}
+		if secrets != nil {
+			header.Secrets = secrets
+			cfg.HTTPHeaders[name] = header
+		}
+	}
+	if err := decryptProxyHeader(decrypt, p(prefix, "proxy_connect_header"), cfg.ProxyConnectHeader); err != nil {
+		return nil, err
+	}
+	if cfg.OAuth2 != nil {
+		if err := decryptProxyHeader(decrypt, p(prefix, "oauth2", "proxy_connect_header"), cfg.OAuth2.ProxyConnectHeader); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
+
+func decryptSecretList(decryptFn receivers.DecryptFunc, key schema.IntegrationFieldPath) ([]commoncfg.Secret, error) {
+	secret, ok := decryptFn.GetPath(key)
+	if !ok {
+		return nil, nil
+	}
+	var secrets []commoncfg.Secret
+	if err := json.Unmarshal([]byte(secret), &secrets); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", key, err)
+	}
+	return secrets, nil
+}
+
+func decryptProxyHeader(decryptFn receivers.DecryptFunc, prefix schema.IntegrationFieldPath, header ProxyHeader) error {
+	for name := range header {
+		secrets, err := decryptSecretList(decryptFn, prefix.With(name))
+		if err != nil {
+			return err
+		}
+		if secrets != nil {
+			header[name] = secrets
+		}
+	}
+	return nil
+}

--- a/http/v0mimir/decrypt_test.go
+++ b/http/v0mimir/decrypt_test.go
@@ -1,0 +1,232 @@
+package v0mimir
+
+import (
+	"testing"
+
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/stretchr/testify/require"
+
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
+)
+
+func TestDecryptHTTPConfig(t *testing.T) {
+	cases := []struct {
+		name        string
+		cfg         *HTTPClientConfig
+		secrets     map[string][]byte
+		expectedCfg *HTTPClientConfig
+		expectedErr string
+	}{
+		{
+			name:        "No secrets, no changes",
+			cfg:         &HTTPClientConfig{},
+			secrets:     nil,
+			expectedCfg: &HTTPClientConfig{},
+		},
+		{
+			name:    "BasicAuth password",
+			cfg:     &HTTPClientConfig{},
+			secrets: map[string][]byte{"http_config.basic_auth.password": []byte("secret-pass")},
+			expectedCfg: &HTTPClientConfig{
+				BasicAuth: &BasicAuth{
+					Password: "secret-pass",
+				},
+			},
+		},
+		{
+			name: "BasicAuth password with existing BasicAuth",
+			cfg: &HTTPClientConfig{
+				BasicAuth: &BasicAuth{
+					Username: "user",
+				},
+			},
+			secrets: map[string][]byte{"http_config.basic_auth.password": []byte("secret-pass")},
+			expectedCfg: &HTTPClientConfig{
+				BasicAuth: &BasicAuth{
+					Username: "user",
+					Password: "secret-pass",
+				},
+			},
+		},
+		{
+			name:    "Authorization credentials",
+			cfg:     &HTTPClientConfig{},
+			secrets: map[string][]byte{"http_config.authorization.credentials": []byte("my-token")},
+			expectedCfg: &HTTPClientConfig{
+				Authorization: &Authorization{
+					Credentials: "my-token",
+				},
+			},
+		},
+		{
+			name:    "OAuth2 client secret",
+			cfg:     &HTTPClientConfig{},
+			secrets: map[string][]byte{"http_config.oauth2.client_secret": []byte("oauth-secret")},
+			expectedCfg: &HTTPClientConfig{
+				OAuth2: &OAuth2{
+					ClientSecret: "oauth-secret",
+				},
+			},
+		},
+		{
+			name:    "Bearer token",
+			cfg:     &HTTPClientConfig{},
+			secrets: map[string][]byte{"http_config.bearer_token": []byte("bearer-val")},
+			expectedCfg: &HTTPClientConfig{
+				BearerToken: "bearer-val",
+			},
+		},
+		{
+			name:    "TLS config key",
+			cfg:     &HTTPClientConfig{},
+			secrets: map[string][]byte{"http_config.tls_config.key": []byte("tls-key")},
+			expectedCfg: &HTTPClientConfig{
+				TLSConfig: TLSConfig{
+					Key: "tls-key",
+				},
+			},
+		},
+		{
+			name:    "OAuth2 TLS config key",
+			cfg:     &HTTPClientConfig{},
+			secrets: map[string][]byte{"http_config.oauth2.tls_config.key": []byte("oauth-tls-key")},
+			expectedCfg: &HTTPClientConfig{
+				OAuth2: &OAuth2{
+					TLSConfig: TLSConfig{
+						Key: "oauth-tls-key",
+					},
+				},
+			},
+		},
+		{
+			name: "All scalar secrets at once",
+			cfg:  &HTTPClientConfig{},
+			secrets: map[string][]byte{
+				"http_config.basic_auth.password":       []byte("pass"),
+				"http_config.authorization.credentials": []byte("creds"),
+				"http_config.oauth2.client_secret":      []byte("cs"),
+				"http_config.bearer_token":              []byte("bt"),
+				"http_config.tls_config.key":            []byte("tk"),
+				"http_config.oauth2.tls_config.key":     []byte("otk"),
+			},
+			expectedCfg: &HTTPClientConfig{
+				BasicAuth:     &BasicAuth{Password: "pass"},
+				Authorization: &Authorization{Credentials: "creds"},
+				OAuth2: &OAuth2{
+					ClientSecret: "cs",
+					TLSConfig:    TLSConfig{Key: "otk"},
+				},
+				BearerToken: "bt",
+				TLSConfig:   TLSConfig{Key: "tk"},
+			},
+		},
+		{
+			name: "Does not overwrite when secret is absent",
+			cfg: &HTTPClientConfig{
+				BasicAuth: &BasicAuth{
+					Username: "user",
+					Password: "original",
+				},
+				BearerToken: "original-bearer",
+			},
+			secrets: nil,
+			expectedCfg: &HTTPClientConfig{
+				BasicAuth: &BasicAuth{
+					Username: "user",
+					Password: "original",
+				},
+				BearerToken: "original-bearer",
+			},
+		},
+		{
+			name: "HTTP headers secrets",
+			cfg: &HTTPClientConfig{
+				HTTPHeaders: Headers{
+					"X-Custom": Header{Values: []string{"val"}},
+				},
+			},
+			secrets: map[string][]byte{
+				"http_config.http_headers.X-Custom": []byte(`["s1","s2"]`),
+			},
+			expectedCfg: &HTTPClientConfig{
+				HTTPHeaders: Headers{
+					"X-Custom": Header{
+						Values:  []string{"val"},
+						Secrets: []commoncfg.Secret{"s1", "s2"},
+					},
+				},
+			},
+		},
+		{
+			name: "HTTP headers secrets invalid JSON",
+			cfg: &HTTPClientConfig{
+				HTTPHeaders: Headers{
+					"X-Bad": Header{},
+				},
+			},
+			secrets: map[string][]byte{
+				"http_config.http_headers.X-Bad": []byte(`not-json`),
+			},
+			expectedErr: "invalid http_config.http_headers.X-Bad",
+		},
+		{
+			name: "Proxy connect header secrets",
+			cfg: &HTTPClientConfig{
+				ProxyConfig: ProxyConfig{
+					ProxyConnectHeader: ProxyHeader{
+						"X-Proxy": []commoncfg.Secret{"old"},
+					},
+				},
+			},
+			secrets: map[string][]byte{
+				"http_config.proxy_connect_header.X-Proxy": []byte(`["new1","new2"]`),
+			},
+			expectedCfg: &HTTPClientConfig{
+				ProxyConfig: ProxyConfig{
+					ProxyConnectHeader: ProxyHeader{
+						"X-Proxy": []commoncfg.Secret{"new1", "new2"},
+					},
+				},
+			},
+		},
+		{
+			name: "OAuth2 proxy connect header secrets",
+			cfg: &HTTPClientConfig{
+				OAuth2: &OAuth2{
+					ClientID: "id",
+					ProxyConfig: ProxyConfig{
+						ProxyConnectHeader: ProxyHeader{
+							"X-Auth": []commoncfg.Secret{"old"},
+						},
+					},
+				},
+			},
+			secrets: map[string][]byte{
+				"http_config.oauth2.proxy_connect_header.X-Auth": []byte(`["new"]`),
+			},
+			expectedCfg: &HTTPClientConfig{
+				OAuth2: &OAuth2{
+					ClientID: "id",
+					ProxyConfig: ProxyConfig{
+						ProxyConnectHeader: ProxyHeader{
+							"X-Auth": []commoncfg.Secret{"new"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := DecryptHTTPConfig("http_config", c.cfg, receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedCfg, actual)
+		})
+	}
+}

--- a/receivers/config_util.go
+++ b/receivers/config_util.go
@@ -45,7 +45,7 @@ func (fn DecryptFunc) DecryptSecretURL(key string) (SecretURL, bool, error) {
 	}
 	parsedURL, err := url.Parse(raw)
 	if err != nil {
-		return SecretURL{}, true, fmt.Errorf("invalid %s %q: %w", key, raw, err)
+		return SecretURL{}, true, fmt.Errorf("invalid URL for %s: %w", key, err)
 	}
 	return SecretURL{URL: parsedURL}, true, nil
 }

--- a/receivers/config_util.go
+++ b/receivers/config_util.go
@@ -2,6 +2,8 @@ package receivers
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -13,6 +15,33 @@ type DecryptFunc func(key string, fallback string) (string, bool)
 func (fn DecryptFunc) Get(key string, fallback string) string {
 	v, _ := fn(key, fallback)
 	return v
+}
+
+// DecryptSecret resolves a Secret field by decrypting the value for the given
+// key, falling back to the current field value.
+func (fn DecryptFunc) DecryptSecret(key string) (Secret, bool) {
+	result, ok := fn(key, "")
+	if !ok {
+		return "", false
+	}
+	return Secret(result), true
+}
+
+// DecryptSecretURL resolves a SecretURL field by decrypting the value for the
+// given key, parsing it as a URL, and returning the result. The current field
+// value is used as the fallback. Returns nil when both the decrypted and
+// fallback values are empty.
+func (fn DecryptFunc) DecryptSecretURL(key string) (SecretURL, bool, error) {
+	var fb string
+	raw, ok := fn(key, fb)
+	if !ok {
+		return SecretURL{}, false, nil
+	}
+	parsedURL, err := url.Parse(raw)
+	if err != nil {
+		return SecretURL{}, true, fmt.Errorf("invalid %s %q: %w", key, raw, err)
+	}
+	return SecretURL{URL: parsedURL}, true, nil
 }
 
 type CommaSeparatedStrings []string

--- a/receivers/config_util.go
+++ b/receivers/config_util.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/alerting/receivers/schema"
 )
 
 type DecryptFunc func(key string, fallback string) (string, bool)
@@ -15,6 +17,10 @@ type DecryptFunc func(key string, fallback string) (string, bool)
 func (fn DecryptFunc) Get(key string, fallback string) string {
 	v, _ := fn(key, fallback)
 	return v
+}
+
+func (fn DecryptFunc) GetPath(path schema.IntegrationFieldPath) (string, bool) {
+	return fn(path.String(), "")
 }
 
 // DecryptSecret resolves a Secret field by decrypting the value for the given

--- a/receivers/discord/v0mimir1/config.go
+++ b/receivers/discord/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -55,6 +56,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if webhookURL, ok, err := decrypt.DecryptSecretURL("webhook_url"); ok {
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to decrypt webhook_url: %w", err)
+		}
+		settings.WebhookURL = &webhookURL
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/discord/v0mimir1/config_test.go
+++ b/receivers/discord/v0mimir1/config_test.go
@@ -1,21 +1,178 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing webhook_url",
+			mutate:      func(cfg *Config) { cfg.WebhookURL = nil },
+			expectedErr: "one of webhook_url or webhook_url_file must be configured",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: "one of webhook_url or webhook_url_file must be configured",
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"webhook_url": "http://localhost"}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://localhost"),
+				Title:          DefaultConfig.Title,
+				Message:        DefaultConfig.Message,
+			},
+		},
+		{
+			name:     "Minimal valid configuration from secrets",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://localhost"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://localhost"),
+				Title:          DefaultConfig.Title,
+				Message:        DefaultConfig.Message,
+			},
+		},
+		{
+			name:     "Secret overrides setting",
+			settings: `{"webhook_url": "http://original"}`,
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://override"),
+				Title:          DefaultConfig.Title,
+				Message:        DefaultConfig.Message,
+			},
+		},
+		{
+			name:     "Custom title and message",
+			settings: `{"webhook_url": "http://localhost", "title": "custom-title", "message": "custom-message"}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://localhost"),
+				Title:          "custom-title",
+				Message:        "custom-message",
+			},
+		},
+		{
+			name:              "Invalid webhook URL from secrets",
+			settings:          `{}`,
+			secrets:           map[string][]byte{"webhook_url": []byte("://invalid")},
+			expectedInitError: "invalid webhook_url",
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				cfg.WebhookURL = receivers.MustParseSecretURL("http://localhost")
+				cfg.Title = "test title"
+				cfg.Message = "test message"
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://discord.example.com/webhook"),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/discord/v0mimir1/config_test.go
+++ b/receivers/discord/v0mimir1/config_test.go
@@ -134,7 +134,7 @@ func TestNewConfig(t *testing.T) {
 			name:              "Invalid webhook URL from secrets",
 			settings:          `{}`,
 			secrets:           map[string][]byte{"webhook_url": []byte("://invalid")},
-			expectedInitError: "invalid webhook_url",
+			expectedInitError: "invalid URL for webhook_url",
 		},
 		{
 			name:     "FullValidConfigForTesting is valid",

--- a/receivers/email/v0mimir1/config.go
+++ b/receivers/email/v0mimir1/config.go
@@ -15,9 +15,12 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/textproto"
+
+	commoncfg "github.com/prometheus/common/config"
 
 	httpcfg "github.com/grafana/alerting/http/v0mimir"
 	"github.com/grafana/alerting/receivers"
@@ -67,6 +70,27 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret("auth_password"); ok {
+		settings.AuthPassword = decrypted
+	}
+	if decrypted, ok := decrypt.DecryptSecret("auth_secret"); ok {
+		settings.AuthSecret = decrypted
+	}
+	if decrypted, ok := decrypt.GetPath(schema.NewIntegrationFieldPath("tls_config", "key")); ok {
+		settings.TLSConfig.Key = commoncfg.Secret(decrypted)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/email/v0mimir1/config.go
+++ b/receivers/email/v0mimir1/config.go
@@ -73,6 +73,12 @@ func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
 	}
+	if c.Smarthost.String() == "" {
+		return errors.New("missing smarthost in email config")
+	}
+	if c.From == "" {
+		return errors.New("missing from address in email config")
+	}
 	if err := c.TLSConfig.Validate(); err != nil {
 		return fmt.Errorf("invalid tls_config: %w", err)
 	}

--- a/receivers/email/v0mimir1/config_test.go
+++ b/receivers/email/v0mimir1/config_test.go
@@ -14,12 +14,19 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"net/mail"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	commoncfg "github.com/prometheus/common/config"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestEmailToIsPresent(t *testing.T) {
@@ -100,15 +107,270 @@ to: 'a@'
 	}
 }
 
+func TestNewConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name: "Error if missing to",
+			settings: `{
+				"from": "a@b.com",
+				"smarthost": "smtp:587"
+			}`,
+			expectedInitError: "missing to address in email config",
+		},
+		{
+			name: "Error if missing smarthost",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com"
+			}`,
+			expectedInitError: "missing smarthost in email config",
+		},
+		{
+			name: "Error if missing from",
+			settings: `{
+				"to": "a@b.com",
+				"smarthost": "smtp:587"
+			}`,
+			expectedInitError: "missing from address in email config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: DefaultConfig.NotifierConfig,
+				To:             "a@b.com",
+				From:           "b@b.com",
+				Smarthost:      receivers.HostPort{Host: "smtp", Port: "587"},
+				Headers:        map[string]string{},
+				HTML:           DefaultConfig.HTML,
+			},
+		},
+		{
+			name: "Secret fields from decrypt",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587"
+			}`,
+			secrets: map[string][]byte{
+				"auth_password": []byte("secret-pass"),
+				"auth_secret":   []byte("secret-sec"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: DefaultConfig.NotifierConfig,
+				To:             "a@b.com",
+				From:           "b@b.com",
+				Smarthost:      receivers.HostPort{Host: "smtp", Port: "587"},
+				AuthPassword:   "secret-pass",
+				AuthSecret:     "secret-sec",
+				Headers:        map[string]string{},
+				HTML:           DefaultConfig.HTML,
+			},
+		},
+		{
+			name: "Secrets override settings",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587",
+				"auth_password": "original"
+			}`,
+			secrets: map[string][]byte{
+				"auth_password": []byte("override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: DefaultConfig.NotifierConfig,
+				To:             "a@b.com",
+				From:           "b@b.com",
+				Smarthost:      receivers.HostPort{Host: "smtp", Port: "587"},
+				AuthPassword:   "override",
+				Headers:        map[string]string{},
+				HTML:           DefaultConfig.HTML,
+			},
+		},
+		{
+			name: "Multiple addresses in to",
+			settings: `{
+				"to": "a@example.com, ,b@example.com,c@example.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: DefaultConfig.NotifierConfig,
+				To:             "a@example.com, ,b@example.com,c@example.com",
+				From:           "b@b.com",
+				Smarthost:      receivers.HostPort{Host: "smtp", Port: "587"},
+				Headers:        map[string]string{},
+				HTML:           DefaultConfig.HTML,
+			},
+		},
+		{
+			name: "TLS config key from secrets",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587",
+				"tls_config": {"cert": "cert-pem"}
+			}`,
+			secrets: map[string][]byte{
+				"tls_config.key": []byte("tls-private-key"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: DefaultConfig.NotifierConfig,
+				To:             "a@b.com",
+				From:           "b@b.com",
+				Smarthost:      receivers.HostPort{Host: "smtp", Port: "587"},
+				Headers:        map[string]string{},
+				HTML:           DefaultConfig.HTML,
+				TLSConfig: httpcfg.TLSConfig{
+					Cert: "cert-pem",
+					Key:  commoncfg.Secret("tls-private-key"),
+				},
+			},
+		},
+		{
+			name: "All secrets at once",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587",
+				"tls_config": {"cert": "cert-pem"}
+			}`,
+			secrets: map[string][]byte{
+				"auth_password":  []byte("pass"),
+				"auth_secret":    []byte("sec"),
+				"tls_config.key": []byte("key"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: DefaultConfig.NotifierConfig,
+				To:             "a@b.com",
+				From:           "b@b.com",
+				Smarthost:      receivers.HostPort{Host: "smtp", Port: "587"},
+				AuthPassword:   "pass",
+				AuthSecret:     "sec",
+				Headers:        map[string]string{},
+				HTML:           DefaultConfig.HTML,
+				TLSConfig: httpcfg.TLSConfig{
+					Cert: "cert-pem",
+					Key:  commoncfg.Secret("key"),
+				},
+			},
+		},
+		{
+			name: "Duplicate headers",
+			settings: `{
+				"to": "a@b.com",
+				"from": "b@b.com",
+				"smarthost": "smtp:587",
+				"headers": {"Subject": "a", "subject": "b"}
+			}`,
+			expectedInitError: "duplicate header",
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				// validate() normalizes headers
+				cfg.Headers = map[string]string{"Subject": "test subject"}
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"auth_password": []byte(string(GetFullValidConfig().AuthPassword)),
+				"auth_secret":   []byte(string(GetFullValidConfig().AuthSecret)),
+			},
+			expectedConfig: GetFullValidConfig(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing to",
+			mutate:      func(cfg *Config) { cfg.To = "" },
+			expectedErr: "missing to address in email config",
+		},
+		{
+			name:        "Missing smarthost",
+			mutate:      func(cfg *Config) { cfg.Smarthost = receivers.HostPort{} },
+			expectedErr: "missing smarthost in email config",
+		},
+		{
+			name:        "Missing from",
+			mutate:      func(cfg *Config) { cfg.From = "" },
+			expectedErr: "missing from address in email config",
+		},
+		{
+			name:        "Duplicate headers",
+			mutate:      func(cfg *Config) { cfg.Headers = map[string]string{"Subject": "a", "subject": "b"} },
+			expectedErr: "duplicate header",
+		},
+		{
+			name:        "Invalid TLS config",
+			mutate:      func(cfg *Config) { cfg.TLSConfig = httpcfg.TLSConfig{Key: "key-without-cert"} },
+			expectedErr: "invalid tls_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/receivers/jira/v0mimir1/config.go
+++ b/receivers/jira/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -78,9 +79,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.validate()
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.APIURL == nil {
+		return errors.New("missing api_url in jira_config")
 	}
 	if c.HTTPConfig != nil {
 		if err := c.HTTPConfig.Validate(); err != nil {

--- a/receivers/jira/v0mimir1/config_test.go
+++ b/receivers/jira/v0mimir1/config_test.go
@@ -1,12 +1,16 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestJiraConfiguration(t *testing.T) {
@@ -77,14 +81,166 @@ custom_fields:
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing project",
+			mutate:      func(cfg *Config) { cfg.Project = "" },
+			expectedErr: "missing project in jira_config",
+		},
+		{
+			name:        "Missing issue_type",
+			mutate:      func(cfg *Config) { cfg.IssueType = "" },
+			expectedErr: "missing issue_type in jira_config",
+		},
+		{
+			name:        "Missing api_url",
+			mutate:      func(cfg *Config) { cfg.APIURL = nil },
+			expectedErr: "missing api_url in jira_config",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing project",
+			settings:          `{"api_url": "http://localhost", "issue_type": "Bug"}`,
+			expectedInitError: "missing project in jira_config",
+		},
+		{
+			name:              "Error if missing issue_type",
+			settings:          `{"api_url": "http://localhost", "project": "PROJ"}`,
+			expectedInitError: "missing issue_type in jira_config",
+		},
+		{
+			name: "Error if missing api_url",
+			settings: `{
+				"project": "PROJ",
+				"issue_type": "Bug"
+			}`,
+			expectedInitError: "missing api_url in jira_config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"api_url": "http://localhost",
+				"project": "PROJ",
+				"issue_type": "Bug"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Project:        "PROJ",
+				IssueType:      "Bug",
+				Summary:        DefaultConfig.Summary,
+				Description:    DefaultConfig.Description,
+				Priority:       DefaultConfig.Priority,
+			},
+		},
+		{
+			name: "Custom fields via JSON tag",
+			settings: `{
+				"api_url": "http://localhost",
+				"project": "PROJ",
+				"issue_type": "Bug",
+				"custom_fields": {"customfield_10000": "value"}
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Project:        "PROJ",
+				IssueType:      "Bug",
+				Summary:        DefaultConfig.Summary,
+				Description:    DefaultConfig.Description,
+				Priority:       DefaultConfig.Priority,
+				Fields:         map[string]any{"customfield_10000": "value"},
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/opsgenie/v0mimir1/config.go
+++ b/receivers/opsgenie/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -85,9 +86,35 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.validate()
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret("api_key"); ok {
+		settings.APIKey = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.APIURL == nil {
+		return errors.New("missing api_url in opsgenie config")
+	}
+	if c.APIKey == "" {
+		return errors.New("missing api_key in opsgenie config")
 	}
 	if c.HTTPConfig != nil {
 		if err := c.HTTPConfig.Validate(); err != nil {

--- a/receivers/opsgenie/v0mimir1/config_test.go
+++ b/receivers/opsgenie/v0mimir1/config_test.go
@@ -14,10 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestOpsgenieTypeMatcher(t *testing.T) {
@@ -121,14 +126,190 @@ api_url: http://example.com
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing api_url",
+			mutate:      func(cfg *Config) { cfg.APIURL = nil },
+			expectedErr: "missing api_url in opsgenie config",
+		},
+		{
+			name:        "Missing api_key",
+			mutate:      func(cfg *Config) { cfg.APIKey = "" },
+			expectedErr: "missing api_key in opsgenie config",
+		},
+		{
+			name: "Invalid responder - missing id/name/username",
+			mutate: func(cfg *Config) {
+				cfg.Responders = []Responder{{Type: "team"}}
+			},
+			expectedErr: "has to have at least one of id, username or name specified",
+		},
+		{
+			name: "Invalid responder type",
+			mutate: func(cfg *Config) {
+				cfg.Responders = []Responder{{ID: "foo", Type: "wrong"}}
+			},
+			expectedErr: "type does not match valid options",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name: "Error if missing api_url",
+			settings: `{
+				"api_key": "key",
+				"project": "PROJ"
+			}`,
+			expectedInitError: "missing api_url in opsgenie config",
+		},
+		{
+			name: "Error if missing api_key",
+			settings: `{
+				"api_url": "http://localhost"
+			}`,
+			expectedInitError: "missing api_key in opsgenie config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"api_key": "test-key",
+				"api_url": "http://localhost"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIKey:         "test-key",
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Message:        DefaultConfig.Message,
+				Description:    DefaultConfig.Description,
+				Source:         DefaultConfig.Source,
+			},
+		},
+		{
+			name: "Secret from decrypt",
+			settings: `{
+				"api_url": "http://localhost"
+			}`,
+			secrets: map[string][]byte{
+				"api_key": []byte("secret-key"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIKey:         "secret-key",
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Message:        DefaultConfig.Message,
+				Description:    DefaultConfig.Description,
+				Source:         DefaultConfig.Source,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"api_key": "original",
+				"api_url": "http://localhost"
+			}`,
+			secrets: map[string][]byte{
+				"api_key": []byte("override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIKey:         "override",
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Message:        DefaultConfig.Message,
+				Description:    DefaultConfig.Description,
+				Source:         DefaultConfig.Source,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"api_key": []byte(string(GetFullValidConfig().APIKey)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/pagerduty/v0mimir1/config.go
+++ b/receivers/pagerduty/v0mimir1/config.go
@@ -109,6 +109,18 @@ func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config,
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
 	}
+	// Apply the same normalization as UnmarshalYAML.
+	if settings.Details == nil {
+		settings.Details = make(map[string]string)
+	}
+	if settings.Source == "" {
+		settings.Source = settings.Client
+	}
+	for k, v := range DefaultPagerdutyDetails {
+		if _, ok := settings.Details[k]; !ok {
+			settings.Details[k] = v
+		}
+	}
 	if err := settings.Validate(); err != nil {
 		return Config{}, err
 	}

--- a/receivers/pagerduty/v0mimir1/config.go
+++ b/receivers/pagerduty/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -91,9 +92,35 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret("routing_key"); ok {
+		settings.RoutingKey = decrypted
+	}
+	if decrypted, ok := decrypt.DecryptSecret("service_key"); ok {
+		settings.ServiceKey = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.URL == nil {
+		return errors.New("missing url in PagerDuty config")
 	}
 	if c.HTTPConfig != nil {
 		if err := c.HTTPConfig.Validate(); err != nil {

--- a/receivers/pagerduty/v0mimir1/config_test.go
+++ b/receivers/pagerduty/v0mimir1/config_test.go
@@ -301,6 +301,8 @@ func TestNewConfig(t *testing.T) {
 				Description:    DefaultConfig.Description,
 				Client:         DefaultConfig.Client,
 				ClientURL:      DefaultConfig.ClientURL,
+				Source:         DefaultConfig.Client,
+				Details:        DefaultPagerdutyDetails,
 			},
 		},
 		{
@@ -317,6 +319,8 @@ func TestNewConfig(t *testing.T) {
 				Description:    DefaultConfig.Description,
 				Client:         DefaultConfig.Client,
 				ClientURL:      DefaultConfig.ClientURL,
+				Source:         DefaultConfig.Client,
+				Details:        DefaultPagerdutyDetails,
 			},
 		},
 		{
@@ -337,7 +341,54 @@ func TestNewConfig(t *testing.T) {
 				Description:    DefaultConfig.Description,
 				Client:         DefaultConfig.Client,
 				ClientURL:      DefaultConfig.ClientURL,
+				Source:         DefaultConfig.Client,
+				Details:        DefaultPagerdutyDetails,
 			},
+		},
+		{
+			name: "Source defaults to Client when empty",
+			settings: `{
+				"url": "http://localhost",
+				"routing_key": "test-key",
+				"client": "custom-client"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:     "test-key",
+				Description:    DefaultConfig.Description,
+				Client:         "custom-client",
+				ClientURL:      DefaultConfig.ClientURL,
+				Source:         "custom-client",
+				Details:        DefaultPagerdutyDetails,
+			},
+		},
+		{
+			name: "Details merges with defaults",
+			settings: `{
+				"url": "http://localhost",
+				"routing_key": "test-key",
+				"details": {"custom_key": "custom_value"}
+			}`,
+			expectedConfig: func() Config {
+				details := make(map[string]string)
+				for k, v := range DefaultPagerdutyDetails {
+					details[k] = v
+				}
+				details["custom_key"] = "custom_value"
+				return Config{
+					NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+					HTTPConfig:     &defaultHTTPConfig,
+					URL:            receivers.MustParseURL("http://localhost"),
+					RoutingKey:     "test-key",
+					Description:    DefaultConfig.Description,
+					Client:         DefaultConfig.Client,
+					ClientURL:      DefaultConfig.ClientURL,
+					Source:         DefaultConfig.Client,
+					Details:        details,
+				}
+			}(),
 		},
 		{
 			name: "Secrets override settings",
@@ -359,6 +410,8 @@ func TestNewConfig(t *testing.T) {
 				Description:    DefaultConfig.Description,
 				Client:         DefaultConfig.Client,
 				ClientURL:      DefaultConfig.ClientURL,
+				Source:         DefaultConfig.Client,
+				Details:        DefaultPagerdutyDetails,
 			},
 		},
 		{
@@ -369,6 +422,12 @@ func TestNewConfig(t *testing.T) {
 				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
 				httpCfg := httpcfg.DefaultHTTPClientConfig
 				cfg.HTTPConfig = &httpCfg
+				// NewConfig merges DefaultPagerdutyDetails into Details
+				for k, v := range DefaultPagerdutyDetails {
+					if _, ok := cfg.Details[k]; !ok {
+						cfg.Details[k] = v
+					}
+				}
 				return cfg
 			}(),
 		},

--- a/receivers/pagerduty/v0mimir1/config_test.go
+++ b/receivers/pagerduty/v0mimir1/config_test.go
@@ -14,11 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestPagerdutyTestRoutingKey(t *testing.T) {
@@ -185,14 +189,214 @@ source: 'alert-manager-source'
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing url",
+			mutate:      func(cfg *Config) { cfg.URL = nil },
+			expectedErr: "missing url in PagerDuty config",
+		},
+		{
+			name: "Missing service or routing key",
+			mutate: func(cfg *Config) {
+				cfg.RoutingKey = ""
+				cfg.ServiceKey = ""
+			},
+			expectedErr: "missing service or routing key in PagerDuty config",
+		},
+		{
+			name: "Both routing_key and routing_key_file",
+			mutate: func(cfg *Config) {
+				cfg.RoutingKeyFile = "file"
+			},
+			expectedErr: "at most one of routing_key & routing_key_file must be configured",
+		},
+		{
+			name: "Both service_key and service_key_file",
+			mutate: func(cfg *Config) {
+				cfg.ServiceKeyFile = "file"
+			},
+			expectedErr: "at most one of service_key & service_key_file must be configured",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name: "Error if missing url",
+			settings: `{
+				"routing_key": "key"
+			}`,
+			expectedInitError: "missing url in PagerDuty config",
+		},
+		{
+			name: "Error if missing routing/service key",
+			settings: `{
+				"url": "http://localhost"
+			}`,
+			expectedInitError: "missing service or routing key in PagerDuty config",
+		},
+		{
+			name: "Minimal valid with routing_key",
+			settings: `{
+				"url": "http://localhost",
+				"routing_key": "test-key"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:     "test-key",
+				Description:    DefaultConfig.Description,
+				Client:         DefaultConfig.Client,
+				ClientURL:      DefaultConfig.ClientURL,
+			},
+		},
+		{
+			name: "Minimal valid with service_key",
+			settings: `{
+				"url": "http://localhost",
+				"service_key": "test-key"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseURL("http://localhost"),
+				ServiceKey:     "test-key",
+				Description:    DefaultConfig.Description,
+				Client:         DefaultConfig.Client,
+				ClientURL:      DefaultConfig.ClientURL,
+			},
+		},
+		{
+			name: "Secrets from decrypt",
+			settings: `{
+				"url": "http://localhost"
+			}`,
+			secrets: map[string][]byte{
+				"routing_key": []byte("secret-routing"),
+				"service_key": []byte("secret-service"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:     "secret-routing",
+				ServiceKey:     "secret-service",
+				Description:    DefaultConfig.Description,
+				Client:         DefaultConfig.Client,
+				ClientURL:      DefaultConfig.ClientURL,
+			},
+		},
+		{
+			name: "Secrets override settings",
+			settings: `{
+				"url": "http://localhost",
+				"routing_key": "original-routing",
+				"service_key": "original-service"
+			}`,
+			secrets: map[string][]byte{
+				"routing_key": []byte("override-routing"),
+				"service_key": []byte("override-service"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:     "override-routing",
+				ServiceKey:     "override-service",
+				Description:    DefaultConfig.Description,
+				Client:         DefaultConfig.Client,
+				ClientURL:      DefaultConfig.ClientURL,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"routing_key": []byte(string(GetFullValidConfig().RoutingKey)),
+				"service_key": []byte(string(GetFullValidConfig().ServiceKey)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/pushover/v0mimir1/config.go
+++ b/receivers/pushover/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -85,6 +86,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret("user_key"); ok {
+		settings.UserKey = decrypted
+	}
+	if decrypted, ok := decrypt.DecryptSecret("token"); ok {
+		settings.Token = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/pushover/v0mimir1/config_test.go
+++ b/receivers/pushover/v0mimir1/config_test.go
@@ -14,10 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestPushoverUserKeyIsPresent(t *testing.T) {
@@ -93,14 +98,181 @@ user_key: 'user key'
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing user_key",
+			mutate:      func(cfg *Config) { cfg.UserKey = "" },
+			expectedErr: "one of user_key or user_key_file must be configured",
+		},
+		{
+			name:        "Missing token",
+			mutate:      func(cfg *Config) { cfg.Token = "" },
+			expectedErr: "one of token or token_file must be configured",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing user_key",
+			settings:          `{"token": "tok"}`,
+			expectedInitError: "one of user_key or user_key_file must be configured",
+		},
+		{
+			name:              "Error if missing token",
+			settings:          `{"user_key": "key"}`,
+			expectedInitError: "one of token or token_file must be configured",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"user_key": "test-user-key",
+				"token": "test-token"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				UserKey:        "test-user-key",
+				Token:          "test-token",
+				Title:          DefaultConfig.Title,
+				Message:        DefaultConfig.Message,
+				URL:            DefaultConfig.URL,
+				Priority:       DefaultConfig.Priority,
+				Retry:          DefaultConfig.Retry,
+				Expire:         DefaultConfig.Expire,
+			},
+		},
+		{
+			name:     "Secrets from decrypt",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"user_key": []byte("secret-user-key"),
+				"token":    []byte("secret-token"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				UserKey:        "secret-user-key",
+				Token:          "secret-token",
+				Title:          DefaultConfig.Title,
+				Message:        DefaultConfig.Message,
+				URL:            DefaultConfig.URL,
+				Priority:       DefaultConfig.Priority,
+				Retry:          DefaultConfig.Retry,
+				Expire:         DefaultConfig.Expire,
+			},
+		},
+		{
+			name: "Secrets override settings",
+			settings: `{
+				"user_key": "original-key",
+				"token": "original-token"
+			}`,
+			secrets: map[string][]byte{
+				"user_key": []byte("override-key"),
+				"token":    []byte("override-token"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				UserKey:        "override-key",
+				Token:          "override-token",
+				Title:          DefaultConfig.Title,
+				Message:        DefaultConfig.Message,
+				URL:            DefaultConfig.URL,
+				Priority:       DefaultConfig.Priority,
+				Retry:          DefaultConfig.Retry,
+				Expire:         DefaultConfig.Expire,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"user_key": []byte(string(GetFullValidConfig().UserKey)),
+				"token":    []byte(string(GetFullValidConfig().Token)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/schema/schema.go
+++ b/receivers/schema/schema.go
@@ -240,6 +240,10 @@ func InitSchema(s IntegrationTypeSchema) IntegrationTypeSchema {
 
 type IntegrationFieldPath []string
 
+func NewIntegrationFieldPath(segments ...string) IntegrationFieldPath {
+	return segments
+}
+
 func ParseIntegrationPath(path string) IntegrationFieldPath {
 	return strings.Split(path, ".")
 }

--- a/receivers/slack/v0mimir1/config.go
+++ b/receivers/slack/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -85,9 +86,35 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.validate()
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if apiURL, ok, err := decrypt.DecryptSecretURL("api_url"); ok {
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to decrypt api_url: %w", err)
+		}
+		settings.APIURL = &apiURL
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.APIURL == nil {
+		return errors.New("missing api_url")
 	}
 	for i, field := range c.Fields {
 		if err := field.Validate(); err != nil {

--- a/receivers/slack/v0mimir1/config_test.go
+++ b/receivers/slack/v0mimir1/config_test.go
@@ -14,10 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestLoadSlackConfiguration(t *testing.T) {
@@ -291,14 +296,225 @@ func newBoolPointer(b bool) *bool {
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing api_url",
+			mutate:      func(cfg *Config) { cfg.APIURL = nil },
+			expectedErr: "missing api_url in slack config",
+		},
+		{
+			name: "Invalid field - missing title",
+			mutate: func(cfg *Config) {
+				cfg.Fields = []*SlackField{{Value: "val"}}
+			},
+			expectedErr: "invalid fields[0]: missing title",
+		},
+		{
+			name: "Invalid field - missing value",
+			mutate: func(cfg *Config) {
+				cfg.Fields = []*SlackField{{Title: "title"}}
+			},
+			expectedErr: "invalid fields[0]: missing value",
+		},
+		{
+			name: "Invalid action - missing type",
+			mutate: func(cfg *Config) {
+				cfg.Actions = []*SlackAction{{Text: "text", URL: "http://localhost"}}
+			},
+			expectedErr: "invalid actions[0]: missing type",
+		},
+		{
+			name: "Invalid action - missing text",
+			mutate: func(cfg *Config) {
+				cfg.Actions = []*SlackAction{{Type: "button", URL: "http://localhost"}}
+			},
+			expectedErr: "invalid actions[0]: missing text",
+		},
+		{
+			name: "Invalid action - missing name or url",
+			mutate: func(cfg *Config) {
+				cfg.Actions = []*SlackAction{{Type: "button", Text: "text"}}
+			},
+			expectedErr: "invalid actions[0]: missing name or url",
+		},
+		{
+			name: "Invalid action confirm - missing text",
+			mutate: func(cfg *Config) {
+				cfg.Actions = []*SlackAction{{
+					Type: "button", Text: "text", Name: "name",
+					ConfirmField: &SlackConfirmationField{Title: "title"},
+				}}
+			},
+			expectedErr: "invalid actions[0]: invalid confirm: missing text",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing api_url",
+			settings:          `{"channel": "#test"}`,
+			expectedInitError: "missing api_url in slack config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"api_url": "http://slack.example.com/webhook"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: false},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIURL:         receivers.MustParseSecretURL("http://slack.example.com/webhook"),
+				Color:          DefaultConfig.Color,
+				Username:       DefaultConfig.Username,
+				Title:          DefaultConfig.Title,
+				TitleLink:      DefaultConfig.TitleLink,
+				IconEmoji:      DefaultConfig.IconEmoji,
+				IconURL:        DefaultConfig.IconURL,
+				Pretext:        DefaultConfig.Pretext,
+				Text:           DefaultConfig.Text,
+				Fallback:       DefaultConfig.Fallback,
+				CallbackID:     DefaultConfig.CallbackID,
+				Footer:         DefaultConfig.Footer,
+			},
+		},
+		{
+			name:     "Secret api_url from decrypt",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"api_url": []byte("http://slack.example.com/secret-webhook"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: false},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIURL:         receivers.MustParseSecretURL("http://slack.example.com/secret-webhook"),
+				Color:          DefaultConfig.Color,
+				Username:       DefaultConfig.Username,
+				Title:          DefaultConfig.Title,
+				TitleLink:      DefaultConfig.TitleLink,
+				IconEmoji:      DefaultConfig.IconEmoji,
+				IconURL:        DefaultConfig.IconURL,
+				Pretext:        DefaultConfig.Pretext,
+				Text:           DefaultConfig.Text,
+				Fallback:       DefaultConfig.Fallback,
+				CallbackID:     DefaultConfig.CallbackID,
+				Footer:         DefaultConfig.Footer,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"api_url": "http://original.example.com/webhook"
+			}`,
+			secrets: map[string][]byte{
+				"api_url": []byte("http://override.example.com/webhook"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: false},
+				HTTPConfig:     &defaultHTTPConfig,
+				APIURL:         receivers.MustParseSecretURL("http://override.example.com/webhook"),
+				Color:          DefaultConfig.Color,
+				Username:       DefaultConfig.Username,
+				Title:          DefaultConfig.Title,
+				TitleLink:      DefaultConfig.TitleLink,
+				IconEmoji:      DefaultConfig.IconEmoji,
+				IconURL:        DefaultConfig.IconURL,
+				Pretext:        DefaultConfig.Pretext,
+				Text:           DefaultConfig.Text,
+				Fallback:       DefaultConfig.Fallback,
+				CallbackID:     DefaultConfig.CallbackID,
+				Footer:         DefaultConfig.Footer,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				// Validate() calls action.validate() which clears Name/Value/ConfirmField when URL is set
+				_ = cfg.Validate()
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"api_url": []byte(GetFullValidConfig().APIURL.String()),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/slack/v0mimir1/config_test.go
+++ b/receivers/slack/v0mimir1/config_test.go
@@ -314,7 +314,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:        "Missing api_url",
 			mutate:      func(cfg *Config) { cfg.APIURL = nil },
-			expectedErr: "missing api_url in slack config",
+			expectedErr: "missing api_url",
 		},
 		{
 			name: "Invalid field - missing title",
@@ -406,7 +406,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:              "Error if missing api_url",
 			settings:          `{"channel": "#test"}`,
-			expectedInitError: "missing api_url in slack config",
+			expectedInitError: "missing api_url",
 		},
 		{
 			name: "Minimal valid configuration",

--- a/receivers/sns/v0mimir1/config.go
+++ b/receivers/sns/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -59,6 +60,26 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret(schema.NewIntegrationFieldPath("sigv4", "secret_key").String()); ok {
+		settings.Sigv4.SecretKey = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/sns/v0mimir1/config_test.go
+++ b/receivers/sns/v0mimir1/config_test.go
@@ -14,10 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestSNS(t *testing.T) {
@@ -107,14 +112,182 @@ sigv4:
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name: "Missing target - must provide one of target_arn, topic_arn, or phone_number",
+			mutate: func(cfg *Config) {
+				cfg.TopicARN = ""
+				cfg.TargetARN = ""
+				cfg.PhoneNumber = ""
+			},
+			expectedErr: "must provide either a Target ARN, Topic ARN, or Phone Number",
+		},
+		{
+			name: "Both topic_arn and target_arn",
+			mutate: func(cfg *Config) {
+				cfg.PhoneNumber = ""
+			},
+			expectedErr: "must provide either a Target ARN, Topic ARN, or Phone Number",
+		},
+		{
+			name: "SigV4 access_key without secret_key",
+			mutate: func(cfg *Config) {
+				cfg.Sigv4.SecretKey = ""
+			},
+			expectedErr: "must provide a AWS SigV4 Access key and Secret Key",
+		},
+		{
+			name: "SigV4 secret_key without access_key",
+			mutate: func(cfg *Config) {
+				cfg.Sigv4.AccessKey = ""
+			},
+			expectedErr: "must provide a AWS SigV4 Access key and Secret Key",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing target",
+			settings:          `{}`,
+			expectedInitError: "must provide either a Target ARN, Topic ARN, or Phone Number",
+		},
+		{
+			name: "Minimal valid with topic_arn",
+			settings: `{
+				"topic_arn": "arn:aws:sns:us-east-1:123456789:test"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				TopicARN:       "arn:aws:sns:us-east-1:123456789:test",
+				Subject:        DefaultConfig.Subject,
+				Message:        DefaultConfig.Message,
+			},
+		},
+		{
+			name: "Secret sigv4.secret_key from decrypt",
+			settings: `{
+				"topic_arn": "arn:aws:sns:us-east-1:123456789:test",
+				"sigv4": {"access_key": "ak"}
+			}`,
+			secrets: map[string][]byte{
+				"sigv4.secret_key": []byte("secret-sk"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				TopicARN:       "arn:aws:sns:us-east-1:123456789:test",
+				Sigv4:          SigV4Config{AccessKey: "ak", SecretKey: "secret-sk"},
+				Subject:        DefaultConfig.Subject,
+				Message:        DefaultConfig.Message,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"topic_arn": "arn:aws:sns:us-east-1:123456789:test",
+				"sigv4": {"access_key": "ak", "secret_key": "original"}
+			}`,
+			secrets: map[string][]byte{
+				"sigv4.secret_key": []byte("override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				TopicARN:       "arn:aws:sns:us-east-1:123456789:test",
+				Sigv4:          SigV4Config{AccessKey: "ak", SecretKey: "override"},
+				Subject:        DefaultConfig.Subject,
+				Message:        DefaultConfig.Message,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"sigv4.secret_key": []byte(string(GetFullValidConfig().Sigv4.SecretKey)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/teams/v0mimir1/config.go
+++ b/receivers/teams/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -57,6 +58,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if webhookURL, ok, err := decrypt.DecryptSecretURL("webhook_url"); ok {
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to decrypt webhook_url: %w", err)
+		}
+		settings.WebhookURL = &webhookURL
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/teams/v0mimir1/config_test.go
+++ b/receivers/teams/v0mimir1/config_test.go
@@ -1,21 +1,166 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing webhook_url",
+			mutate:      func(cfg *Config) { cfg.WebhookURL = nil },
+			expectedErr: "one of webhook_url or webhook_url_file must be configured",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing webhook_url",
+			settings:          `{"title": "test"}`,
+			expectedInitError: "one of webhook_url or webhook_url_file must be configured",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"webhook_url": "http://teams.example.com/webhook"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://teams.example.com/webhook"),
+				Title:          DefaultConfig.Title,
+				Summary:        DefaultConfig.Summary,
+				Text:           DefaultConfig.Text,
+			},
+		},
+		{
+			name:     "Secret webhook_url from decrypt",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://teams.example.com/secret-webhook"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://teams.example.com/secret-webhook"),
+				Title:          DefaultConfig.Title,
+				Summary:        DefaultConfig.Summary,
+				Text:           DefaultConfig.Text,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"webhook_url": "http://original.example.com/webhook"
+			}`,
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://override.example.com/webhook"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://override.example.com/webhook"),
+				Title:          DefaultConfig.Title,
+				Summary:        DefaultConfig.Summary,
+				Text:           DefaultConfig.Text,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"webhook_url": []byte(GetFullValidConfig().WebhookURL.String()),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/teams/v0mimir2/config.go
+++ b/receivers/teams/v0mimir2/config.go
@@ -15,6 +15,7 @@
 package v0mimir2
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -55,6 +56,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if webhookURL, ok, err := decrypt.DecryptSecretURL("webhook_url"); ok {
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to decrypt webhook_url: %w", err)
+		}
+		settings.WebhookURL = &webhookURL
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/teams/v0mimir2/config_test.go
+++ b/receivers/teams/v0mimir2/config_test.go
@@ -1,21 +1,163 @@
 package v0mimir2
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing webhook_url",
+			mutate:      func(cfg *Config) { cfg.WebhookURL = nil },
+			expectedErr: "one of webhook_url or webhook_url_file must be configured",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing webhook_url",
+			settings:          `{"title": "test"}`,
+			expectedInitError: "one of webhook_url or webhook_url_file must be configured",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"webhook_url": "http://teams.example.com/webhook"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://teams.example.com/webhook"),
+				Title:          DefaultConfig.Title,
+				Text:           DefaultConfig.Text,
+			},
+		},
+		{
+			name:     "Secret webhook_url from decrypt",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://teams.example.com/secret-webhook"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://teams.example.com/secret-webhook"),
+				Title:          DefaultConfig.Title,
+				Text:           DefaultConfig.Text,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"webhook_url": "http://original.example.com/webhook"
+			}`,
+			secrets: map[string][]byte{
+				"webhook_url": []byte("http://override.example.com/webhook"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				WebhookURL:     receivers.MustParseSecretURL("http://override.example.com/webhook"),
+				Title:          DefaultConfig.Title,
+				Text:           DefaultConfig.Text,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"webhook_url": []byte(GetFullValidConfig().WebhookURL.String()),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/telegram/v0mimir1/config.go
+++ b/receivers/telegram/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -71,6 +72,26 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		c.ChatID = pl.ChatIDJson
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret("token"); ok {
+		settings.BotToken = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/telegram/v0mimir1/config_test.go
+++ b/receivers/telegram/v0mimir1/config_test.go
@@ -14,12 +14,16 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestTelegramConfiguration(t *testing.T) {
@@ -95,14 +99,171 @@ parse_mode: Markdown
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing bot_token",
+			mutate:      func(cfg *Config) { cfg.BotToken = "" },
+			expectedErr: "missing bot_token or bot_token_file on telegram_config",
+		},
+		{
+			name:        "Missing chat_id",
+			mutate:      func(cfg *Config) { cfg.ChatID = 0 },
+			expectedErr: "missing chat_id on telegram_config",
+		},
+		{
+			name:        "Invalid parse_mode",
+			mutate:      func(cfg *Config) { cfg.ParseMode = "invalid" },
+			expectedErr: "unknown parse_mode on telegram_config",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing bot_token",
+			settings:          `{"chat": 123}`,
+			expectedInitError: "missing bot_token or bot_token_file on telegram_config",
+		},
+		{
+			name:              "Error if missing chat_id",
+			settings:          `{"token": "tok"}`,
+			expectedInitError: "missing chat_id on telegram_config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"token": "test-token",
+				"chat": 123
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				BotToken:       "test-token",
+				ChatID:         123,
+				Message:        DefaultConfig.Message,
+				ParseMode:      DefaultConfig.ParseMode,
+			},
+		},
+		{
+			name:     "Secret token from decrypt",
+			settings: `{"chat": 123}`,
+			secrets: map[string][]byte{
+				"token": []byte("secret-token"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				BotToken:       "secret-token",
+				ChatID:         123,
+				Message:        DefaultConfig.Message,
+				ParseMode:      DefaultConfig.ParseMode,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"token": "original",
+				"chat": 123
+			}`,
+			secrets: map[string][]byte{
+				"token": []byte("override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				BotToken:       "override",
+				ChatID:         123,
+				Message:        DefaultConfig.Message,
+				ParseMode:      DefaultConfig.ParseMode,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"token": []byte(string(GetFullValidConfig().BotToken)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/victorops/v0mimir1/config.go
+++ b/receivers/victorops/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -64,9 +65,35 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.validate()
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if decrypted, ok := decrypt.DecryptSecret("api_key"); ok {
+		settings.APIKey = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.APIURL == nil {
+		return errors.New("missing api_url in VictorOps config")
+	}
+	if c.APIKey == "" {
+		return errors.New("missing api_key in VictorOps config")
 	}
 	if c.HTTPConfig != nil {
 		if err := c.HTTPConfig.Validate(); err != nil {

--- a/receivers/victorops/v0mimir1/config_test.go
+++ b/receivers/victorops/v0mimir1/config_test.go
@@ -14,10 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestVictorOpsConfiguration(t *testing.T) {
@@ -113,14 +118,206 @@ custom_fields:
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing routing_key",
+			mutate:      func(cfg *Config) { cfg.RoutingKey = "" },
+			expectedErr: "missing Routing key in VictorOps config",
+		},
+		{
+			name:        "Missing api_url",
+			mutate:      func(cfg *Config) { cfg.APIURL = nil },
+			expectedErr: "missing api_url in VictorOps config",
+		},
+		{
+			name:        "Missing api_key",
+			mutate:      func(cfg *Config) { cfg.APIKey = "" },
+			expectedErr: "missing api_key in VictorOps config",
+		},
+		{
+			name: "Reserved custom field",
+			mutate: func(cfg *Config) {
+				cfg.CustomFields = map[string]string{"entity_state": "value"}
+			},
+			expectedErr: "conflicts with the fixed/static fields",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name: "Error if missing routing_key",
+			settings: `{
+				"api_url": "http://localhost",
+				"api_key": "key"
+			}`,
+			expectedInitError: "missing Routing key in VictorOps config",
+		},
+		{
+			name: "Error if missing api_url",
+			settings: `{
+				"api_key": "key",
+				"routing_key": "team1"
+			}`,
+			expectedInitError: "missing api_url in VictorOps config",
+		},
+		{
+			name: "Error if missing api_key",
+			settings: `{
+				"api_url": "http://localhost",
+				"routing_key": "team1"
+			}`,
+			expectedInitError: "missing api_key in VictorOps config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"api_url": "http://localhost",
+				"api_key": "test-key",
+				"routing_key": "team1"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig:    receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:        &defaultHTTPConfig,
+				APIKey:            "test-key",
+				APIURL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:        "team1",
+				MessageType:       DefaultConfig.MessageType,
+				StateMessage:      DefaultConfig.StateMessage,
+				EntityDisplayName: DefaultConfig.EntityDisplayName,
+				MonitoringTool:    DefaultConfig.MonitoringTool,
+			},
+		},
+		{
+			name: "Secret from decrypt",
+			settings: `{
+				"api_url": "http://localhost",
+				"routing_key": "team1"
+			}`,
+			secrets: map[string][]byte{
+				"api_key": []byte("secret-key"),
+			},
+			expectedConfig: Config{
+				NotifierConfig:    receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:        &defaultHTTPConfig,
+				APIKey:            "secret-key",
+				APIURL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:        "team1",
+				MessageType:       DefaultConfig.MessageType,
+				StateMessage:      DefaultConfig.StateMessage,
+				EntityDisplayName: DefaultConfig.EntityDisplayName,
+				MonitoringTool:    DefaultConfig.MonitoringTool,
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"api_url": "http://localhost",
+				"api_key": "original",
+				"routing_key": "team1"
+			}`,
+			secrets: map[string][]byte{
+				"api_key": []byte("override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig:    receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:        &defaultHTTPConfig,
+				APIKey:            "override",
+				APIURL:            receivers.MustParseURL("http://localhost"),
+				RoutingKey:        "team1",
+				MessageType:       DefaultConfig.MessageType,
+				StateMessage:      DefaultConfig.StateMessage,
+				EntityDisplayName: DefaultConfig.EntityDisplayName,
+				MonitoringTool:    DefaultConfig.MonitoringTool,
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"api_key": []byte(string(GetFullValidConfig().APIKey)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/webex/v0mimir1/config.go
+++ b/receivers/webex/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -52,9 +53,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.validate()
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.APIURL == nil {
+		return errors.New("missing api_url in webex config")
 	}
 	if c.HTTPConfig != nil {
 		if err := c.HTTPConfig.Validate(); err != nil {

--- a/receivers/webex/v0mimir1/config_test.go
+++ b/receivers/webex/v0mimir1/config_test.go
@@ -14,12 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestWebexConfiguration(t *testing.T) {
@@ -58,14 +61,146 @@ http_config:
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing room_id",
+			mutate:      func(cfg *Config) { cfg.RoomID = "" },
+			expectedErr: "missing room_id on webex_config",
+		},
+		{
+			name:        "Missing api_url",
+			mutate:      func(cfg *Config) { cfg.APIURL = nil },
+			expectedErr: "missing api_url in webex config",
+		},
+		{
+			name: "Missing http_config.authorization",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig.Authorization = nil
+			},
+			expectedErr: "missing webex_configs.http_config.authorization",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig.BasicAuth = &httpcfg.BasicAuth{}
+				cfg.HTTPConfig.OAuth2 = &httpcfg.OAuth2{}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing room_id",
+			settings:          `{"api_url": "https://localhost", "http_config": {"authorization": {"credentials": "tok"}}}`,
+			expectedInitError: "missing room_id on webex_config",
+		},
+		{
+			name:              "Error if missing authorization",
+			settings:          `{"api_url": "https://localhost", "room_id": "123"}`,
+			expectedInitError: "missing webex_configs.http_config.authorization",
+		},
+		{
+			name:     "Valid configuration",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				// DecryptHTTPConfig always returns non-nil
+				httpCfg, _ := httpcfg.DecryptHTTPConfig("http_config", cfg.HTTPConfig, receiversTesting.DecryptForTesting(nil))
+				cfg.HTTPConfig = httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name: "Authorization credentials from decrypt",
+			settings: `{
+				"api_url": "https://localhost",
+				"room_id": "123"
+			}`,
+			secrets: map[string][]byte{
+				"http_config.authorization.credentials": []byte("secret-token"),
+			},
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(`{"api_url": "https://localhost", "room_id": "123"}`), &cfg)
+				httpCfg, _ := httpcfg.DecryptHTTPConfig("http_config", cfg.HTTPConfig, receiversTesting.DecryptForTesting(map[string][]byte{
+					"http_config.authorization.credentials": []byte("secret-token"),
+				}))
+				// Validate() sets default Authorization.Type to "Bearer"
+				_ = httpCfg.Validate()
+				cfg.HTTPConfig = httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"http_config.authorization.credentials": []byte(string(GetFullValidConfig().HTTPConfig.Authorization.Credentials)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				httpCfg, _ := httpcfg.DecryptHTTPConfig("http_config", cfg.HTTPConfig, receiversTesting.DecryptForTesting(map[string][]byte{
+					"http_config.authorization.credentials": []byte(string(cfg.HTTPConfig.Authorization.Credentials)),
+				}))
+				cfg.HTTPConfig = httpCfg
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/webhook/v0mimir1/config.go
+++ b/receivers/webhook/v0mimir1/config.go
@@ -15,6 +15,7 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -63,6 +64,29 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	return c.validate()
+}
+
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if webhookURL, ok, err := decrypt.DecryptSecretURL("url"); ok {
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to decrypt url: %w", err)
+		}
+		settings.URL = &webhookURL
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
 }
 
 func (c *Config) Validate() error {

--- a/receivers/webhook/v0mimir1/config_test.go
+++ b/receivers/webhook/v0mimir1/config_test.go
@@ -14,11 +14,16 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestWebhookURLIsPresent(t *testing.T) {
@@ -109,14 +114,145 @@ http_config:
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing url",
+			mutate:      func(cfg *Config) { cfg.URL = nil },
+			expectedErr: "one of url or url_file must be configured",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if missing url",
+			settings:          `{}`,
+			expectedInitError: "one of url or url_file must be configured",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"url": "http://webhook.example.com"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseSecretURL("http://webhook.example.com"),
+			},
+		},
+		{
+			name:     "Secret url from decrypt",
+			settings: `{}`,
+			secrets: map[string][]byte{
+				"url": []byte("http://webhook.example.com/secret"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseSecretURL("http://webhook.example.com/secret"),
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"url": "http://original.example.com"
+			}`,
+			secrets: map[string][]byte{
+				"url": []byte("http://override.example.com"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: true},
+				HTTPConfig:     &defaultHTTPConfig,
+				URL:            receivers.MustParseSecretURL("http://override.example.com"),
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"url": []byte(GetFullValidConfig().URL.String()),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }

--- a/receivers/wechat/v0mimir1/config.go
+++ b/receivers/wechat/v0mimir1/config.go
@@ -15,6 +15,8 @@
 package v0mimir1
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -73,9 +75,41 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.validate()
 }
 
+// NewConfig creates a Config from raw JSON and a decrypt function for secure fields.
+func NewConfig(jsonData json.RawMessage, decrypt receivers.DecryptFunc) (Config, error) {
+	settings := DefaultConfig
+	var err error
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+	if settings.MessageType == "" {
+		settings.MessageType = "text"
+	}
+	if decrypted, ok := decrypt.DecryptSecret("api_secret"); ok {
+		settings.APISecret = decrypted
+	}
+	settings.HTTPConfig, err = httpcfg.DecryptHTTPConfig("http_config", settings.HTTPConfig, decrypt)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decrypt http_config: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Config{}, err
+	}
+	return settings, nil
+}
+
 func (c *Config) Validate() error {
 	if err := c.validate(); err != nil {
 		return err
+	}
+	if c.APIURL == nil {
+		return errors.New("missing api_url in wechat config")
+	}
+	if c.APISecret == "" {
+		return errors.New("missing api_secret in wechat config")
+	}
+	if c.CorpID == "" {
+		return errors.New("missing corp_id in wechat config")
 	}
 	if c.HTTPConfig != nil {
 		if err := c.HTTPConfig.Validate(); err != nil {

--- a/receivers/wechat/v0mimir1/config_test.go
+++ b/receivers/wechat/v0mimir1/config_test.go
@@ -14,10 +14,15 @@
 package v0mimir1
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/grafana/alerting/receivers"
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
 )
 
 func TestWeChatTypeMatcher(t *testing.T) {
@@ -36,14 +41,210 @@ func TestWeChatTypeMatcher(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("GetFullValidConfig is valid", func(t *testing.T) {
-		cfg := GetFullValidConfig()
-		require.NoError(t, cfg.Validate())
-	})
 	t.Run("FullValidConfigForTesting is valid", func(t *testing.T) {
 		var cfg Config
 		err := yaml.UnmarshalStrict([]byte(FullValidConfigForTesting), &cfg)
 		require.NoError(t, err)
 		require.NoError(t, cfg.Validate())
 	})
+	cases := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		expectedErr string
+	}{
+		{
+			name:   "GetFullValidConfig is valid",
+			mutate: func(cfg *Config) {},
+		},
+		{
+			name:        "Missing api_url",
+			mutate:      func(cfg *Config) { cfg.APIURL = nil },
+			expectedErr: "missing api_url in wechat config",
+		},
+		{
+			name:        "Missing api_secret",
+			mutate:      func(cfg *Config) { cfg.APISecret = "" },
+			expectedErr: "missing api_secret in wechat config",
+		},
+		{
+			name:        "Missing corp_id",
+			mutate:      func(cfg *Config) { cfg.CorpID = "" },
+			expectedErr: "missing corp_id in wechat config",
+		},
+		{
+			name:        "Invalid message_type",
+			mutate:      func(cfg *Config) { cfg.MessageType = "invalid" },
+			expectedErr: "does not match valid options",
+		},
+		{
+			name: "Invalid http_config",
+			mutate: func(cfg *Config) {
+				cfg.HTTPConfig = &httpcfg.HTTPClientConfig{
+					BasicAuth: &httpcfg.BasicAuth{},
+					OAuth2:    &httpcfg.OAuth2{},
+				}
+			},
+			expectedErr: "invalid http_config",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := GetFullValidConfig()
+			c.mutate(&cfg)
+			err := cfg.Validate()
+
+			if c.expectedErr != "" {
+				require.ErrorContains(t, err, c.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	defaultHTTPConfig := httpcfg.DefaultHTTPClientConfig
+
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name: "Error if missing api_url",
+			settings: `{
+				"api_secret": "secret",
+				"corp_id": "corp"
+			}`,
+			expectedInitError: "missing api_url in wechat config",
+		},
+		{
+			name: "Error if missing api_secret",
+			settings: `{
+				"api_url": "http://localhost",
+				"corp_id": "corp"
+			}`,
+			expectedInitError: "missing api_secret in wechat config",
+		},
+		{
+			name: "Error if missing corp_id",
+			settings: `{
+				"api_url": "http://localhost",
+				"api_secret": "secret"
+			}`,
+			expectedInitError: "missing corp_id in wechat config",
+		},
+		{
+			name: "Minimal valid configuration",
+			settings: `{
+				"api_url": "http://localhost",
+				"api_secret": "test-secret",
+				"corp_id": "test-corp"
+			}`,
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: false},
+				HTTPConfig:     &defaultHTTPConfig,
+				APISecret:      "test-secret",
+				CorpID:         "test-corp",
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Message:        DefaultConfig.Message,
+				ToUser:         DefaultConfig.ToUser,
+				ToParty:        DefaultConfig.ToParty,
+				ToTag:          DefaultConfig.ToTag,
+				AgentID:        DefaultConfig.AgentID,
+				MessageType:    "text",
+			},
+		},
+		{
+			name: "Secret from decrypt",
+			settings: `{
+				"api_url": "http://localhost",
+				"corp_id": "test-corp"
+			}`,
+			secrets: map[string][]byte{
+				"api_secret": []byte("secret-from-decrypt"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: false},
+				HTTPConfig:     &defaultHTTPConfig,
+				APISecret:      "secret-from-decrypt",
+				CorpID:         "test-corp",
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Message:        DefaultConfig.Message,
+				ToUser:         DefaultConfig.ToUser,
+				ToParty:        DefaultConfig.ToParty,
+				ToTag:          DefaultConfig.ToTag,
+				AgentID:        DefaultConfig.AgentID,
+				MessageType:    "text",
+			},
+		},
+		{
+			name: "Secret overrides setting",
+			settings: `{
+				"api_url": "http://localhost",
+				"api_secret": "original",
+				"corp_id": "test-corp"
+			}`,
+			secrets: map[string][]byte{
+				"api_secret": []byte("override"),
+			},
+			expectedConfig: Config{
+				NotifierConfig: receivers.NotifierConfig{VSendResolved: false},
+				HTTPConfig:     &defaultHTTPConfig,
+				APISecret:      "override",
+				CorpID:         "test-corp",
+				APIURL:         receivers.MustParseURL("http://localhost"),
+				Message:        DefaultConfig.Message,
+				ToUser:         DefaultConfig.ToUser,
+				ToParty:        DefaultConfig.ToParty,
+				ToTag:          DefaultConfig.ToTag,
+				AgentID:        DefaultConfig.AgentID,
+				MessageType:    "text",
+			},
+		},
+		{
+			name:     "FullValidConfigForTesting is valid",
+			settings: FullValidConfigForTesting,
+			expectedConfig: func() Config {
+				cfg := DefaultConfig
+				_ = json.Unmarshal([]byte(FullValidConfigForTesting), &cfg)
+				httpCfg := httpcfg.DefaultHTTPClientConfig
+				cfg.HTTPConfig = &httpCfg
+				return cfg
+			}(),
+		},
+		{
+			name:     "GetFullValidConfig round-trips through JSON",
+			settings: func() string { b, _ := json.Marshal(GetFullValidConfig()); return string(b) }(),
+			secrets: map[string][]byte{
+				"api_secret": []byte(string(GetFullValidConfig().APISecret)),
+			},
+			expectedConfig: func() Config {
+				cfg := GetFullValidConfig()
+				cfg.HTTPConfig = &defaultHTTPConfig
+				return cfg
+			}(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := NewConfig(json.RawMessage(c.settings), receiversTesting.DecryptForTesting(c.secrets))
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Add `NewConfig(json.RawMessage, DecryptFunc) (Config, error)` to all 15 legacy receiver integrations as an alternative to YAML unmarshaling
- Add `DecryptHTTPConfig` in `http/v0mimir` for decrypting all secret fields in HTTPClientConfig
- Add helper methods on `DecryptFunc`: `DecryptSecret`, `DecryptSecretURL`, `GetPath`
- Port missing validations from `definition/compat.go` `LoadCompat` into each integration's `Validate()`
- Add comprehensive `TestNewConfig` (table-driven) and `TestValidate` (mutate pattern) for each integration

| # | Integration | Secrets | Validations from LoadCompat |
|---|---|---|---|
| 1 | discord/v0mimir1 | SecretURL: `webhook_url` | — |
| 2 | email/v0mimir1 | Secret: `auth_password`, `auth_secret`; TLS key | `smarthost`, `from` |
| 3 | jira/v0mimir1 | HTTPConfig only | `api_url` |
| 4 | opsgenie/v0mimir1 | Secret: `api_key` | `api_url`, `api_key` |
| 5 | pagerduty/v0mimir1 | Secret: `routing_key`, `service_key` | `url` |
| 6 | pushover/v0mimir1 | Secret: `user_key`, `token` | — |
| 7 | slack/v0mimir1 | SecretURL: `api_url` | `api_url` |
| 8 | sns/v0mimir1 | Secret: `sigv4.secret_key` | — |
| 9 | teams/v0mimir1 | SecretURL: `webhook_url` | — |
| 10 | teams/v0mimir2 | SecretURL: `webhook_url` | — |
| 11 | telegram/v0mimir1 | Secret: `token` | — |
| 12 | victorops/v0mimir1 | Secret: `api_key` | `api_url`, `api_key` |
| 13 | webex/v0mimir1 | HTTPConfig only | `api_url` |
| 14 | webhook/v0mimir1 | SecretURL: `url` | — |
| 15 | wechat/v0mimir1 | Secret: `api_secret` | `api_url`, `api_secret`, `corp_id` |

All `NewConfig` functions follow a consistent pattern: unmarshal JSON into DefaultConfig, decrypt integration-specific secrets, call `DecryptHTTPConfig`, then `Validate()`. All `Secure: true` schema fields are covered by the corresponding decrypt calls.

NOTE: The factory functions deliberately ignore "file" fields as they are not allowed in the Grafana and Mimir.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config initialization/validation and secret handling across many legacy receivers, which can change runtime behavior for misconfigured integrations or decryption edge cases. Risk is mitigated by extensive new table-driven tests but still spans multiple integrations and HTTP auth paths.
> 
> **Overview**
> Adds a JSON-based `NewConfig(json.RawMessage, DecryptFunc)` factory to legacy `v0mimir1`/`v0mimir2` receivers so configs can be initialized from JSON, decrypted, and validated without relying on YAML unmarshalling.
> 
> Introduces centralized HTTP secret decryption via `http/v0mimir.DecryptHTTPConfig` (basic auth, authorization, OAuth2, bearer token, TLS keys, header/proxy header secrets) plus new `DecryptFunc` helpers (`GetPath`, `DecryptSecret`, `DecryptSecretURL`) and `schema.NewIntegrationFieldPath` for structured secret key paths.
> 
> Tightens `Validate()` in several integrations by adding previously-missing required-field checks (for example `api_url`, `url`, `api_key`, email `smarthost`/`from`, wechat `corp_id`), and adds comprehensive `TestNewConfig`/expanded `TestValidate` coverage across receivers to verify defaults, secret overrides, and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01c6883731e11f2f6bbfdf74b62b1e6a58ced067. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->