### PR TITLE
fix(teams): fix typo in card body json

### DIFF
--- a/receivers/teams/v0mimir2/teams.go
+++ b/receivers/teams/v0mimir2/teams.go
@@ -65,7 +65,7 @@ type Content struct {
 type Body struct {
 	Type   string `json:"type"`
 	Text   string `json:"text"`
-	Weight string `json:"weigth,omitempty"`
+	Weight string `json:"weight,omitempty"`
 	Size   string `json:"size,omitempty"`
 	Wrap   bool   `json:"wrap,omitempty"`
 	Style  string `json:"style,omitempty"`

--- a/receivers/teams/v0mimir2/teams.go
+++ b/receivers/teams/v0mimir2/teams.go
@@ -62,7 +62,7 @@ type Content struct {
 type Body struct {
 	Type   string `json:"type"`
 	Text   string `json:"text"`
-	Weight string `json:"weigth,omitempty"`
+	Weight string `json:"weight,omitempty"`
 	Size   string `json:"size,omitempty"`
 	Wrap   bool   `json:"wrap,omitempty"`
 	Style  string `json:"style,omitempty"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-field JSON tag correction with no auth, data, or behavioral logic changes beyond correct Adaptive Card serialization.
> 
> **Overview**
> Corrects the Adaptive Card `Body` struct JSON tag from **`weigth`** to **`weight`** in the v0mimir2 Teams notifier so title TextBlocks (e.g. **`Weight: "Bolder"`**) serialize with the schema field Teams expects.
> 
> Without this fix, bold heading styling on alert titles in Teams v2 messages would not apply because the payload used a misspelled property name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d3d4ae916d64e4bee6bbbe7ea2a117397e4e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->