### PR TITLE
Add Matrix receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Alerting
 
-- 
+- [FEATURE] Receivers: add Matrix receiver that posts alerts to a Matrix room via the Client-Server API.
 
 ## Scope Glossary
 

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -28,6 +28,7 @@ import (
 	jira "github.com/grafana/alerting/receivers/jira/v1"
 	kafka "github.com/grafana/alerting/receivers/kafka/v1"
 	line "github.com/grafana/alerting/receivers/line/v1"
+	matrix "github.com/grafana/alerting/receivers/matrix/v1"
 	mqtt "github.com/grafana/alerting/receivers/mqtt/v1"
 	oncall "github.com/grafana/alerting/receivers/oncall/v1"
 	opsgenie "github.com/grafana/alerting/receivers/opsgenie/v1"
@@ -138,6 +139,11 @@ func BuildGrafanaReceiverIntegrations(
 	for i, cfg := range receiver.LineConfigs {
 		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
 			return line.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
+		})
+	}
+	for i, cfg := range receiver.MatrixConfigs {
+		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
+			return matrix.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
 		})
 	}
 	for i, cfg := range receiver.MqttConfigs {

--- a/notify/notifytest/grafana_integrations.go
+++ b/notify/notifytest/grafana_integrations.go
@@ -23,6 +23,8 @@ import (
 	kafkav1 "github.com/grafana/alerting/receivers/kafka/v1"
 	"github.com/grafana/alerting/receivers/line"
 	linev1 "github.com/grafana/alerting/receivers/line/v1"
+	"github.com/grafana/alerting/receivers/matrix"
+	matrixv1 "github.com/grafana/alerting/receivers/matrix/v1"
 	"github.com/grafana/alerting/receivers/mqtt"
 	mqttv1 "github.com/grafana/alerting/receivers/mqtt/v1"
 	"github.com/grafana/alerting/receivers/oncall"
@@ -104,6 +106,12 @@ var AllKnownV1ConfigsForTesting = map[schema.IntegrationType]NotifierConfigTest{
 		Version:      schema.V1,
 		Config:       linev1.FullValidConfigForTesting,
 		Secrets:      linev1.FullValidSecretsForTesting,
+	},
+	matrix.Type: {
+		NotifierType: matrix.Type,
+		Version:      schema.V1,
+		Config:       matrixv1.FullValidConfigForTesting,
+		Secrets:      matrixv1.FullValidSecretsForTesting,
 	},
 	mqtt.Type: {
 		NotifierType:                mqtt.Type,

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -25,6 +25,7 @@ import (
 	jira "github.com/grafana/alerting/receivers/jira/v1"
 	kafka "github.com/grafana/alerting/receivers/kafka/v1"
 	line "github.com/grafana/alerting/receivers/line/v1"
+	matrix "github.com/grafana/alerting/receivers/matrix/v1"
 	mqtt "github.com/grafana/alerting/receivers/mqtt/v1"
 	oncall "github.com/grafana/alerting/receivers/oncall/v1"
 	opsgenie "github.com/grafana/alerting/receivers/opsgenie/v1"
@@ -171,6 +172,7 @@ type GrafanaReceiverConfig struct {
 	JiraConfigs         []*NotifierConfig[jira.Config]
 	KafkaConfigs        []*NotifierConfig[kafka.Config]
 	LineConfigs         []*NotifierConfig[line.Config]
+	MatrixConfigs       []*NotifierConfig[matrix.Config]
 	OpsgenieConfigs     []*NotifierConfig[opsgenie.Config]
 	MqttConfigs         []*NotifierConfig[mqtt.Config]
 	PagerdutyConfigs    []*NotifierConfig[pagerduty.Config]
@@ -364,6 +366,16 @@ func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver 
 			return err
 		}
 		result.LineConfigs = append(result.LineConfigs, notifierConfig)
+	case schema.MatrixType:
+		cfg, err := matrix.NewConfig(receiver.Settings, decryptFn)
+		if err != nil {
+			return err
+		}
+		notifierConfig, err := newNotifierConfig(receiver, idx, cfg, decryptFn)
+		if err != nil {
+			return err
+		}
+		result.MatrixConfigs = append(result.MatrixConfigs, notifierConfig)
 	case schema.MQTTType:
 		cfg, err := mqtt.NewConfig(receiver.Settings, decryptFn)
 		if err != nil {

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -510,6 +510,7 @@ func TestHTTPConfig(t *testing.T) {
 					"apiUrl":         testServer.URL, // OpsGenie
 					"client_url":     testServer.URL, // PagerDuty
 					"endpointUrl":    testServer.URL, // Slack, Wecom
+					"homeserverUrl":  testServer.URL, // Matrix
 				})
 				require.NoError(t, err)
 				newSettings, err := MergeSettings(config.Settings, urlOverride)

--- a/notify/schema.go
+++ b/notify/schema.go
@@ -19,6 +19,7 @@ import (
 	jiraV0 "github.com/grafana/alerting/receivers/jira/v0mimir1"
 	"github.com/grafana/alerting/receivers/kafka"
 	"github.com/grafana/alerting/receivers/line"
+	"github.com/grafana/alerting/receivers/matrix"
 	"github.com/grafana/alerting/receivers/mqtt"
 	"github.com/grafana/alerting/receivers/oncall"
 	"github.com/grafana/alerting/receivers/opsgenie"
@@ -71,6 +72,7 @@ func initSchemas() {
 		jira.Schema,
 		kafka.Schema,
 		line.Schema,
+		matrix.Schema,
 		mqtt.Schema,
 		oncall.Schema,
 		opsgenie.Schema,

--- a/notify/schema_test.go
+++ b/notify/schema_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/alerting/receivers/jira"
 	"github.com/grafana/alerting/receivers/kafka"
 	"github.com/grafana/alerting/receivers/line"
+	"github.com/grafana/alerting/receivers/matrix"
 	"github.com/grafana/alerting/receivers/mqtt"
 	"github.com/grafana/alerting/receivers/oncall"
 	"github.com/grafana/alerting/receivers/opsgenie"
@@ -81,6 +82,7 @@ func TestGetSecretKeysForContactPointType(t *testing.T) {
 		{receiverType: opsgenie.Type, version: schema.V1, expectedSecretFields: []string{"apiKey"}},
 		{receiverType: webex.Type, version: schema.V1, expectedSecretFields: []string{"bot_token"}},
 		{receiverType: sns.Type, version: schema.V1, expectedSecretFields: []string{"sigv4.access_key", "sigv4.secret_key"}},
+		{receiverType: matrix.Type, version: schema.V1, expectedSecretFields: []string{"accessToken"}},
 		{receiverType: mqtt.Type, version: schema.V1, expectedSecretFields: []string{"password", "tlsConfig.caCertificate", "tlsConfig.clientCertificate", "tlsConfig.clientKey"}},
 		{receiverType: jira.Type, version: schema.V1, expectedSecretFields: []string{"user", "password", "api_token"}},
 		{receiverType: victorops.Type, version: schema.V0mimir1, expectedSecretFields: append([]string{"api_key"}, httpConfigSecrets...)},

--- a/receivers/matrix/schema.go
+++ b/receivers/matrix/schema.go
@@ -1,0 +1,19 @@
+package matrix
+
+import (
+	v1 "github.com/grafana/alerting/receivers/matrix/v1"
+	"github.com/grafana/alerting/receivers/schema"
+)
+
+const Type = schema.MatrixType
+
+var Schema = schema.InitSchema(
+	schema.IntegrationTypeSchema{
+		Type:           Type,
+		Name:           "Matrix",
+		Description:    "Sends notifications to a Matrix room via the Client-Server API",
+		Heading:        "Matrix settings",
+		CurrentVersion: v1.Version,
+	},
+	v1.Schema,
+)

--- a/receivers/matrix/v1/config.go
+++ b/receivers/matrix/v1/config.go
@@ -1,0 +1,134 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/receivers/schema"
+	"github.com/grafana/alerting/templates"
+)
+
+const Version = schema.V1
+
+const (
+	MessageTypeText   = "m.text"
+	MessageTypeNotice = "m.notice"
+)
+
+type Config struct {
+	HomeserverURL string `json:"homeserverUrl,omitempty" yaml:"homeserverUrl,omitempty"`
+	AccessToken   string `json:"accessToken,omitempty" yaml:"accessToken,omitempty"`
+	RoomID        string `json:"roomId,omitempty" yaml:"roomId,omitempty"`
+	MessageType   string `json:"messageType,omitempty" yaml:"messageType,omitempty"`
+	Message       string `json:"message,omitempty" yaml:"message,omitempty"`
+	Title         string `json:"title,omitempty" yaml:"title,omitempty"`
+}
+
+func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
+	var settings Config
+	if err := json.Unmarshal(jsonData, &settings); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+
+	settings.HomeserverURL = strings.TrimRight(strings.TrimSpace(settings.HomeserverURL), "/")
+	if settings.HomeserverURL == "" {
+		return Config{}, errors.New("homeserver URL must be specified")
+	}
+	parsed, err := url.Parse(settings.HomeserverURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return Config{}, fmt.Errorf("invalid homeserver URL %q", settings.HomeserverURL)
+	}
+	settings.HomeserverURL = parsed.String()
+
+	settings.AccessToken = decryptFn.Get("accessToken", settings.AccessToken)
+	if settings.AccessToken == "" {
+		return Config{}, errors.New("access token must be specified")
+	}
+
+	settings.RoomID = strings.TrimSpace(settings.RoomID)
+	if settings.RoomID == "" {
+		return Config{}, errors.New("room ID must be specified")
+	}
+	if !strings.HasPrefix(settings.RoomID, "!") || !strings.Contains(settings.RoomID, ":") {
+		return Config{}, fmt.Errorf("room ID must be an internal room ID like \"!abc:example.com\", got %q", settings.RoomID)
+	}
+
+	switch settings.MessageType {
+	case "":
+		settings.MessageType = MessageTypeText
+	case MessageTypeText, MessageTypeNotice:
+	default:
+		return Config{}, fmt.Errorf("invalid message type %q, must be %q or %q", settings.MessageType, MessageTypeText, MessageTypeNotice)
+	}
+
+	if settings.Message == "" {
+		settings.Message = templates.DefaultMessageEmbed
+	}
+	if settings.Title == "" {
+		settings.Title = templates.DefaultMessageTitleEmbed
+	}
+	return settings, nil
+}
+
+var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
+	Version:   Version,
+	CanCreate: true,
+	Options: []schema.Field{
+		{
+			Label:        "Homeserver URL",
+			Element:      schema.ElementTypeInput,
+			InputType:    schema.InputTypeText,
+			Description:  "URL of the Matrix homeserver, e.g. https://matrix.example.com",
+			Placeholder:  "https://matrix.example.com",
+			PropertyName: "homeserverUrl",
+			Required:     true,
+		},
+		{
+			Label:        "Access token",
+			Element:      schema.ElementTypeInput,
+			InputType:    schema.InputTypeText,
+			Description:  "Access token of the bot account that will post to the room",
+			PropertyName: "accessToken",
+			Required:     true,
+			Secure:       true,
+		},
+		{
+			Label:        "Room ID",
+			Element:      schema.ElementTypeInput,
+			InputType:    schema.InputTypeText,
+			Description:  "Internal Matrix room ID. Must start with \"!\". Aliases like #room:server are not supported.",
+			Placeholder:  "!abcdef:example.com",
+			PropertyName: "roomId",
+			Required:     true,
+		},
+		{
+			Label:   "Message type",
+			Element: schema.ElementTypeSelect,
+			SelectOptions: []schema.SelectOption{
+				{Value: MessageTypeText, Label: "Text (m.text)"},
+				{Value: MessageTypeNotice, Label: "Notice (m.notice)"},
+			},
+			Description:  "Matrix event msgtype. m.notice marks the event as bot-generated so other bots will not reply to it.",
+			PropertyName: "messageType",
+		},
+		{
+			Label:        "Title",
+			Element:      schema.ElementTypeInput,
+			InputType:    schema.InputTypeText,
+			Description:  "Templated title of the Matrix message",
+			Placeholder:  templates.DefaultMessageTitleEmbed,
+			PropertyName: "title",
+		},
+		{
+			Label:        "Message",
+			Element:      schema.ElementTypeTextArea,
+			Description:  "Templated body of the Matrix message",
+			Placeholder:  templates.DefaultMessageEmbed,
+			PropertyName: "message",
+		},
+	},
+})

--- a/receivers/matrix/v1/config_test.go
+++ b/receivers/matrix/v1/config_test.go
@@ -1,0 +1,120 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	receiversTesting "github.com/grafana/alerting/receivers/testing"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestNewConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		settings          string
+		secrets           map[string][]byte
+		expectedConfig    Config
+		expectedInitError string
+	}{
+		{
+			name:              "Error if empty",
+			settings:          "",
+			expectedInitError: "failed to unmarshal settings",
+		},
+		{
+			name:              "Error if empty JSON object",
+			settings:          `{}`,
+			expectedInitError: "homeserver URL must be specified",
+		},
+		{
+			name:              "Error if homeserver URL is invalid",
+			settings:          `{"homeserverUrl": "not a url"}`,
+			expectedInitError: "invalid homeserver URL",
+		},
+		{
+			name:              "Error if access token is missing",
+			settings:          `{"homeserverUrl": "https://matrix.example.com", "roomId": "!abc:example.com"}`,
+			expectedInitError: "access token must be specified",
+		},
+		{
+			name:              "Error if room ID is missing",
+			settings:          `{"homeserverUrl": "https://matrix.example.com", "accessToken": "t"}`,
+			expectedInitError: "room ID must be specified",
+		},
+		{
+			name:              "Error if room ID is an alias",
+			settings:          `{"homeserverUrl": "https://matrix.example.com", "accessToken": "t", "roomId": "#public:example.com"}`,
+			expectedInitError: "room ID must be an internal room ID",
+		},
+		{
+			name:              "Error if message type is invalid",
+			settings:          `{"homeserverUrl": "https://matrix.example.com", "accessToken": "t", "roomId": "!abc:example.com", "messageType": "m.image"}`,
+			expectedInitError: "invalid message type",
+		},
+		{
+			name:     "Minimal valid configuration",
+			settings: `{"homeserverUrl": "https://matrix.example.com", "accessToken": "t", "roomId": "!abc:example.com"}`,
+			expectedConfig: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "t",
+				RoomID:        "!abc:example.com",
+				MessageType:   MessageTypeText,
+				Title:         templates.DefaultMessageTitleEmbed,
+				Message:       templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Access token from secrets takes precedence",
+			settings: `{"homeserverUrl": "https://matrix.example.com", "accessToken": "plaintext", "roomId": "!abc:example.com"}`,
+			secrets:  map[string][]byte{"accessToken": []byte("decrypted")},
+			expectedConfig: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "decrypted",
+				RoomID:        "!abc:example.com",
+				MessageType:   MessageTypeText,
+				Title:         templates.DefaultMessageTitleEmbed,
+				Message:       templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Trailing slash trimmed from homeserver URL",
+			settings: `{"homeserverUrl": "https://matrix.example.com/", "accessToken": "t", "roomId": "!abc:example.com"}`,
+			expectedConfig: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "t",
+				RoomID:        "!abc:example.com",
+				MessageType:   MessageTypeText,
+				Title:         templates.DefaultMessageTitleEmbed,
+				Message:       templates.DefaultMessageEmbed,
+			},
+		},
+		{
+			name:     "Extracts all fields",
+			settings: FullValidConfigForTesting,
+			expectedConfig: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "test-token",
+				RoomID:        "!abc:example.com",
+				MessageType:   MessageTypeText,
+				Title:         "test-title",
+				Message:       "test-message",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			decryptFn := receiversTesting.DecryptForTesting(c.secrets)
+			actual, err := NewConfig(json.RawMessage(c.settings), decryptFn)
+
+			if c.expectedInitError != "" {
+				require.ErrorContains(t, err, c.expectedInitError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.expectedConfig, actual)
+		})
+	}
+}

