### PR TITLE
Set To header to undisclosed-recipients when using BCC

### DIFF
--- a/receivers/email_sender.go
+++ b/receivers/email_sender.go
@@ -236,6 +236,7 @@ func (s *defaultEmailSender) buildEmail(msg *Message) *gomail.Message {
 	}
 	m.SetHeader("From", msg.From)
 	if s.cfg.UseBCC && !msg.SingleEmail {
+		m.SetHeader("To", "undisclosed-recipients:;")
 		m.SetHeader("Bcc", msg.To...)
 	} else {
 		m.SetHeader("To", msg.To...)

--- a/receivers/email_sender_test.go
+++ b/receivers/email_sender_test.go
@@ -152,7 +152,7 @@ func TestBuildEmail(t *testing.T) {
 			checkBodyContent: true,
 		},
 		{
-			name: "UseBCC=true, SingleEmail=false - recipients in Bcc",
+			name: "UseBCC=true, SingleEmail=false - recipients in Bcc, To set to undisclosed-recipients",
 			cfg: EmailSenderConfig{
 				UseBCC:       true,
 				ContentTypes: []string{"text/plain"},
@@ -164,7 +164,7 @@ func TestBuildEmail(t *testing.T) {
 				SingleEmail: false,
 				Body:        map[string]string{"text/plain": "This is a test message"},
 			},
-			expectedTo:  nil,
+			expectedTo:  []string{"undisclosed-recipients:;"},
 			expectedBcc: []string{"to1@to.com", "to2@to.com"},
 		},
 		{


### PR DESCRIPTION
When UseBCC is enabled, the To header was left empty, which looks odd to recipients and may cause some mail servers to flag the message as spam. Set it to `undisclosed-recipients:;` per [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small header change limited to the `UseBCC && !SingleEmail` path, with tests updated to lock in the new `To`/`Bcc` behavior.
> 
> **Overview**
> When `EmailSenderConfig.UseBCC` is enabled (and `SingleEmail` is false), outgoing emails now set the `To` header to `undisclosed-recipients:;` while placing actual recipients in `Bcc`, instead of leaving `To` empty.
> 
> Tests in `email_sender_test.go` were updated to expect the new `To` header value in this scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4da7d68235aae427117e24448e8955b275003cc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->