### PR TITLE
Notify: Skip writing notification history when testing receivers.

### DIFF
--- a/notify/nfstatus/integration.go
+++ b/notify/nfstatus/integration.go
@@ -195,8 +195,19 @@ func (n *statusCaptureNotifier) Notify(ctx context.Context, alerts ...*types.Ale
 	return retry, err
 }
 
+type testNotificationKeyType struct{}
+
+// TestNotificationKey is a context key that, when set, causes the notification
+// historian to skip recording the entry. This is used by TestNotifier to avoid
+// writing incomplete history entries for test notifications.
+var TestNotificationKey = testNotificationKeyType{}
+
 func (n *statusCaptureNotifier) recordNotificationHistory(ctx context.Context, alerts []*types.Alert, retry bool, err error, duration time.Duration, info NotifyInfo) {
 	if n.notificationHistorian == nil {
+		return
+	}
+
+	if ctx.Value(TestNotificationKey) != nil {
 		return
 	}
 

--- a/notify/nfstatus/integration_test.go
+++ b/notify/nfstatus/integration_test.go
@@ -163,6 +163,24 @@ func TestIntegrationWithNotificationHistorian(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestIntegrationSkipsHistorianForTestNotification(t *testing.T) {
+	notifier := &fakeNotifier{}
+	notificationHistorian := &mockNotificationHistorian{}
+	integration := NewIntegration(notifier, &fakeResolvedSender{}, "foo", 42, "bar", notificationHistorian, log.NewNopLogger())
+
+	ctx := notify.WithReceiverName(context.Background(), "testReceiver")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"key": "value"})
+	ctx = notify.WithGroupKey(ctx, "testGroupKey")
+	ctx = context.WithValue(ctx, TestNotificationKey, true)
+
+	_, err := integration.Notify(ctx)
+	assert.NoError(t, err)
+
+	// Give the goroutine time to run (or not).
+	time.Sleep(100 * time.Millisecond)
+	notificationHistorian.AssertNotCalled(t, "Record", mock.Anything, mock.Anything)
+}
+
 func TestNotificationHistoryEntry_Validate(t *testing.T) {
 	now := time.Now()
 

--- a/notify/test_receivers.go
+++ b/notify/test_receivers.go
@@ -61,6 +61,7 @@ func TestIntegration(ctx context.Context,
 }
 
 func TestNotifier(ctx context.Context, notifier *nfstatus.Integration, testAlert types.Alert, now time.Time) error {
+	ctx = context.WithValue(ctx, nfstatus.TestNotificationKey, true)
 	ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", notifier.Name(), testAlert.Labels.Fingerprint(), now.Unix()))
 	ctx = notify.WithGroupLabels(ctx, testAlert.Labels)
 	ctx = notify.WithReceiverName(ctx, notifier.Name())


### PR DESCRIPTION
The historian is being invoked when manually testing receivers, which I don't
think is correct, as this would just pollute the log of real notifications.
If a use case arises, we could log the test notifications with a flag in the
future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is gated behind an explicit context flag and only affects notification-history recording during test sends, with a unit test covering the behavior.
> 
> **Overview**
> Prevents manual/test receiver notifications from polluting notification history by introducing a `TestNotificationKey` context flag and skipping `notificationHistorian.Record` when it’s set.
> 
> `TestNotifier` now sets this flag automatically, and a new integration test asserts that history is not recorded for test notifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b4f4a3ee61a517b35986dc2d826e3bb30f0f71e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->