--- a/receivers/matrix/v1/matrix.go
+++ b/receivers/matrix/v1/matrix.go
@@ -1,0 +1,239 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/templates"
+)
+
+const (
+	matrixSendPathFormat = "/_matrix/client/v3/rooms/%s/send/m.room.message/%s"
+	matrixFormatHTML     = "org.matrix.custom.html"
+	// maxFormattedBodyBytes keeps the event under the default Matrix 64 KiB cap
+	// with headroom for the JSON envelope and the plaintext body.
+	maxFormattedBodyBytes = 48 * 1024
+)
+
+type matrixMessage struct {
+	MsgType       string `json:"msgtype"`
+	Body          string `json:"body"`
+	Format        string `json:"format,omitempty"`
+	FormattedBody string `json:"formatted_body,omitempty"`
+}
+
+type matrixError struct {
+	ErrCode string `json:"errcode"`
+	Error   string `json:"error"`
+}
+
+type Notifier struct {
+	*receivers.Base
+	ns       receivers.WebhookSender
+	tmpl     *templates.Template
+	settings Config
+}
+
+func New(cfg Config, meta receivers.Metadata, template *templates.Template, sender receivers.WebhookSender, logger log.Logger) *Notifier {
+	return &Notifier{
+		Base:     receivers.NewBase(meta, logger),
+		ns:       sender,
+		tmpl:     template,
+		settings: cfg,
+	}
+}
+
+func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	l := n.GetLogger(ctx)
+	var tmplErr error
+	tmpl, _ := templates.TmplText(ctx, n.tmpl, as, l, &tmplErr)
+
+	title := tmpl(n.settings.Title)
+	body := tmpl(n.settings.Message)
+	if tmplErr != nil {
+		level.Warn(l).Log("msg", "failed to template Matrix message", "err", tmplErr.Error())
+	}
+
+	msg := matrixMessage{
+		MsgType:       n.settings.MessageType,
+		Body:          joinTitleBody(title, body),
+		Format:        matrixFormatHTML,
+		FormattedBody: renderHTML(title, as),
+	}
+
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal Matrix message: %w", err)
+	}
+
+	cmd := &receivers.SendWebhookSettings{
+		URL:         n.buildSendURL(),
+		HTTPMethod:  "PUT",
+		ContentType: "application/json",
+		Body:        string(payload),
+		HTTPHeader: map[string]string{
+			"Authorization": "Bearer " + n.settings.AccessToken,
+		},
+		Validation: validateResponse,
+	}
+
+	if err := n.ns.SendWebhook(ctx, l, cmd); err != nil {
+		return false, fmt.Errorf("send notification to Matrix: %w", err)
+	}
+	return true, nil
+}
+
+func (n *Notifier) SendResolved() bool {
+	return !n.GetDisableResolveMessage()
+}
+
+func (n *Notifier) buildSendURL() string {
+	txnID := fmt.Sprintf("grafana-%d", time.Now().UnixNano())
+	return n.settings.HomeserverURL + fmt.Sprintf(matrixSendPathFormat, url.PathEscape(n.settings.RoomID), url.PathEscape(txnID))
+}
+
+func joinTitleBody(title, body string) string {
+	switch {
+	case title == "" && body == "":
+		return ""
+	case title == "":
+		return body
+	case body == "":
+		return title
+	default:
+		return title + "\n\n" + body
+	}
+}
+
+func renderHTML(title string, alerts []*types.Alert) string {
+	var b strings.Builder
+	if title != "" {
+		b.WriteString("<h4>")
+		b.WriteString(html.EscapeString(title))
+		b.WriteString("</h4>")
+	}
+
+	firing, resolved := splitByStatus(alerts)
+	if len(firing) > 0 {
+		b.WriteString("<p><strong>Firing</strong></p>")
+		writeAlertList(&b, firing)
+	}
+	if len(resolved) > 0 {
+		b.WriteString("<p><strong>Resolved</strong></p>")
+		writeAlertList(&b, resolved)
+	}
+
+	return truncateUTF8(b.String(), maxFormattedBodyBytes)
+}
+
+// truncateUTF8 returns s trimmed to at most max bytes without splitting a
+// multi-byte rune. If trimming is needed, the result ends with an ellipsis.
+func truncateUTF8(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	const marker = "…"
+	budget := max - len(marker)
+	if budget <= 0 {
+		return ""
+	}
+	end := 0
+	for end < len(s) {
+		_, size := utf8.DecodeRuneInString(s[end:])
+		if end+size > budget {
+			break
+		}
+		end += size
+	}
+	return s[:end] + marker
+}
+
+func splitByStatus(alerts []*types.Alert) (firing, resolved []*types.Alert) {
+	for _, a := range alerts {
+		if a.Status() == model.AlertResolved {
+			resolved = append(resolved, a)
+		} else {
+			firing = append(firing, a)
+		}
+	}
+	return firing, resolved
+}
+
+func writeAlertList(b *strings.Builder, alerts []*types.Alert) {
+	b.WriteString("<ul>")
+	for _, a := range alerts {
+		b.WriteString("<li>")
+		b.WriteString(html.EscapeString(a.Name()))
+
+		if summary, ok := a.Annotations["summary"]; ok && summary != "" {
+			b.WriteString(": ")
+			b.WriteString(html.EscapeString(string(summary)))
+		} else if desc, ok := a.Annotations["description"]; ok && desc != "" {
+			b.WriteString(": ")
+			b.WriteString(html.EscapeString(string(desc)))
+		}
+
+		if labels := formatLabels(a.Labels); labels != "" {
+			b.WriteString(" <code>")
+			b.WriteString(html.EscapeString(labels))
+			b.WriteString("</code>")
+		}
+
+		if a.GeneratorURL != "" {
+			b.WriteString(` [<a href="`)
+			b.WriteString(html.EscapeString(a.GeneratorURL))
+			b.WriteString(`">source</a>]`)
+		}
+		b.WriteString("</li>")
+	}
+	b.WriteString("</ul>")
+}
+
+func formatLabels(ls model.LabelSet) string {
+	keys := make([]string, 0, len(ls))
+	for k := range ls {
+		if k == model.AlertNameLabel {
+			continue
+		}
+		keys = append(keys, string(k))
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(string(ls[model.LabelName(k)]))
+	}
+	return b.String()
+}
+
+func validateResponse(body []byte, statusCode int) error {
+	if statusCode/100 == 2 {
+		return nil
+	}
+	var merr matrixError
+	if err := json.Unmarshal(body, &merr); err == nil && merr.ErrCode != "" {
+		return fmt.Errorf("matrix API responded with %d %s: %s", statusCode, merr.ErrCode, merr.Error)
+	}
+	return fmt.Errorf("unexpected status %d from matrix", statusCode)
+}

