### PR TITLE
Notify: Improve tracing and logging for historian errors.

### DIFF
--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -73,6 +73,7 @@ type NotificationHistorian struct {
 	writesTotal    prometheus.Counter
 	writesFailed   prometheus.Counter
 	logger         log.Logger
+	tracer         trace.Tracer
 }
 
 func NewNotificationHistorian(
@@ -91,6 +92,7 @@ func NewNotificationHistorian(
 		writesTotal:    writesTotal,
 		writesFailed:   writesFailed,
 		logger:         logger,
+		tracer:         tracer,
 	}
 }
 
@@ -111,17 +113,23 @@ func (h *NotificationHistorian) Record(ctx context.Context, nhe nfstatus.Notific
 	// This also prevents timeouts or other lingering objects (like transactions) from being
 	// incorrectly propagated here from other areas.
 	writeCtx, cancel := context.WithTimeout(context.Background(), NotificationHistoryWriteTimeout)
-	writeCtx = trace.ContextWithSpan(writeCtx, trace.SpanFromContext(ctx))
 	defer cancel()
 
-	level.Debug(h.logger).Log("msg", "Saving notification history")
+	writeCtx, span := h.tracer.Start(writeCtx, "ngalert.notification-historian.record",
+		trace.WithLinks(trace.LinkFromContext(ctx)),
+	)
+	defer span.End()
+
+	logger := log.With(h.logger, "traceID", span.SpanContext().TraceID())
+
+	level.Debug(logger).Log("msg", "Saving notification history")
 	h.writesTotal.Inc()
 
 	if err := h.client.Push(writeCtx, streams); err != nil {
-		level.Error(h.logger).Log("msg", "Failed to save notification history", "error", err)
+		level.Error(logger).Log("msg", "Failed to save notification history", "error", err)
 		h.writesFailed.Inc()
 	}
-	level.Debug(h.logger).Log("msg", "Done saving notification history")
+	level.Debug(logger).Log("msg", "Done saving notification history")
 }
 
 // prepareStreams prepares the data to be written to Loki. It is written to two streams:

--- a/notify/historian/lokiclient/client.go
+++ b/notify/historian/lokiclient/client.go
@@ -451,7 +451,7 @@ func (c *HTTPLokiClient) handleLokiResponse(logger log.Logger, res *http.Respons
 		} else {
 			level.Error(logger).Log("msg", "Error response from Loki with an empty body", "status", res.StatusCode)
 		}
-		return nil, fmt.Errorf("received a non-200 response from loki, status: %d", res.StatusCode)
+		return nil, fmt.Errorf("received a non-200 response from loki, status: %d, body: %q", res.StatusCode, string(data))
 	}
 
 	return data, nil


### PR DESCRIPTION
Few changes:
- Create a span in Record(), but not as direct child as writing is async.
- Log the trace ID in the error message.
- Return the body of the loki write error in the error so it is logged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to observability (span creation, trace-linked logging) and richer error messages, without altering the notification history payloads or write behavior.
> 
> **Overview**
> Adds explicit tracing for notification history writes by starting a new span in `NotificationHistorian.Record` (linked to the caller span rather than inheriting its context) and logging with the resulting `traceID` for easier correlation.
> 
> Improves Loki write failure diagnostics by including the HTTP response body in the non-2xx error returned from `handleLokiResponse`, so upstream logs capture Loki’s error details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb06cbc56ae125105880fc37c2cfc7bfdee60e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->