### PR TITLE
Fix race condition when calling ApplyConfig

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -883,16 +883,16 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 	am.receivers = receivers
 
 	am.wg.Add(1)
-	go func() {
+	go func(d *dispatch.Dispatcher) {
 		defer am.wg.Done()
-		am.dispatcher.Run()
-	}()
+		d.Run()
+	}(am.dispatcher)
 
 	am.wg.Add(1)
-	go func() {
+	go func(i *inhibit.Inhibitor) {
 		defer am.wg.Done()
-		am.inhibitor.Run()
-	}()
+		i.Run()
+	}(am.inhibitor)
 
 	am.config = &cfg
 	am.configHash = CalculateConfigFingerprint(cfg)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches alert delivery concurrency by changing how `dispatcher.Run()`/`inhibitor.Run()` goroutines are launched during config reloads. While small, mistakes here could lead to leaked goroutines or running/stopping the wrong instances under rapid reloads.
> 
> **Overview**
> Prevents a config-reload race in `ApplyConfig` by starting `dispatcher` and `inhibitor` goroutines with *captured instances* (passing pointers into the closure) instead of reading `am.dispatcher`/`am.inhibitor` inside the goroutine.
> 
> This ensures concurrent/rapid re-`ApplyConfig` calls can’t cause the newly spawned goroutines to run the *wrong* (later-replaced) component instances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b3e993ff25e4d6289076f8b4eb95ad4e02a0eb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->