### PR TITLE
Consolidate all known integration types in one file

### DIFF
--- a/receivers/alertmanager/schema.go
+++ b/receivers/alertmanager/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "prometheus-alertmanager"
+const Type = schema.AlertManagerType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/dingding/schema.go
+++ b/receivers/dingding/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "dingding"
+const Type = schema.DingDingType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/discord/schema.go
+++ b/receivers/discord/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "discord"
+const Type = schema.DiscordType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/email/schema.go
+++ b/receivers/email/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "email"
+const Type = schema.EmailType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/googlechat/schema.go
+++ b/receivers/googlechat/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "googlechat"
+const Type = schema.GoogleChatType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/jira/schema.go
+++ b/receivers/jira/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "jira"
+const Type = schema.JiraType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/kafka/schema.go
+++ b/receivers/kafka/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "kafka"
+const Type = schema.KafkaType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/line/schema.go
+++ b/receivers/line/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "LINE"
+const Type = schema.LineType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/mqtt/schema.go
+++ b/receivers/mqtt/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "mqtt"
+const Type = schema.MQTTType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/oncall/schema.go
+++ b/receivers/oncall/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "oncall"
+const Type = schema.OnCallType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/opsgenie/schema.go
+++ b/receivers/opsgenie/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "opsgenie"
+const Type = schema.OpsGenieType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/pagerduty/schema.go
+++ b/receivers/pagerduty/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "pagerduty"
+const Type = schema.PagerDutyType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/pushover/schema.go
+++ b/receivers/pushover/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 )
 
-const Type schema.IntegrationType = "pushover"
+const Type = schema.PushoverType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/schema/known_types.go
+++ b/receivers/schema/known_types.go
@@ -1,0 +1,28 @@
+package schema
+
+const (
+	AlertManagerType IntegrationType = "prometheus-alertmanager"
+	DingDingType     IntegrationType = "dingding"
+	DiscordType      IntegrationType = "discord"
+	EmailType        IntegrationType = "email"
+	GoogleChatType   IntegrationType = "googlechat"
+	JiraType         IntegrationType = "jira"
+	KafkaType        IntegrationType = "kafka"
+	LineType         IntegrationType = "LINE"
+	MQTTType         IntegrationType = "mqtt"
+	OnCallType       IntegrationType = "oncall"
+	OpsGenieType     IntegrationType = "opsgenie"
+	PagerDutyType    IntegrationType = "pagerduty"
+	PushoverType     IntegrationType = "pushover"
+	SensuGoType      IntegrationType = "sensugo"
+	SlackType        IntegrationType = "slack"
+	SNSType          IntegrationType = "sns"
+	TeamsType        IntegrationType = "teams"
+	TelegramType     IntegrationType = "telegram"
+	ThreemaType      IntegrationType = "threema"
+	VictorOpsType    IntegrationType = "victorops"
+	WebexType        IntegrationType = "webex"
+	WebhookType      IntegrationType = "webhook"
+	WeChatType       IntegrationType = "wechat"
+	WeComType        IntegrationType = "wecom"
+)

--- a/receivers/sensugo/schema.go
+++ b/receivers/sensugo/schema.go
@@ -5,7 +5,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/sensugo/v1"
 )
 
-const Type schema.IntegrationType = "sensugo"
+const Type = schema.SensuGoType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/slack/schema.go
+++ b/receivers/slack/schema.go
@@ -6,7 +6,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/slack/v1"
 )
 
-const Type schema.IntegrationType = "slack"
+const Type = schema.SlackType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/sns/schema.go
+++ b/receivers/sns/schema.go
@@ -6,7 +6,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/sns/v1"
 )
 
-const Type schema.IntegrationType = "sns"
+const Type = schema.SNSType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/teams/schema.go
+++ b/receivers/teams/schema.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/teams/v1"
 )
 
-const Type schema.IntegrationType = "teams"
+const Type = schema.TeamsType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/telegram/schema.go
+++ b/receivers/telegram/schema.go
@@ -6,7 +6,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/telegram/v1"
 )
 
-const Type schema.IntegrationType = "telegram"
+const Type = schema.TelegramType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/threema/schema.go
+++ b/receivers/threema/schema.go
@@ -5,7 +5,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/threema/v1"
 )
 
-const Type schema.IntegrationType = "threema"
+const Type = schema.ThreemaType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:        Type,

--- a/receivers/victorops/schema.go
+++ b/receivers/victorops/schema.go
@@ -6,7 +6,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/victorops/v1"
 )
 
-const Type schema.IntegrationType = "victorops"
+const Type = schema.VictorOpsType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/webex/schema.go
+++ b/receivers/webex/schema.go
@@ -6,7 +6,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/webex/v1"
 )
 
-const Type schema.IntegrationType = "webex"
+const Type = schema.WebexType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/webhook/schema.go
+++ b/receivers/webhook/schema.go
@@ -6,7 +6,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/webhook/v1"
 )
 
-const Type schema.IntegrationType = "webhook"
+const Type = schema.WebhookType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,

--- a/receivers/wechat/schema.go
+++ b/receivers/wechat/schema.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/alerting/receivers/wechat/v0mimir1"
 )
 
-const Type schema.IntegrationType = "wechat"
+const Type = schema.WeChatType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:        Type,

--- a/receivers/wecom/schema.go
+++ b/receivers/wecom/schema.go
@@ -5,7 +5,7 @@ import (
 	v1 "github.com/grafana/alerting/receivers/wecom/v1"
 )
 
-const Type schema.IntegrationType = "wecom"
+const Type = schema.WeComType
 
 var Schema = schema.InitSchema(schema.IntegrationTypeSchema{
 	Type:           Type,


### PR DESCRIPTION
It's simpler to reference them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that consolidates string literals into shared constants; main risk is accidental mismatch/rename of an integration type string causing schema lookups to fail.
> 
> **Overview**
> **Consolidates integration type identifiers** by introducing `receivers/schema/known_types.go` with a single set of `IntegrationType` constants for all known receiver types.
> 
> Updates each receiver `schema.go` to reference these shared constants (e.g., `schema.SlackType`) instead of defining local string-typed `Type` constants, reducing duplication and ensuring consistent type values across integrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9cc2077589626e18e0965645a8dbd1517bdb6b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->