### PR TITLE
Normalize NewConfig signatures for email/v1 and teams/v1

### DIFF
--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -315,7 +315,7 @@ func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver 
 		}
 		result.DiscordConfigs = append(result.DiscordConfigs, notifierConfig)
 	case schema.EmailType:
-		cfg, err := email.NewConfig(receiver.Settings)
+		cfg, err := email.NewConfig(receiver.Settings, decryptFn)
 		if err != nil {
 			return err
 		}
@@ -445,7 +445,7 @@ func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver 
 		}
 		result.SNSConfigs = append(result.SNSConfigs, notifierConfig)
 	case schema.TeamsType:
-		cfg, err := teams.NewConfig(receiver.Settings)
+		cfg, err := teams.NewConfig(receiver.Settings, decryptFn)
 		if err != nil {
 			return err
 		}

--- a/receivers/email/v1/config.go
+++ b/receivers/email/v1/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/templates"
 )
@@ -19,7 +20,7 @@ type Config struct {
 	Subject     string
 }
 
-func NewConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage, _ receivers.DecryptFunc) (Config, error) {
 	type emailSettingsRaw struct {
 		SingleEmail bool   `json:"singleEmail,omitempty" yaml:"singleEmail,omitempty"`
 		Addresses   string `json:"addresses,omitempty" yaml:"addresses,omitempty"`

--- a/receivers/email/v1/config_test.go
+++ b/receivers/email/v1/config_test.go
@@ -86,7 +86,7 @@ func TestNewConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := NewConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings), nil)
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)

--- a/receivers/teams/v1/config.go
+++ b/receivers/teams/v1/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/templates"
 )
@@ -19,7 +20,7 @@ type Config struct {
 	SectionTitle string `json:"sectiontitle,omitempty" yaml:"sectiontitle,omitempty"`
 }
 
-func NewConfig(jsonData json.RawMessage) (Config, error) {
+func NewConfig(jsonData json.RawMessage, _ receivers.DecryptFunc) (Config, error) {
 	settings := Config{}
 	err := json.Unmarshal(jsonData, &settings)
 	if err != nil {

--- a/receivers/teams/v1/config_test.go
+++ b/receivers/teams/v1/config_test.go
@@ -65,7 +65,7 @@ func TestNewConfig(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := NewConfig(json.RawMessage(c.settings))
+			actual, err := NewConfig(json.RawMessage(c.settings), nil)
 
 			if c.expectedInitError != "" {
 				require.ErrorContains(t, err, c.expectedInitError)


### PR DESCRIPTION
Add unused DecryptFunc parameter to email.NewConfig and teams.NewConfig so all v1 integrations share a uniform NewConfig(json.RawMessage, DecryptFunc) signature, enabling a generic factory pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a signature normalization that threads the existing `DecryptFunc` through call sites but does not change decryption or runtime behavior for `email`/`teams` configs (parameter is unused). Main risk is limited to build breaks for any external/internal callers not updated.
> 
> **Overview**
> **Normalizes receiver factory signatures** by updating `email/v1` and `teams/v1` `NewConfig` to accept a (currently unused) `receivers.DecryptFunc`, matching other v1 integrations.
> 
> Updates `notify/receivers.go` to pass `decryptFn` for Email and Teams, and adjusts unit tests to supply `nil`, enabling a generic config-construction pattern without changing config parsing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83050fdef0055037a29d222b938ef0953b05c0e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->