--- a/receivers/matrix/v1/matrix_test.go
+++ b/receivers/matrix/v1/matrix_test.go
@@ -1,0 +1,174 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/templates"
+)
+
+func TestNotify(t *testing.T) {
+	tmpl := templates.ForTests(t)
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	cases := []struct {
+		name           string
+		settings       Config
+		alerts         []*types.Alert
+		expectMsgType  string
+		expectBodyHas  []string
+		expectHTMLHas  []string
+		expectHTMLMiss []string
+	}{
+		{
+			name: "Firing alert, default template, labels are sorted",
+			settings: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "secret",
+				RoomID:        "!room:example.com",
+				MessageType:   MessageTypeText,
+				Title:         templates.DefaultMessageTitleEmbed,
+				Message:       templates.DefaultMessageEmbed,
+			},
+			alerts: []*types.Alert{{
+				Alert: model.Alert{
+					Labels:       model.LabelSet{"alertname": "CPUHigh", "zone": "eu", "instance": "host-1", "severity": "critical"},
+					Annotations:  model.LabelSet{"summary": "CPU is high"},
+					GeneratorURL: "http://grafana/alerting/view",
+				},
+			}},
+			expectMsgType: "m.text",
+			expectBodyHas: []string{"CPUHigh"},
+			expectHTMLHas: []string{"<h4>", "Firing", "CPUHigh", "CPU is high", "instance=host-1, severity=critical, zone=eu", `href="http://grafana/alerting/view"`},
+		},
+		{
+			name: "Resolved and firing, m.notice",
+			settings: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "secret",
+				RoomID:        "!room:example.com",
+				MessageType:   MessageTypeNotice,
+				Title:         "alerts",
+				Message:       "body text",
+			},
+			alerts: []*types.Alert{
+				{Alert: model.Alert{Labels: model.LabelSet{"alertname": "A"}}},
+				{Alert: model.Alert{Labels: model.LabelSet{"alertname": "B"}, EndsAt: time.Now().Add(-time.Minute)}},
+			},
+			expectMsgType: "m.notice",
+			expectBodyHas: []string{"alerts", "body text"},
+			expectHTMLHas: []string{"Firing", "A", "Resolved", "B"},
+		},
+		{
+			name: "Title only",
+			settings: Config{
+				HomeserverURL: "https://matrix.example.com",
+				AccessToken:   "secret",
+				RoomID:        "!room:example.com",
+				MessageType:   MessageTypeText,
+				Title:         "only title",
+				Message:       "",
+			},
+			alerts: []*types.Alert{{
+				Alert: model.Alert{Labels: model.LabelSet{"alertname": "X"}},
+			}},
+			expectMsgType:  "m.text",
+			expectBodyHas:  []string{"only title"},
+			expectHTMLHas:  []string{"<h4>only title</h4>"},
+			expectHTMLMiss: []string{"<a "},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sender := receivers.MockNotificationService()
+			n := New(c.settings, receivers.Metadata{}, tmpl, sender, log.NewNopLogger())
+
+			ctx := notify.WithGroupKey(context.Background(), "test")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+
+			ok, err := n.Notify(ctx, c.alerts...)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			sent := sender.Webhook
+			require.Equal(t, "PUT", sent.HTTPMethod)
+			require.Equal(t, "application/json", sent.ContentType)
+			require.Equal(t, "Bearer secret", sent.HTTPHeader["Authorization"])
+
+			require.True(t, strings.HasPrefix(sent.URL, "https://matrix.example.com/_matrix/client/v3/rooms/"))
+			require.Contains(t, sent.URL, url.PathEscape("!room:example.com"))
+			require.Contains(t, sent.URL, "/send/m.room.message/grafana-")
+
+			var msg matrixMessage
+			require.NoError(t, json.Unmarshal([]byte(sent.Body), &msg))
+			require.Equal(t, c.expectMsgType, msg.MsgType)
+			require.Equal(t, "org.matrix.custom.html", msg.Format)
+			for _, want := range c.expectBodyHas {
+				require.Contains(t, msg.Body, want)
+			}
+			for _, want := range c.expectHTMLHas {
+				require.Contains(t, msg.FormattedBody, want)
+			}
+			for _, miss := range c.expectHTMLMiss {
+				require.NotContains(t, msg.FormattedBody, miss)
+			}
+
+			require.NotNil(t, sent.Validation)
+		})
+	}
+}
+
+func TestValidateResponse(t *testing.T) {
+	require.NoError(t, validateResponse([]byte(`{}`), 200))
+	require.NoError(t, validateResponse([]byte(`{"event_id":"$abc"}`), 200))
+
+	err := validateResponse([]byte(`{"errcode":"M_FORBIDDEN","error":"you shall not pass"}`), 403)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "matrix API responded")
+	require.Contains(t, err.Error(), "M_FORBIDDEN")
+	require.Contains(t, err.Error(), "you shall not pass")
+
+	err = validateResponse([]byte(`not json`), 500)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "500")
+}
+
+func TestSendResolved(t *testing.T) {
+	n := &Notifier{Base: receivers.NewBase(receivers.Metadata{DisableResolveMessage: false}, log.NewNopLogger())}
+	require.True(t, n.SendResolved())
+	n = &Notifier{Base: receivers.NewBase(receivers.Metadata{DisableResolveMessage: true}, log.NewNopLogger())}
+	require.False(t, n.SendResolved())
+}
+
+func TestRenderHTMLTruncationIsUTF8Safe(t *testing.T) {
+	// Build a firing alert whose summary is long enough to force truncation
+	// AND contains multi-byte characters (CJK + emoji) so any byte-boundary
+	// split would produce invalid UTF-8.
+	longSummary := strings.Repeat("日本語テスト🚀 ", 4000)
+	alerts := []*types.Alert{{
+		Alert: model.Alert{
+			Labels:      model.LabelSet{"alertname": "wide"},
+			Annotations: model.LabelSet{"summary": model.LabelValue(longSummary)},
+		},
+	}}
+
+	out := renderHTML("title", alerts)
+
+	require.LessOrEqual(t, len(out), maxFormattedBodyBytes, "rendered HTML should be truncated within the byte budget")
+	require.True(t, utf8.ValidString(out), "truncated HTML must remain valid UTF-8")
+}

