### PR TITLE
Increase TLS handshake timeout to 15s and extract to constant

### DIFF
--- a/http/oauth2.go
+++ b/http/oauth2.go
@@ -109,7 +109,7 @@ func NewOAuth2TokenSource(config OAuth2Config, clientConfig clientConfiguration)
 		MaxIdleConns:          20,
 		MaxIdleConnsPerHost:   1, // see https://github.com/golang/go/issues/13801
 		IdleConnTimeout:       10 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
+		TLSHandshakeTimeout:   receivers.TLSHandshakeTimeout,
 		ExpectContinueTimeout: 1 * time.Second,
 
 		// The following differs from upstream, allowing proxy settings to be configured.

--- a/http/tls.go
+++ b/http/tls.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/grafana/alerting/receivers"
 )
 
 // NewTLSClient creates a new HTTP client with the provided TLS configuration or with default settings.
@@ -28,7 +30,7 @@ func NewTLSClient(tlsConfig *tls.Config, dialContextfunc func(context.Context, s
 			TLSClientConfig:     tlsConfig,
 			Proxy:               http.ProxyFromEnvironment,
 			DialContext:         dialContextfunc,
-			TLSHandshakeTimeout: 5 * time.Second,
+			TLSHandshakeTimeout: receivers.TLSHandshakeTimeout,
 			// Disable keep alive since this is always used as a short lived client
 			DisableKeepAlives: true,
 		},

--- a/receivers/slack/v1/slack.go
+++ b/receivers/slack/v1/slack.go
@@ -56,7 +56,7 @@ var (
 			DialContext: (&net.Dialer{
 				Timeout: 30 * time.Second,
 			}).DialContext,
-			TLSHandshakeTimeout: 5 * time.Second,
+			TLSHandshakeTimeout: receivers.TLSHandshakeTimeout,
 		},
 	}
 )

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -30,6 +30,9 @@ const (
 
 	AlertStateAlerting AlertStateType = "alerting"
 	AlertStateOK       AlertStateType = "ok"
+
+	// TLSHandshakeTimeout is the maximum time to wait for a TLS handshake.
+	TLSHandshakeTimeout = 15 * time.Second
 )
 
 func GetAlertStatusColor(status model.AlertStatus) string {
@@ -192,7 +195,7 @@ func (s *defaultSender) SendHTTPRequest(ctx context.Context, url *url.URL, cfg H
 		DialContext: (&net.Dialer{
 			Timeout: 30 * time.Second,
 		}).DialContext,
-		TLSHandshakeTimeout: 5 * time.Second,
+		TLSHandshakeTimeout: TLSHandshakeTimeout,
 		// Disable keep alive since this is a short lived client
 		DisableKeepAlives: true,
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change that only adjusts network timeout behavior, but it affects multiple outbound HTTP clients so could slightly delay failures in pathological handshake hangs.
> 
> **Overview**
> Increases the outbound `TLSHandshakeTimeout` to **15s** and centralizes it as `receivers.TLSHandshakeTimeout`.
> 
> Updates the OAuth2 transport (`http/oauth2.go`), generic TLS client (`http/tls.go`), Slack notifier client, and `receivers` HTTP sender to use the shared constant instead of hardcoded 5–10s values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e609083ff0f9bef223a132c84fbb62db7ffbf07c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->