### PR TITLE
Add integration version to log context

### DIFF
--- a/receivers/base.go
+++ b/receivers/base.go
@@ -27,7 +27,7 @@ func (n *Base) GetDisableResolveMessage() bool {
 
 func (n *Base) GetLogger(ctx context.Context) log.Logger {
 	gkey, _ := notify.GroupKey(ctx)
-	return log.With(n.logger, "receiver", n.Name, "integration", fmt.Sprintf("%s[%d]", n.Type, n.Index), "aggrGroup", gkey)
+	return log.With(n.logger, "receiver", n.Name, "integration", fmt.Sprintf("%s[%d]", n.Type, n.Index), "version", n.Version, "aggrGroup", gkey)
 }
 
 // Metadata contains the metadata of the notifier.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only enriches log fields in `Base.GetLogger` with no behavior changes beyond log output format.
> 
> **Overview**
> Receiver logging now includes the integration `version` field in the structured context returned by `Base.GetLogger`, improving log filtering/diagnostics for different integration revisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fd0461de8b3d799b731a1c218a97195e00ee899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->