--- a/receivers/matrix/v1/testing.go
+++ b/receivers/matrix/v1/testing.go
@@ -1,0 +1,16 @@
+package v1
+
+// FullValidConfigForTesting is a string representation of a JSON object that contains all fields supported by the notifier Config. It can be used without secrets.
+const FullValidConfigForTesting = `{
+	"homeserverUrl": "https://matrix.example.com",
+	"accessToken": "test-token",
+	"roomId": "!abc:example.com",
+	"messageType": "m.text",
+	"title": "test-title",
+	"message": "test-message"
+}`
+
+// FullValidSecretsForTesting is a string representation of a JSON object that contains secret fields of the notifier Config.
+const FullValidSecretsForTesting = `{
+	"accessToken": "test-token"
+}`

--- a/receivers/schema/known_types.go
+++ b/receivers/schema/known_types.go
@@ -9,6 +9,7 @@ const (
 	JiraType         IntegrationType = "jira"
 	KafkaType        IntegrationType = "kafka"
 	LineType         IntegrationType = "LINE"
+	MatrixType       IntegrationType = "matrix"
 	MQTTType         IntegrationType = "mqtt"
 	OnCallType       IntegrationType = "oncall"
 	OpsGenieType     IntegrationType = "opsgenie"


### PR DESCRIPTION
## What

Adds a native Matrix receiver that posts alerts to a Matrix room via the Client-Server API with a pre-issued bot access token. The receiver sends an `m.room.message` event with both a plaintext `body` and an HTML `formatted_body`. The HTML splits alerts into firing and resolved sections and lists each alert with a sorted label summary and a source link, so clients that render HTML (Element, Cinny, FluffyChat) get a readable summary and clients that do not still get the plaintext.

## Why

grafana/grafana#19777 has been open since 2019 asking for native Matrix notifications. Two earlier attempts (grafana/grafana#10606 and #29931) were closed because they targeted the legacy alerting engine that has since been removed. Unified alerting has been taking new receivers in this library ever since (mqtt, oncall, jira), so that reason no longer applies.

Until this lands, every Matrix user running Grafana has to put a shim HTTP server in front of the webhook contact point to translate the payload. This PR removes that step.

## Scope

Kept deliberately narrow, matching how Slack, Telegram and Discord are wired.

Unencrypted rooms only. E2EE needs olm/megolm, device keys and cross-signing, which is essentially a full Matrix client. Alert rooms are bot rooms and usually have encryption off anyway. The limit is called out in the field description.

Internal room IDs only (`!abc:server`). No alias resolution, no extra round-trip to `/directory/room/{alias}`. Aliases get rejected at config time with a clear error.

Pre-issued access token. No login flow, no token refresh. Matches how Slack and Telegram handle credentials.

## Config fields

| Field | Required | Secret | Notes |
|---|---|---|---|
| `homeserverUrl` | yes | no  | e.g. `https://matrix.example.com` |
| `accessToken`   | yes | yes | Bot account access token |
| `roomId`        | yes | no  | Internal room ID, must start with `!` |
| `messageType`   | no  | no  | `m.text` (default) or `m.notice` |
| `title`         | no  | no  | Templated title, defaults to the shared Grafana title template |
| `message`       | no  | no  | Templated body, defaults to the shared Grafana message template |

## Testing

Table-driven `TestNotify` against `receivers.MockNotificationService` asserts the HTTP method, headers, URL shape (including path-escape of `!room:server`), and the rendered `msgtype`, `body`, `format`, `formatted_body` fields. Cases cover firing only, mixed firing and resolved with `m.notice`, title only, and a multi-label case that pins deterministic label ordering.

`TestNewConfig` covers missing homeserver, invalid URL, missing token, missing room, alias rejection (`#public:server`), invalid message type, trailing-slash trimming, secret decryption precedence, and a full round-trip against the shared fixture.

`TestValidateResponse` covers 2xx success, Matrix error JSON decoding (`M_FORBIDDEN`), and non-JSON error bodies.

The `notify` integration tests pick up Matrix automatically via `notifytest.AllKnownV1ConfigsForTesting`. `TestGetSecretKeysForContactPointType` gets a matrix-v1 case and the `homeserverUrl` URL override is added to `TestHTTPConfig`.

`make test` (race + netgo), `make mod-check`, and `make lint` all pass clean.

## Follow-up

A companion PR against grafana/grafana will bump the `grafana/alerting` vendor, register the channel in `pkg/services/ngalert/notifier/channels_config/available_channels.go`, and add `'matrix'` to the frontend `GrafanaNotifierType` union and the mock notifiers map. That goes out once this PR is merged and a release is tagged.

Related: grafana/grafana#19777

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new outbound notification integration that sends authenticated HTTP requests to Matrix homeservers, introducing new configuration/templating paths and external-call failure modes.
> 
> **Overview**
> Adds a new **Matrix** receiver that posts alerts to a Matrix room via the Client-Server API, sending `m.room.message` events with both plaintext `body` and HTML `formatted_body` (including firing/resolved sections and deterministic label rendering with size/UTF-8-safe truncation).
> 
> Wires the new integration through `notify` (`schema`, receiver parsing, factory creation) and the test harness (`notifytest`, schema/receiver tests) including secret-field registration (`accessToken`) and URL override support (`homeserverUrl`), and documents the feature in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6813534eff4194a4fc3765bf5e50e67e73b49341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->