### PR TITLE
Make all v0 Notifiers implement SendResolved method

### DIFF
--- a/receivers/discord/v0mimir1/discord.go
+++ b/receivers/discord/v0mimir1/discord.go
@@ -86,6 +86,8 @@ type webhookEmbed struct {
 	Color       int    `json:"color"`
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)

--- a/receivers/email/v0mimir1/email.go
+++ b/receivers/email/v0mimir1/email.go
@@ -126,6 +126,8 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 	return nil, err
 }
 
+func (n *Email) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var (

--- a/receivers/jira/v0mimir1/jira.go
+++ b/receivers/jira/v0mimir1/jira.go
@@ -119,6 +119,8 @@ func New(c *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg.HT
 	}, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)

--- a/receivers/opsgenie/v0mimir1/opsgenie.go
+++ b/receivers/opsgenie/v0mimir1/opsgenie.go
@@ -93,6 +93,8 @@ type opsGenieUpdateDescriptionMessage struct {
 	Description string `json:"description,omitempty"`
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	requests, retry, err := n.createRequests(ctx, as...)

--- a/receivers/pagerduty/v0mimir1/pagerduty.go
+++ b/receivers/pagerduty/v0mimir1/pagerduty.go
@@ -303,6 +303,8 @@ func (n *Notifier) notifyV2(
 	return retry, err
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)

--- a/receivers/pushover/v0mimir1/pushover.go
+++ b/receivers/pushover/v0mimir1/pushover.go
@@ -67,6 +67,8 @@ func New(c *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg.HT
 	}, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, ok := notify.GroupKey(ctx)

--- a/receivers/slack/v0mimir1/slack.go
+++ b/receivers/slack/v0mimir1/slack.go
@@ -92,6 +92,8 @@ type attachment struct {
 	MrkdwnIn   []string      `json:"mrkdwn_in,omitempty"`
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var err error

--- a/receivers/sns/v0mimir1/sns.go
+++ b/receivers/sns/v0mimir1/sns.go
@@ -61,6 +61,8 @@ func New(c *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg.HT
 	}, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, error) {
 	var (
 		err  error

--- a/receivers/teams/v0mimir1/teams.go
+++ b/receivers/teams/v0mimir1/teams.go
@@ -75,6 +75,8 @@ func New(c *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg.HT
 	return n, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)
 	if err != nil {

--- a/receivers/teams/v0mimir2/teams.go
+++ b/receivers/teams/v0mimir2/teams.go
@@ -107,6 +107,8 @@ func New(c *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg.HT
 	return n, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)
 	if err != nil {

--- a/receivers/telegram/v0mimir1/telegram.go
+++ b/receivers/telegram/v0mimir1/telegram.go
@@ -64,6 +64,8 @@ func New(conf *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg
 	}, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, error) {
 	var (
 		err  error

--- a/receivers/victorops/v0mimir1/victorops.go
+++ b/receivers/victorops/v0mimir1/victorops.go
@@ -67,6 +67,8 @@ const (
 	victorOpsEventResolve = "RECOVERY"
 )
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	var err error

--- a/receivers/webex/v0mimir1/webex.go
+++ b/receivers/webex/v0mimir1/webex.go
@@ -66,6 +66,8 @@ type webhook struct {
 	RoomID   string `json:"roomId,omitempty"`
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)

--- a/receivers/webhook/v0mimir1/webhook.go
+++ b/receivers/webhook/v0mimir1/webhook.go
@@ -88,6 +88,8 @@ func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, ui
 	return alerts, 0
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
 	ctx, span := tracer.Start(ctx, "webhook.Notifier.Notify", trace.WithAttributes(

--- a/receivers/wechat/v0mimir1/wechat.go
+++ b/receivers/wechat/v0mimir1/wechat.go
@@ -80,6 +80,8 @@ func New(c *Config, t *template.Template, l log.Logger, httpOpts ...commoncfg.HT
 	return &Notifier{conf: c, tmpl: t, logger: l, client: client}, nil
 }
 
+func (n *Notifier) SendResolved() bool { return n.conf.SendResolved() }
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, err := notify.ExtractGroupKey(ctx)


### PR DESCRIPTION
The v1 integrations already do it and our construction logic relies on this. So, v0 get it so we can build it together with v1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple `SendResolved()` passthrough methods to existing v0 notifier types without changing notification delivery logic.
> 
> **Overview**
> Adds `SendResolved()` to all v0 receiver notifiers (Discord, Email, Jira, OpsGenie, PagerDuty, Pushover, Slack, SNS, Teams v1/v2, Telegram, VictorOps, Webex, Webhook, WeChat) so they consistently expose the resolved-notification setting via `conf.SendResolved()` and can be constructed/interrogated the same way as v1 integrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2150aabc78446bef6476a10904937558f07d92a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->