### PR TITLE
Notify: manifest-centric integration factory with per-version validation and notifier construction

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -456,7 +456,12 @@ func BuildReceiverIntegrationsWithManifests(
 				return decryptFn(context.Background(), secureSettings, key, fallback), true
 			})
 
+			opts := opts
+			// v0 do not use sender. Instead, each v0 factory creates its own HTTP client internally,
+			// combining the shared httpClientOptions (passed as variadic args to New()) with the
+			// per-integration HTTP config embedded in the typed config struct.
 			if cfg.Version == schema.V1 {
+				// TODO refactor this down to config factory, and use the same approach as in V0
 				httpClientConfig, err := parseHTTPConfig(cfg, decrypt)
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse HTTP config for %q (UID: %q): %w", cfg.Name, cfg.UID, err)

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -328,6 +328,7 @@ func BuildReceiversIntegrations(
 	version string,
 	logger log.Logger,
 	notificationHistorian nfstatus.NotificationHistorian,
+	useManifestBuilder bool,
 ) (map[string][]*Integration, error) {
 	nameToReceiver := make(map[string]*APIReceiver, len(apiReceivers))
 	for _, receiver := range apiReceivers {
@@ -343,7 +344,13 @@ func BuildReceiversIntegrations(
 
 	integrationsMap := make(map[string][]*Integration, len(apiReceivers))
 	for name, apiReceiver := range nameToReceiver {
-		integrations, err := BuildReceiverIntegrations(tenantID, apiReceiver, templ, images, decryptFn, decodeFn, emailSender, httpClientOptions, notifierFunc, version, logger, notificationHistorian)
+		var integrations []*Integration
+		var err error
+		if useManifestBuilder {
+			integrations, err = BuildReceiverIntegrationsWithManifests(tenantID, apiReceiver, templ, images, decryptFn, decodeFn, emailSender, httpClientOptions, notifierFunc, version, logger, notificationHistorian)
+		} else {
+			integrations, err = BuildReceiverIntegrations(tenantID, apiReceiver, templ, images, decryptFn, decodeFn, emailSender, httpClientOptions, notifierFunc, version, logger, notificationHistorian)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to build receiver %s: %w", name, err)
 		}

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -483,7 +483,14 @@ func BuildReceiverIntegrationsWithManifests(
 				if err != nil {
 					return nil, fmt.Errorf("failed to create HTTP client for %q (UID: %q): %w", cfg.Name, cfg.UID, err)
 				}
-				opts.Sender = client
+				// Jira's getIssueTransitionByName uses GET, which Client.SendWebhook rejects (POST/PUT only).
+				// ForkedSender handles GET by bypassing Client.SendWebhook and making the request directly.
+				// TODO remove it once the GET is supported by the client
+				if cfg.Type == schema.JiraType {
+					opts.Sender = http.NewForkedSender(client)
+				} else {
+					opts.Sender = client
+				}
 			}
 
 			factory, ok := GetFactoryForIntegrationVersion(cfg.Type, cfg.Version)

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -422,12 +422,7 @@ func BuildReceiverIntegrationsWithManifests(
 ) ([]*Integration, error) {
 	var integrations []*Integration
 	if len(receiver.Integrations) > 0 {
-		tmpl, err := tmpls.GetTemplate(templates.GrafanaKind)
-		if err != nil {
-			return nil, err
-		}
 		opts := receivers.NotifierOpts{
-			Template:       tmpl,
 			Images:         images,
 			Logger:         logger,
 			EmailSender:    emailSender,
@@ -435,9 +430,24 @@ func BuildReceiverIntegrationsWithManifests(
 			GrafanaVersion: version,
 			HttpOpts:       http.ToHTTPClientOption(httpClientOptions...),
 		}
-		for i, cfg := range receiver.Integrations {
+		// Track per-type indices so that integrations of the same type get consecutive indices (0, 1, 2…).
+		// This matches BuildGrafanaReceiverIntegrations behavior and preserves notification log management (see createReceiverStage).
+		typeCounters := make(map[schema.IntegrationType]int)
+		for _, cfg := range receiver.Integrations {
+			idx := typeCounters[cfg.Type]
+			typeCounters[cfg.Type]++
+
+			kind := templates.GrafanaKind
+			if cfg.Version != schema.V1 {
+				kind = templates.MimirKind
+			}
+			tmpl, err := tmpls.GetTemplate(kind)
+			if err != nil {
+				return nil, err
+			}
+
 			meta := receivers.Metadata{
-				Index:                 i,
+				Index:                 idx,
 				UID:                   cfg.UID,
 				Name:                  cfg.Name,
 				Type:                  cfg.Type,
@@ -457,6 +467,7 @@ func BuildReceiverIntegrationsWithManifests(
 			})
 
 			opts := opts
+			opts.Template = tmpl
 			// v0 do not use sender. Instead, each v0 factory creates its own HTTP client internally,
 			// combining the shared httpClientOptions (passed as variadic args to New()) with the
 			// per-integration HTTP config embedded in the typed config struct.
@@ -481,9 +492,8 @@ func BuildReceiverIntegrationsWithManifests(
 			if err != nil {
 				return nil, fmt.Errorf("failed to build notifier for %q (UID: %q): %w", cfg.Name, cfg.UID, err)
 			}
-			rs, _ := n.(notify.ResolvedSender)
 			wrapped := wrapNotifierFunc(cfg.Name, nfstatus.NewNotifierAdapter(n))
-			integrations = append(integrations, NewIntegration(wrapped, rs, string(cfg.Type), i, cfg.Name, notificationHistorian, logger))
+			integrations = append(integrations, NewIntegration(wrapped, n, string(cfg.Type), idx, cfg.Name, notificationHistorian, logger))
 		}
 	}
 	mimir, err := BuildPrometheusReceiverIntegrations(receiver.ConfigReceiver, tmpls, httpClientOptions, logger, wrapNotifierFunc, notificationHistorian)

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -406,6 +406,8 @@ func BuildReceiverIntegrations(
 // BuildReceiverIntegrationsWithManifests builds integrations for the provided API receiver using
 // the manifest-based factory for v1 (Grafana) integrations instead of the typed config switch.
 // Prometheus integrations are still built via BuildPrometheusReceiverIntegrations.
+// Unlike BuildGrafanaReceiverIntegrations, this function is fail-fast: it returns on the first
+// error without returning partial results.
 func BuildReceiverIntegrationsWithManifests(
 	tenantID int64,
 	receiver *APIReceiver,

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -33,6 +33,7 @@ import (
 	opsgenie "github.com/grafana/alerting/receivers/opsgenie/v1"
 	pagerduty "github.com/grafana/alerting/receivers/pagerduty/v1"
 	pushover "github.com/grafana/alerting/receivers/pushover/v1"
+	"github.com/grafana/alerting/receivers/schema"
 	sensugo "github.com/grafana/alerting/receivers/sensugo/v1"
 	slack "github.com/grafana/alerting/receivers/slack/v1"
 	sns "github.com/grafana/alerting/receivers/sns/v1"
@@ -399,5 +400,91 @@ func BuildReceiverIntegrations(
 	}
 	integrations = append(integrations, mimir...)
 
+	return integrations, nil
+}
+
+// BuildReceiverIntegrationsWithManifests builds integrations for the provided API receiver using
+// the manifest-based factory for v1 (Grafana) integrations instead of the typed config switch.
+// Prometheus integrations are still built via BuildPrometheusReceiverIntegrations.
+func BuildReceiverIntegrationsWithManifests(
+	tenantID int64,
+	receiver *APIReceiver,
+	tmpls TemplatesProvider,
+	images images.Provider,
+	decryptFn GetDecryptedValueFn,
+	decodeFn DecodeSecretsFn,
+	emailSender receivers.EmailSender,
+	httpClientOptions []http.ClientOption,
+	wrapNotifierFunc WrapNotifierFunc,
+	version string,
+	logger log.Logger,
+	notificationHistorian nfstatus.NotificationHistorian,
+) ([]*Integration, error) {
+	var integrations []*Integration
+	if len(receiver.Integrations) > 0 {
+		tmpl, err := tmpls.GetTemplate(templates.GrafanaKind)
+		if err != nil {
+			return nil, err
+		}
+		opts := receivers.NotifierOpts{
+			Template:       tmpl,
+			Images:         images,
+			Logger:         logger,
+			EmailSender:    emailSender,
+			OrgID:          tenantID,
+			GrafanaVersion: version,
+			HttpOpts:       http.ToHTTPClientOption(httpClientOptions...),
+		}
+		for i, cfg := range receiver.Integrations {
+			meta := receivers.Metadata{
+				Index:                 i,
+				UID:                   cfg.UID,
+				Name:                  cfg.Name,
+				Type:                  cfg.Type,
+				Version:               cfg.Version,
+				DisableResolveMessage: cfg.DisableResolveMessage,
+			}
+
+			secureSettings, err := decodeFn(cfg.SecureSettings)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode secure settings for %q (UID: %q): %w", cfg.Name, cfg.UID, err)
+			}
+			decrypt := receivers.DecryptFunc(func(key string, fallback string) (string, bool) {
+				if _, ok := secureSettings[key]; !ok {
+					return fallback, false
+				}
+				return decryptFn(context.Background(), secureSettings, key, fallback), true
+			})
+
+			if cfg.Version == schema.V1 {
+				httpClientConfig, err := parseHTTPConfig(cfg, decrypt)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse HTTP config for %q (UID: %q): %w", cfg.Name, cfg.UID, err)
+				}
+				client, err := http.NewClient(httpClientConfig, httpClientOptions...)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create HTTP client for %q (UID: %q): %w", cfg.Name, cfg.UID, err)
+				}
+				opts.Sender = client
+			}
+
+			factory, ok := GetFactoryForIntegrationVersion(cfg.Type, cfg.Version)
+			if !ok {
+				return nil, fmt.Errorf("invalid integration type or version: %s %s", cfg.Type, cfg.Version)
+			}
+			n, err := factory.NewNotifier(cfg.Settings, decrypt, meta, opts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build notifier for %q (UID: %q): %w", cfg.Name, cfg.UID, err)
+			}
+			rs, _ := n.(notify.ResolvedSender)
+			wrapped := wrapNotifierFunc(cfg.Name, nfstatus.NewNotifierAdapter(n))
+			integrations = append(integrations, NewIntegration(wrapped, rs, string(cfg.Type), i, cfg.Name, notificationHistorian, logger))
+		}
+	}
+	mimir, err := BuildPrometheusReceiverIntegrations(receiver.ConfigReceiver, tmpls, httpClientOptions, logger, wrapNotifierFunc, notificationHistorian)
+	if err != nil {
+		return nil, err
+	}
+	integrations = append(integrations, mimir...)
 	return integrations, nil
 }

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -23,6 +24,7 @@ import (
 	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/grafana/alerting/receivers"
+	"github.com/grafana/alerting/receivers/schema"
 	webhook_v0mimir1 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
 	"github.com/grafana/alerting/templates"
 )
@@ -230,6 +232,77 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 		integrations := actual["test"]
 		require.Len(t, integrations, 1)
 		require.Equal(t, "webhook[0]", integrations[0].String())
+	})
+}
+
+func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
+	var orgID = rand.Int63()
+	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
+	imageProvider := &images.URLProvider{}
+	cfg, err := templates.NewConfig("grafana", "http://localhost", "", templates.DefaultLimits)
+	require.NoError(t, err)
+	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
+	require.NoError(t, err)
+	emailService := receivers.MockNotificationService()
+
+	noopWrapper := func(_ string, n nfstatus.Notifier) nfstatus.Notifier { return n }
+
+	build := func(t *testing.T, receiver *APIReceiver, wrapper WrapNotifierFunc) ([]*Integration, error) {
+		t.Helper()
+		return BuildReceiverIntegrationsWithManifests(
+			orgID, receiver, tmpl, imageProvider,
+			GetDecryptedValueFnForTesting, DecodeSecretsFromBase64,
+			emailService, nil, wrapper, version, log.NewNopLogger(), nil,
+		)
+	}
+
+	t.Run("should build all known integrations across all versions", func(t *testing.T) {
+		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		for _, c := range notifytest.AllKnownConfigsForTesting {
+			recCfg.Integrations = append(recCfg.Integrations, c.GetRawNotifierConfig(""))
+		}
+
+		wrapped := 0
+		integrations, err := build(t, recCfg, func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
+			wrapped++
+			return n
+		})
+		require.NoError(t, err)
+		require.Len(t, integrations, len(notifytest.AllKnownConfigsForTesting))
+		require.Equal(t, len(notifytest.AllKnownConfigsForTesting), wrapped, "wrap function should be called once per integration")
+	})
+
+	t.Run("should return error for unknown integration type", func(t *testing.T) {
+		recCfg := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{
+				Integrations: []*models.IntegrationConfig{
+					{UID: "uid", Name: "test", Type: "unknown-type", Version: schema.V1, Settings: json.RawMessage(`{}`)},
+				},
+			},
+		}
+		_, err := build(t, recCfg, noopWrapper)
+		require.ErrorContains(t, err, "invalid integration type or version")
+	})
+
+	t.Run("should return error for unknown version", func(t *testing.T) {
+		recCfg := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{
+				Integrations: []*models.IntegrationConfig{
+					{UID: "uid", Name: "test", Type: schema.WebhookType, Version: "v99", Settings: json.RawMessage(`{}`)},
+				},
+			},
+		}
+		_, err := build(t, recCfg, noopWrapper)
+		require.ErrorContains(t, err, "invalid integration type or version")
+	})
+
+	t.Run("should not produce any integrations when receiver has no Grafana integrations", func(t *testing.T) {
+		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		integrations, err := build(t, recCfg, noopWrapper)
+		require.NoError(t, err)
+		require.Empty(t, integrations)
 	})
 }
 

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -304,6 +304,27 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, integrations)
 	})
+
+	t.Run("should use per-type index for integrations of the same type", func(t *testing.T) {
+		webhookCfg := notifytest.AllKnownV1ConfigsForTesting[schema.WebhookType]
+		emailCfg := notifytest.AllKnownV1ConfigsForTesting[schema.EmailType]
+		recCfg := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{
+				Integrations: []*models.IntegrationConfig{
+					webhookCfg.GetRawNotifierConfig("webhook-0"),
+					emailCfg.GetRawNotifierConfig("email-0"),
+					webhookCfg.GetRawNotifierConfig("webhook-1"),
+				},
+			},
+		}
+		integrations, err := build(t, recCfg, noopWrapper)
+		require.NoError(t, err)
+		require.Len(t, integrations, 3)
+		require.Equal(t, "webhook[0]", integrations[0].String())
+		require.Equal(t, "email[0]", integrations[1].String())
+		require.Equal(t, "webhook[1]", integrations[2].String())
+	})
 }
 
 func TestBuildPrometheusReceiverIntegrations(t *testing.T) {

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -179,12 +179,38 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			version,
 			log.NewNopLogger(),
 			nil,
+			true,
 		)
 		require.NoError(t, err)
 		require.Contains(t, actual, "test1")
 		require.Equal(t, "webhook[0]", actual["test1"][0].String())
 		require.Contains(t, actual, "test2")
 		require.Equal(t, "email[0]", actual["test2"][0].String())
+
+		t.Run("legacy way", func(t *testing.T) {
+			actual, err := BuildReceiversIntegrations(
+				orgID,
+				apiReceivers,
+				tmpl,
+				imageProvider,
+				NoopDecrypt,
+				DecodeSecretsFromBase64,
+				emailService,
+				nil,
+				func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
+					return n
+				},
+				version,
+				log.NewNopLogger(),
+				nil,
+				false,
+			)
+			require.NoError(t, err)
+			require.Contains(t, actual, "test1")
+			require.Equal(t, "webhook[0]", actual["test1"][0].String())
+			require.Contains(t, actual, "test2")
+			require.Equal(t, "email[0]", actual["test2"][0].String())
+		})
 	})
 
 	t.Run("should ignore duplicates", func(t *testing.T) {
@@ -226,6 +252,7 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			version,
 			log.NewNopLogger(),
 			nil,
+			true,
 		)
 		require.NoError(t, err)
 		require.Contains(t, actual, "test")

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/grafana/alerting/utils/hash"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/dispatch"
@@ -34,6 +33,8 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/alerting/utils/hash"
 
 	"github.com/grafana/alerting/cluster"
 	"github.com/grafana/alerting/definition"
@@ -250,6 +251,8 @@ type GrafanaAlertmanagerOpts struct {
 	NotificationHistorian nfstatus.NotificationHistorian
 
 	DispatchTimer DispatchTimer
+
+	BuildWithManifestBuilder bool
 }
 
 func (c *GrafanaAlertmanagerOpts) Validate() error {
@@ -831,6 +834,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 		am.opts.Version,
 		am.logger,
 		am.opts.NotificationHistorian,
+		am.opts.BuildWithManifestBuilder,
 	)
 	if err != nil {
 		return err
@@ -1073,6 +1077,22 @@ func (am *GrafanaAlertmanager) tenantString() string {
 }
 
 func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver *APIReceiver, tmpls TemplatesProvider) ([]*Integration, error) {
+	if am.opts.BuildWithManifestBuilder {
+		return BuildReceiverIntegrationsWithManifests(
+			am.opts.TenantID,
+			receiver,
+			tmpls,
+			am.opts.ImageProvider,
+			am.opts.Decrypter,
+			DecodeSecretsFromBase64,
+			am.opts.EmailSender,
+			nil,
+			NoWrap,
+			am.opts.Version,
+			am.logger,
+			am.opts.NotificationHistorian,
+		)
+	}
 	return BuildReceiverIntegrations(
 		am.opts.TenantID,
 		receiver,

--- a/notify/historian/lokiclient/client.go
+++ b/notify/historian/lokiclient/client.go
@@ -193,11 +193,7 @@ func (c *HTTPLokiClient) Push(ctx context.Context, s []Stream) error {
 	}()
 
 	_, err = c.handleLokiResponse(c.logger, resp)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (c *HTTPLokiClient) setAuthAndTenantHeaders(req *http.Request) {

--- a/notify/notifytest/grafana_integrations.go
+++ b/notify/notifytest/grafana_integrations.go
@@ -12,12 +12,15 @@ import (
 	"github.com/grafana/alerting/receivers/dingding"
 	dingdingv1 "github.com/grafana/alerting/receivers/dingding/v1"
 	"github.com/grafana/alerting/receivers/discord"
+	discordv0mimir1 "github.com/grafana/alerting/receivers/discord/v0mimir1"
 	discordv1 "github.com/grafana/alerting/receivers/discord/v1"
 	"github.com/grafana/alerting/receivers/email"
+	emailv0mimir1 "github.com/grafana/alerting/receivers/email/v0mimir1"
 	emailv1 "github.com/grafana/alerting/receivers/email/v1"
 	"github.com/grafana/alerting/receivers/googlechat"
 	googlechatv1 "github.com/grafana/alerting/receivers/googlechat/v1"
 	"github.com/grafana/alerting/receivers/jira"
+	jirav0mimir1 "github.com/grafana/alerting/receivers/jira/v0mimir1"
 	jirav1 "github.com/grafana/alerting/receivers/jira/v1"
 	"github.com/grafana/alerting/receivers/kafka"
 	kafkav1 "github.com/grafana/alerting/receivers/kafka/v1"
@@ -28,30 +31,43 @@ import (
 	"github.com/grafana/alerting/receivers/oncall"
 	oncallv1 "github.com/grafana/alerting/receivers/oncall/v1"
 	"github.com/grafana/alerting/receivers/opsgenie"
+	opsgeniev0mimir1 "github.com/grafana/alerting/receivers/opsgenie/v0mimir1"
 	opsgeniev1 "github.com/grafana/alerting/receivers/opsgenie/v1"
 	"github.com/grafana/alerting/receivers/pagerduty"
+	pagerdutyv0mimir1 "github.com/grafana/alerting/receivers/pagerduty/v0mimir1"
 	pagerdutyv1 "github.com/grafana/alerting/receivers/pagerduty/v1"
 	"github.com/grafana/alerting/receivers/pushover"
+	pushoverv0mimir1 "github.com/grafana/alerting/receivers/pushover/v0mimir1"
 	pushoverv1 "github.com/grafana/alerting/receivers/pushover/v1"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/sensugo"
 	sensugov1 "github.com/grafana/alerting/receivers/sensugo/v1"
 	"github.com/grafana/alerting/receivers/slack"
+	slackv0mimir1 "github.com/grafana/alerting/receivers/slack/v0mimir1"
 	slackv1 "github.com/grafana/alerting/receivers/slack/v1"
 	"github.com/grafana/alerting/receivers/sns"
+	snsv0mimir1 "github.com/grafana/alerting/receivers/sns/v0mimir1"
 	snsv1 "github.com/grafana/alerting/receivers/sns/v1"
 	"github.com/grafana/alerting/receivers/teams"
+	teamsv0mimir1 "github.com/grafana/alerting/receivers/teams/v0mimir1"
+	teamsv0mimir2 "github.com/grafana/alerting/receivers/teams/v0mimir2"
 	teamsv1 "github.com/grafana/alerting/receivers/teams/v1"
 	"github.com/grafana/alerting/receivers/telegram"
+	telegramv0mimir1 "github.com/grafana/alerting/receivers/telegram/v0mimir1"
 	telegramv1 "github.com/grafana/alerting/receivers/telegram/v1"
 	"github.com/grafana/alerting/receivers/threema"
 	threemav1 "github.com/grafana/alerting/receivers/threema/v1"
 	"github.com/grafana/alerting/receivers/victorops"
+	victoropsv0mimir1 "github.com/grafana/alerting/receivers/victorops/v0mimir1"
 	victoropsv1 "github.com/grafana/alerting/receivers/victorops/v1"
 	"github.com/grafana/alerting/receivers/webex"
+	webexv0mimir1 "github.com/grafana/alerting/receivers/webex/v0mimir1"
 	webexv1 "github.com/grafana/alerting/receivers/webex/v1"
 	"github.com/grafana/alerting/receivers/webhook"
+	webhookv0mimir1 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
 	webhookv1 "github.com/grafana/alerting/receivers/webhook/v1"
+	"github.com/grafana/alerting/receivers/wechat"
+	wechatv0mimir1 "github.com/grafana/alerting/receivers/wechat/v0mimir1"
 	"github.com/grafana/alerting/receivers/wecom"
 	wecomv1 "github.com/grafana/alerting/receivers/wecom/v1"
 )
@@ -240,6 +256,250 @@ type NotifierConfigTest struct {
 	Config                      string
 	Secrets                     string
 	CommonHTTPConfigUnsupported bool
+}
+
+// IntegrationVersionKey is a composite key combining integration type and version,
+// used to uniquely identify a specific versioned integration configuration.
+type IntegrationVersionKey struct {
+	Type    schema.IntegrationType
+	Version schema.Version
+}
+
+// AllKnownConfigsForTesting contains valid test configurations for all known integrations
+// across all versions (V1, V0mimir1, V0mimir2), keyed by (IntegrationType, Version).
+var AllKnownConfigsForTesting = map[IntegrationVersionKey]NotifierConfigTest{
+	// V1
+	{alertmanager.Type, schema.V1}: {
+		NotifierType:                alertmanager.Type,
+		Version:                     schema.V1,
+		Config:                      alertmanagerv1.FullValidConfigForTesting,
+		Secrets:                     alertmanagerv1.FullValidSecretsForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{dingding.Type, schema.V1}: {
+		NotifierType: dingding.Type,
+		Version:      schema.V1,
+		Config:       dingdingv1.FullValidConfigForTesting,
+		Secrets:      dingdingv1.FullValidSecretsForTesting,
+	},
+	{discord.Type, schema.V1}: {
+		NotifierType: discord.Type,
+		Version:      schema.V1,
+		Config:       discordv1.FullValidConfigForTesting,
+	},
+	{email.Type, schema.V1}: {
+		NotifierType:                email.Type,
+		Version:                     schema.V1,
+		Config:                      emailv1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{googlechat.Type, schema.V1}: {
+		NotifierType: googlechat.Type,
+		Version:      schema.V1,
+		Config:       googlechatv1.FullValidConfigForTesting,
+		Secrets:      googlechatv1.FullValidSecretsForTesting,
+	},
+	{jira.Type, schema.V1}: {
+		NotifierType: jira.Type,
+		Version:      schema.V1,
+		Config:       jirav1.FullValidConfigForTesting,
+		Secrets:      jirav1.FullValidSecretsForTesting,
+	},
+	{kafka.Type, schema.V1}: {
+		NotifierType: kafka.Type,
+		Version:      schema.V1,
+		Config:       kafkav1.FullValidConfigForTesting,
+		Secrets:      kafkav1.FullValidSecretsForTesting,
+	},
+	{line.Type, schema.V1}: {
+		NotifierType: line.Type,
+		Version:      schema.V1,
+		Config:       linev1.FullValidConfigForTesting,
+		Secrets:      linev1.FullValidSecretsForTesting,
+	},
+	{mqtt.Type, schema.V1}: {
+		NotifierType:                mqtt.Type,
+		Version:                     schema.V1,
+		Config:                      mqttv1.FullValidConfigForTesting,
+		Secrets:                     mqttv1.FullValidSecretsForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{oncall.Type, schema.V1}: {
+		NotifierType: oncall.Type,
+		Version:      schema.V1,
+		Config:       oncallv1.FullValidConfigForTesting,
+		Secrets:      oncallv1.FullValidSecretsForTesting,
+	},
+	{opsgenie.Type, schema.V1}: {
+		NotifierType: opsgenie.Type,
+		Version:      schema.V1,
+		Config:       opsgeniev1.FullValidConfigForTesting,
+		Secrets:      opsgeniev1.FullValidSecretsForTesting,
+	},
+	{pagerduty.Type, schema.V1}: {
+		NotifierType: pagerduty.Type,
+		Version:      schema.V1,
+		Config:       pagerdutyv1.FullValidConfigForTesting,
+		Secrets:      pagerdutyv1.FullValidSecretsForTesting,
+	},
+	{pushover.Type, schema.V1}: {
+		NotifierType: pushover.Type,
+		Version:      schema.V1,
+		Config:       pushoverv1.FullValidConfigForTesting,
+		Secrets:      pushoverv1.FullValidSecretsForTesting,
+	},
+	{sensugo.Type, schema.V1}: {
+		NotifierType: sensugo.Type,
+		Version:      schema.V1,
+		Config:       sensugov1.FullValidConfigForTesting,
+		Secrets:      sensugov1.FullValidSecretsForTesting,
+	},
+	{slack.Type, schema.V1}: {
+		NotifierType:                slack.Type,
+		Version:                     schema.V1,
+		Config:                      slackv1.FullValidConfigForTesting,
+		Secrets:                     slackv1.FullValidSecretsForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{sns.Type, schema.V1}: {
+		NotifierType:                sns.Type,
+		Version:                     schema.V1,
+		Config:                      snsv1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{teams.Type, schema.V1}: {
+		NotifierType: teams.Type,
+		Version:      schema.V1,
+		Config:       teamsv1.FullValidConfigForTesting,
+	},
+	{telegram.Type, schema.V1}: {
+		NotifierType: telegram.Type,
+		Version:      schema.V1,
+		Config:       telegramv1.FullValidConfigForTesting,
+		Secrets:      telegramv1.FullValidSecretsForTesting,
+	},
+	{threema.Type, schema.V1}: {
+		NotifierType: threema.Type,
+		Version:      schema.V1,
+		Config:       threemav1.FullValidConfigForTesting,
+		Secrets:      threemav1.FullValidSecretsForTesting,
+	},
+	{victorops.Type, schema.V1}: {
+		NotifierType: victorops.Type,
+		Version:      schema.V1,
+		Config:       victoropsv1.FullValidConfigForTesting,
+		Secrets:      victoropsv1.FullValidSecretsForTesting,
+	},
+	{webhook.Type, schema.V1}: {
+		NotifierType: webhook.Type,
+		Version:      schema.V1,
+		Config:       webhookv1.FullValidConfigForTesting,
+		Secrets:      webhookv1.FullValidSecretsForTesting,
+	},
+	{wecom.Type, schema.V1}: {
+		NotifierType: wecom.Type,
+		Version:      schema.V1,
+		Config:       wecomv1.FullValidConfigForTesting,
+		Secrets:      wecomv1.FullValidSecretsForTesting,
+	},
+	{webex.Type, schema.V1}: {
+		NotifierType: webex.Type,
+		Version:      schema.V1,
+		Config:       webexv1.FullValidConfigForTesting,
+		Secrets:      webexv1.FullValidSecretsForTesting,
+	},
+	// V0mimir1
+	{discord.Type, schema.V0mimir1}: {
+		NotifierType:                discord.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      discordv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{email.Type, schema.V0mimir1}: {
+		NotifierType:                email.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      emailv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{jira.Type, schema.V0mimir1}: {
+		NotifierType:                jira.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      jirav0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{opsgenie.Type, schema.V0mimir1}: {
+		NotifierType:                opsgenie.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      opsgeniev0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{pagerduty.Type, schema.V0mimir1}: {
+		NotifierType:                pagerduty.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      pagerdutyv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{pushover.Type, schema.V0mimir1}: {
+		NotifierType:                pushover.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      pushoverv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{slack.Type, schema.V0mimir1}: {
+		NotifierType:                slack.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      slackv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{sns.Type, schema.V0mimir1}: {
+		NotifierType:                sns.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      snsv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{teams.Type, schema.V0mimir1}: {
+		NotifierType:                teams.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      teamsv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{telegram.Type, schema.V0mimir1}: {
+		NotifierType:                telegram.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      telegramv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{victorops.Type, schema.V0mimir1}: {
+		NotifierType:                victorops.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      victoropsv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{webex.Type, schema.V0mimir1}: {
+		NotifierType:                webex.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      webexv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{webhook.Type, schema.V0mimir1}: {
+		NotifierType:                webhook.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      webhookv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	{wechat.Type, schema.V0mimir1}: {
+		NotifierType:                wechat.Type,
+		Version:                     schema.V0mimir1,
+		Config:                      wechatv0mimir1.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
+	// V0mimir2
+	{teams.Type, schema.V0mimir2}: {
+		NotifierType:                teams.Type,
+		Version:                     schema.V0mimir2,
+		Config:                      teamsv0mimir2.FullValidConfigForTesting,
+		CommonHTTPConfigUnsupported: true,
+	},
 }
 
 func (n NotifierConfigTest) GetRawNotifierConfig(name string) *models.IntegrationConfig {

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -256,6 +256,46 @@ func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decode De
 	return result, nil
 }
 
+func ValidateAPIReceiver(ctx context.Context, api *APIReceiver, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
+	var errs []error
+	if api.Name == "" {
+		errs = append(errs, fmt.Errorf("receiver name is required"))
+	}
+	if err := api.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+	for idx, integration := range api.Integrations {
+		err := validateIntegrationConfig(ctx, integration, decode, decrypt)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid integration config at index %d: %w", idx, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func validateIntegrationConfig(ctx context.Context, cfg *models.IntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
+	secureSettings, err := decode(cfg.SecureSettings)
+	if err != nil {
+		return err
+	}
+
+	decryptFn := func(key string, fallback string) (string, bool) {
+		if _, ok := secureSettings[key]; !ok {
+			return fallback, false
+		}
+		return decrypt(ctx, secureSettings, key, fallback), true
+	}
+
+	factory, ok := GetFactoryForIntegrationVersion(cfg.Type, cfg.Version)
+	if !ok {
+		return fmt.Errorf("invalid integration type or version: %s %s", cfg.Type, cfg.Version)
+	}
+	return factory.ValidateConfig(cfg.Settings, decryptFn)
+}
+
 // parseNotifier parses receivers and populates the corresponding field in GrafanaReceiverConfig. Returns an error if the configuration cannot be parsed.
 func parseNotifier(ctx context.Context, result *GrafanaReceiverConfig, receiver *models.IntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn, idx int) error {
 	// normalize the type to the original type and version

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -265,7 +265,7 @@ func ValidateAPIReceiver(ctx context.Context, api *APIReceiver, decode DecodeSec
 		errs = append(errs, err)
 	}
 	for idx, integration := range api.Integrations {
-		err := validateIntegrationConfig(ctx, integration, decode, decrypt)
+		err := ValidateIntegrationConfig(ctx, integration, decode, decrypt)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("invalid integration config at index %d: %w", idx, err))
 		}
@@ -276,7 +276,7 @@ func ValidateAPIReceiver(ctx context.Context, api *APIReceiver, decode DecodeSec
 	return nil
 }
 
-func validateIntegrationConfig(ctx context.Context, cfg *models.IntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
+func ValidateIntegrationConfig(ctx context.Context, cfg *models.IntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
 	secureSettings, err := decode(cfg.SecureSettings)
 	if err != nil {
 		return err

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -277,6 +277,16 @@ func ValidateAPIReceiver(ctx context.Context, api *APIReceiver, decode DecodeSec
 }
 
 func ValidateIntegrationConfig(ctx context.Context, cfg *models.IntegrationConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
+	if cfg.Type == "" {
+		return fmt.Errorf("type should not be an empty string")
+	}
+	if cfg.Settings == nil {
+		return fmt.Errorf("settings should not be empty")
+	}
+	if cfg.Version == "" {
+		return fmt.Errorf("version should not be an empty string")
+	}
+
 	secureSettings, err := decode(cfg.SecureSettings)
 	if err != nil {
 		return err

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -657,3 +657,112 @@ func TestReceiver_JSONRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAPIReceiver(t *testing.T) {
+	ctx := context.Background()
+	decrypt := GetDecryptedValueFnForTesting
+
+	t.Run("accepts valid configs for all known integrations", func(t *testing.T) {
+		for key, cfg := range notifytest.AllKnownConfigsForTesting {
+			t.Run(fmt.Sprintf("%s %s", key.Type, key.Version), func(t *testing.T) {
+				raw := cfg.GetRawNotifierConfig("")
+				api := &APIReceiver{
+					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+					ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+				}
+				require.NoError(t, ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt))
+			})
+		}
+	})
+
+	t.Run("returns error when receiver name is empty", func(t *testing.T) {
+		api := &APIReceiver{}
+		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "receiver name is required")
+	})
+
+	t.Run("returns error for unknown integration type", func(t *testing.T) {
+		raw := &models.IntegrationConfig{
+			Name:     "test",
+			Type:     "unknown-type",
+			Version:  schema.V1,
+			Settings: json.RawMessage(`{}`),
+		}
+		api := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		}
+		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+		require.ErrorContains(t, err, "invalid integration config at index 0")
+		require.ErrorContains(t, err, "invalid integration type or version")
+	})
+
+	t.Run("returns error for unknown integration version", func(t *testing.T) {
+		raw := &models.IntegrationConfig{
+			Name:     "test",
+			Type:     schema.WebhookType,
+			Version:  "v99",
+			Settings: json.RawMessage(`{}`),
+		}
+		api := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		}
+		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+		require.ErrorContains(t, err, "invalid integration config at index 0")
+		require.ErrorContains(t, err, "invalid integration type or version")
+	})
+
+	t.Run("returns error when integration config is invalid", func(t *testing.T) {
+		// webhook v1 requires a non-empty URL
+		raw := &models.IntegrationConfig{
+			Name:     "test",
+			Type:     schema.WebhookType,
+			Version:  schema.V1,
+			Settings: json.RawMessage(`{"url": ""}`),
+		}
+		api := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		}
+		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+		require.ErrorContains(t, err, "invalid integration config at index 0")
+	})
+
+	t.Run("returns error when secure settings cannot be decoded", func(t *testing.T) {
+		raw := &models.IntegrationConfig{
+			Name:           "test",
+			Type:           schema.WebhookType,
+			Version:        schema.V1,
+			Settings:       json.RawMessage(`{"url": "http://localhost"}`),
+			SecureSettings: map[string]string{"key": "not-valid-base64!!!"},
+		}
+		api := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		}
+		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+		require.ErrorContains(t, err, "invalid integration config at index 0")
+	})
+
+	t.Run("collects errors from multiple invalid integrations", func(t *testing.T) {
+		makeInvalid := func(name string) *models.IntegrationConfig {
+			return &models.IntegrationConfig{
+				Name:     name,
+				Type:     "unknown-type",
+				Version:  schema.V1,
+				Settings: json.RawMessage(`{}`),
+			}
+		}
+		api := &APIReceiver{
+			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
+			ReceiverConfig: models.ReceiverConfig{
+				Integrations: []*models.IntegrationConfig{makeInvalid("a"), makeInvalid("b")},
+			},
+		}
+		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+		require.ErrorContains(t, err, "invalid integration config at index 0")
+		require.ErrorContains(t, err, "invalid integration config at index 1")
+	})
+}

--- a/notify/schema.go
+++ b/notify/schema.go
@@ -268,11 +268,14 @@ func IntegrationTypeFromMimirTypeReflect(t reflect.Type) (schema.IntegrationType
 
 func GetFactoryForIntegrationVersion(t schema.IntegrationType, v schema.Version) (receivers.IntegrationVersionFactory, bool) {
 	initSchemaOnce.Do(initSchemas)
-	_, ok := allSchemas[t]
+	if canonical, ok := aliasToType[t]; ok {
+		t = canonical
+	}
+	sch, ok := allSchemas[t]
 	if !ok {
 		return receivers.IntegrationVersionFactory{}, false
 	}
-	return allSchemas[t].GetFactoryForVersion(v)
+	return sch.GetFactoryForVersion(v)
 }
 
 // TODO make it more efficient and self maintained

--- a/notify/schema.go
+++ b/notify/schema.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/alertmanager"
 	"github.com/grafana/alerting/receivers/dingding"
 	"github.com/grafana/alerting/receivers/discord"
@@ -56,40 +57,40 @@ var (
 
 // map of all known types including aliases and schema factories
 var (
-	allSchemas     map[schema.IntegrationType]schema.IntegrationTypeSchema
+	allSchemas     map[schema.IntegrationType]receivers.Manifest
 	aliasToType    map[schema.IntegrationType]schema.IntegrationType
 	initSchemaOnce sync.Once
 )
 
 func initSchemas() {
-	all := []schema.IntegrationTypeSchema{
-		alertmanager.Schema,
-		dingding.Schema,
-		discord.Schema,
-		email.Schema,
-		googlechat.Schema,
-		jira.Schema,
-		kafka.Schema,
-		line.Schema,
-		mqtt.Schema,
-		oncall.Schema,
-		opsgenie.Schema,
-		pagerduty.Schema,
-		pushover.Schema,
-		sensugo.Schema,
-		slack.Schema,
-		sns.Schema,
-		teams.Schema,
-		telegram.Schema,
-		threema.Schema,
-		victorops.Schema,
-		webex.Schema,
-		webhook.Schema,
-		wechat.Schema,
-		wecom.Schema,
+	all := []receivers.Manifest{
+		alertmanager.Manifest,
+		dingding.Manifest,
+		discord.Manifest,
+		email.Manifest,
+		googlechat.Manifest,
+		jira.Manifest,
+		kafka.Manifest,
+		line.Manifest,
+		mqtt.Manifest,
+		oncall.Manifest,
+		opsgenie.Manifest,
+		pagerduty.Manifest,
+		pushover.Manifest,
+		sensugo.Manifest,
+		slack.Manifest,
+		sns.Manifest,
+		teams.Manifest,
+		telegram.Manifest,
+		threema.Manifest,
+		victorops.Manifest,
+		webex.Manifest,
+		webhook.Manifest,
+		wechat.Manifest,
+		wecom.Manifest,
 	}
 
-	allSch := make(map[schema.IntegrationType]schema.IntegrationTypeSchema, len(all))
+	allSch := make(map[schema.IntegrationType]receivers.Manifest, len(all))
 	aliases := make(map[schema.IntegrationType]schema.IntegrationType)
 	for _, sch := range all {
 		if _, ok := allSch[sch.Type]; ok {
@@ -126,7 +127,7 @@ func GetSchemaForAllIntegrations() []schema.IntegrationTypeSchema {
 		if _, ok := seen[t]; ok {
 			continue
 		}
-		result = append(result, sch)
+		result = append(result, sch.IntegrationTypeSchema)
 		for _, t := range sch.GetAllTypes() {
 			seen[t] = struct{}{}
 		}
@@ -143,11 +144,11 @@ func GetSchemaForIntegration(integrationType schema.IntegrationType) (schema.Int
 	get := func(t schema.IntegrationType) (schema.IntegrationTypeSchema, bool) {
 		sch, ok := allSchemas[t]
 		if ok {
-			return sch, true
+			return sch.IntegrationTypeSchema, true
 		}
 		original, ok := aliasToType[t]
 		if ok {
-			return allSchemas[original], true
+			return allSchemas[original].IntegrationTypeSchema, true
 		}
 		return schema.IntegrationTypeSchema{}, false
 	}
@@ -263,6 +264,15 @@ func IntegrationTypeFromMimirTypeReflect(t reflect.Type) (schema.IntegrationType
 		return IntegrationTypeFromMimirTypeReflect(t.Elem())
 	}
 	return "", errors.New("not a struct or slice")
+}
+
+func GetFactoryForIntegrationVersion(t schema.IntegrationType, v schema.Version) (receivers.IntegrationVersionFactory, bool) {
+	initSchemaOnce.Do(initSchemas)
+	_, ok := allSchemas[t]
+	if !ok {
+		return receivers.IntegrationVersionFactory{}, false
+	}
+	return allSchemas[t].GetFactoryForVersion(v)
 }
 
 // TODO make it more efficient and self maintained

--- a/notify/schema_test.go
+++ b/notify/schema_test.go
@@ -355,6 +355,15 @@ func TestGetFactoryForIntegrationVersion(t *testing.T) {
 		}
 	})
 
+	t.Run("should resolve alias types", func(t *testing.T) {
+		// "msteams" is an alias for the canonical "teams" type at V0mimir1
+		_, ok := GetFactoryForIntegrationVersion("msteams", schema.V0mimir1)
+		require.True(t, ok)
+		// "msteamsv2" is an alias for the canonical "teams" type at V0mimir2
+		_, ok = GetFactoryForIntegrationVersion("msteamsv2", schema.V0mimir2)
+		require.True(t, ok)
+	})
+
 	t.Run("should return false for unknown type", func(t *testing.T) {
 		_, ok := GetFactoryForIntegrationVersion("unknown-type", schema.V1)
 		require.False(t, ok)

--- a/notify/schema_test.go
+++ b/notify/schema_test.go
@@ -345,6 +345,27 @@ func TestIntegrationTypeFromMimirType(t *testing.T) {
 	})
 }
 
+func TestGetFactoryForIntegrationVersion(t *testing.T) {
+	t.Run("should return factory for all known integration versions", func(t *testing.T) {
+		for key := range notifytest.AllKnownConfigsForTesting {
+			t.Run(fmt.Sprintf("%s-%s", key.Type, key.Version), func(t *testing.T) {
+				_, ok := GetFactoryForIntegrationVersion(key.Type, key.Version)
+				require.True(t, ok)
+			})
+		}
+	})
+
+	t.Run("should return false for unknown type", func(t *testing.T) {
+		_, ok := GetFactoryForIntegrationVersion("unknown-type", schema.V1)
+		require.False(t, ok)
+	})
+
+	t.Run("should return false for known type with unknown version", func(t *testing.T) {
+		_, ok := GetFactoryForIntegrationVersion(schema.WebhookType, "v99")
+		require.False(t, ok)
+	})
+}
+
 func unique(slice []string) []string {
 	keys := make(map[string]struct{}, len(slice))
 	list := make([]string, 0, len(slice))

--- a/receivers/alertmanager/schema.go
+++ b/receivers/alertmanager/schema.go
@@ -1,6 +1,7 @@
 package alertmanager
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/alertmanager/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -16,4 +17,9 @@ var Schema = schema.InitSchema(
 		CurrentVersion: v1.Version,
 	},
 	v1.Schema,
+)
+
+var Manifest = receivers.NewManifest(
+	Schema,
+	v1.Factory,
 )

--- a/receivers/alertmanager/v1/config.go
+++ b/receivers/alertmanager/v1/config.go
@@ -82,3 +82,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.AlertManagerType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/dingding/schema.go
+++ b/receivers/dingding/schema.go
@@ -1,6 +1,7 @@
 package dingding
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/dingding/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -17,3 +18,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/dingding/v1/config.go
+++ b/receivers/dingding/v1/config.go
@@ -88,3 +88,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.DingDingType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Logger), nil
+	},
+}

--- a/receivers/discord/schema.go
+++ b/receivers/discord/schema.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/discord/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/discord/v1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -18,4 +19,10 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 	v0mimir1.Schema,
+)
+
+var Manifest = receivers.NewManifest(
+	Schema,
+	v0mimir1.Factory,
+	v1.Factory,
 )

--- a/receivers/discord/v0mimir1/config.go
+++ b/receivers/discord/v0mimir1/config.go
@@ -143,10 +143,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.DiscordType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/discord/v0mimir1/config.go
+++ b/receivers/discord/v0mimir1/config.go
@@ -137,3 +137,26 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		httpcfg.V0HttpConfigOption(),
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.DiscordType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}

--- a/receivers/discord/v1/config.go
+++ b/receivers/discord/v1/config.go
@@ -99,10 +99,6 @@ var Factory = receivers.IntegrationVersionFactory{
 		if err != nil {
 			return nil, err
 		}
-		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.GrafanaVersion)
-		if err != nil {
-			return nil, err
-		}
-		return ch, nil
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.GrafanaVersion), nil
 	},
 }

--- a/receivers/discord/v1/config.go
+++ b/receivers/discord/v1/config.go
@@ -89,10 +89,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.DiscordType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/discord/v1/config.go
+++ b/receivers/discord/v1/config.go
@@ -83,3 +83,26 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.DiscordType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.GrafanaVersion)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}

--- a/receivers/email/schema.go
+++ b/receivers/email/schema.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/email/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/email/v1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/email/v0mimir1/config.go
+++ b/receivers/email/v0mimir1/config.go
@@ -218,3 +218,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		httpcfg.V0TLSConfigOption("tls_config"),
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.EmailType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger), nil
+	},
+}

--- a/receivers/email/v1/config.go
+++ b/receivers/email/v1/config.go
@@ -95,3 +95,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.EmailType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.EmailSender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/factory.go
+++ b/receivers/factory.go
@@ -29,6 +29,7 @@ type NotifierOpts struct {
 // NotificationChannel is the interface that all notifiers must satisfy.
 type NotificationChannel interface {
 	notify.Notifier
+	notify.ResolvedSender
 }
 
 type ValidateIntegrationFunc func(json.RawMessage, DecryptFunc) error

--- a/receivers/factory.go
+++ b/receivers/factory.go
@@ -1,0 +1,78 @@
+package receivers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-kit/log"
+	commoncfg "github.com/prometheus/common/config"
+
+	"github.com/prometheus/alertmanager/notify"
+
+	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/receivers/schema"
+	"github.com/grafana/alerting/templates"
+)
+
+// NotifierOpts bundles runtime dependencies for constructing any notifier.
+type NotifierOpts struct {
+	Template       *templates.Template
+	Images         images.Provider
+	Logger         log.Logger
+	EmailSender    EmailSender
+	Sender         WebhookSender
+	OrgID          int64
+	GrafanaVersion string
+	HttpOpts       []commoncfg.HTTPClientOption
+}
+
+// NotificationChannel is the interface that all notifiers must satisfy.
+type NotificationChannel interface {
+	notify.Notifier
+}
+
+type ValidateIntegrationFunc func(json.RawMessage, DecryptFunc) error
+type NewNotifierFunc func(raw json.RawMessage, decryptFn DecryptFunc, meta Metadata, opts NotifierOpts) (NotificationChannel, error)
+
+type IntegrationVersionFactory struct {
+	Version        schema.Version
+	Type           schema.IntegrationType
+	ValidateConfig ValidateIntegrationFunc
+	NewNotifier    NewNotifierFunc
+}
+
+type Manifest struct {
+	schema.IntegrationTypeSchema
+	factories []IntegrationVersionFactory
+}
+
+func NewManifest(s schema.IntegrationTypeSchema, factories ...IntegrationVersionFactory) Manifest {
+	factoryVersions := make(map[schema.Version]struct{}, len(factories))
+	for _, f := range factories {
+		if _, ok := s.GetVersion(f.Version); !ok {
+			panic(fmt.Sprintf("factory version %s not found in schema for %s", f.Version, s.Type))
+		}
+		if _, ok := factoryVersions[f.Version]; ok {
+			panic(fmt.Sprintf("duplicate factory version %s for %s", f.Version, s.Type))
+		}
+		factoryVersions[f.Version] = struct{}{}
+	}
+	for _, v := range s.Versions {
+		if _, ok := factoryVersions[v.Version]; !ok {
+			panic(fmt.Sprintf("schema version %s has no factory for %s", v.Version, s.Type))
+		}
+	}
+	return Manifest{
+		IntegrationTypeSchema: s,
+		factories:             factories,
+	}
+}
+
+func (i Manifest) GetFactoryForVersion(version schema.Version) (IntegrationVersionFactory, bool) {
+	for _, integration := range i.factories {
+		if integration.Version == version {
+			return integration, true
+		}
+	}
+	return IntegrationVersionFactory{}, false
+}

--- a/receivers/factory_test.go
+++ b/receivers/factory_test.go
@@ -1,0 +1,82 @@
+package receivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/receivers/schema"
+)
+
+func testSchema(versions ...schema.Version) schema.IntegrationTypeSchema {
+	s := schema.IntegrationTypeSchema{
+		Type: "test",
+		Name: "Test",
+	}
+	for _, v := range versions {
+		s.Versions = append(s.Versions, schema.IntegrationSchemaVersion{Version: v})
+	}
+	return s
+}
+
+func testFactory(version schema.Version) IntegrationVersionFactory {
+	return IntegrationVersionFactory{
+		Version: version,
+		Type:    "test",
+	}
+}
+
+func TestNewManifest(t *testing.T) {
+	t.Run("matching versions", func(t *testing.T) {
+		s := testSchema(schema.V1, schema.V0mimir1)
+		require.NotPanics(t, func() {
+			m := NewManifest(s, testFactory(schema.V1), testFactory(schema.V0mimir1))
+			assert.Equal(t, s.Type, m.Type)
+		})
+	})
+
+	t.Run("single version", func(t *testing.T) {
+		s := testSchema(schema.V1)
+		require.NotPanics(t, func() {
+			NewManifest(s, testFactory(schema.V1))
+		})
+	})
+
+	t.Run("factory version not in schema", func(t *testing.T) {
+		s := testSchema(schema.V1)
+		assert.PanicsWithValue(t, "factory version v0mimir1 not found in schema for test", func() {
+			NewManifest(s, testFactory(schema.V1), testFactory(schema.V0mimir1))
+		})
+	})
+
+	t.Run("duplicate factory version", func(t *testing.T) {
+		s := testSchema(schema.V1)
+		assert.PanicsWithValue(t, "duplicate factory version v1 for test", func() {
+			NewManifest(s, testFactory(schema.V1), testFactory(schema.V1))
+		})
+	})
+
+	t.Run("schema version missing factory", func(t *testing.T) {
+		s := testSchema(schema.V1, schema.V0mimir1)
+		assert.PanicsWithValue(t, "schema version v0mimir1 has no factory for test", func() {
+			NewManifest(s, testFactory(schema.V1))
+		})
+	})
+}
+
+func TestManifest_GetFactoryForVersion(t *testing.T) {
+	s := testSchema(schema.V1, schema.V0mimir1)
+	m := NewManifest(s, testFactory(schema.V0mimir1), testFactory(schema.V1))
+
+	t.Run("found", func(t *testing.T) {
+		f, ok := m.GetFactoryForVersion(schema.V1)
+		require.True(t, ok)
+		assert.Equal(t, schema.V1, f.Version)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := m.GetFactoryForVersion(schema.V0mimir2)
+		assert.False(t, ok)
+	})
+}

--- a/receivers/googlechat/schema.go
+++ b/receivers/googlechat/schema.go
@@ -1,6 +1,7 @@
 package googlechat
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/googlechat/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -17,3 +18,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/googlechat/v1/config.go
+++ b/receivers/googlechat/v1/config.go
@@ -82,3 +82,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.GoogleChatType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.GrafanaVersion), nil
+	},
+}

--- a/receivers/jira/schema.go
+++ b/receivers/jira/schema.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/jira/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/jira/v1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/jira/v0mimir1/config.go
+++ b/receivers/jira/v0mimir1/config.go
@@ -217,3 +217,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		httpcfg.V0HttpConfigOption(),
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.JiraType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+	},
+}

--- a/receivers/jira/v1/config.go
+++ b/receivers/jira/v1/config.go
@@ -315,3 +315,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.JiraType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Logger), nil
+	},
+}

--- a/receivers/kafka/schema.go
+++ b/receivers/kafka/schema.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/kafka/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -17,3 +18,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/kafka/v1/config.go
+++ b/receivers/kafka/v1/config.go
@@ -153,3 +153,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.KafkaType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/line/schema.go
+++ b/receivers/line/schema.go
@@ -1,6 +1,7 @@
 package line
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/line/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -18,3 +19,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/line/v1/config.go
+++ b/receivers/line/v1/config.go
@@ -69,3 +69,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.LineType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Logger), nil
+	},
+}

--- a/receivers/mqtt/schema.go
+++ b/receivers/mqtt/schema.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/mqtt/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -18,3 +19,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/mqtt/v1/config.go
+++ b/receivers/mqtt/v1/config.go
@@ -238,3 +238,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.MQTTType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Logger, nil), nil
+	},
+}

--- a/receivers/oncall/schema.go
+++ b/receivers/oncall/schema.go
@@ -1,6 +1,7 @@
 package oncall
 
 import (
+	"github.com/grafana/alerting/receivers"
 	v1 "github.com/grafana/alerting/receivers/oncall/v1"
 	"github.com/grafana/alerting/receivers/schema"
 )
@@ -17,3 +18,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/oncall/v1/config.go
+++ b/receivers/oncall/v1/config.go
@@ -163,3 +163,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.OnCallType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.OrgID), nil
+	},
+}

--- a/receivers/opsgenie/schema.go
+++ b/receivers/opsgenie/schema.go
@@ -1,6 +1,7 @@
 package opsgenie
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/opsgenie/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/opsgenie/v1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/opsgenie/v0mimir1/config.go
+++ b/receivers/opsgenie/v0mimir1/config.go
@@ -282,3 +282,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		httpcfg.V0HttpConfigOption(),
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.OpsGenieType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+	},
+}

--- a/receivers/opsgenie/v1/config.go
+++ b/receivers/opsgenie/v1/config.go
@@ -232,3 +232,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.OpsGenieType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/pagerduty/schema.go
+++ b/receivers/pagerduty/schema.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/pagerduty/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/pagerduty/v1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/pagerduty/v0mimir1/config.go
+++ b/receivers/pagerduty/v0mimir1/config.go
@@ -301,6 +301,22 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	},
 })
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.PagerDutyType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+	},
+}
+
 // PagerdutyLink is used to add link to an incident.
 type PagerdutyLink struct {
 	Href string `yaml:"href,omitempty" json:"href,omitempty"`

--- a/receivers/pagerduty/v1/config.go
+++ b/receivers/pagerduty/v1/config.go
@@ -200,3 +200,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.PagerDutyType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/pushover/schema.go
+++ b/receivers/pushover/schema.go
@@ -1,6 +1,7 @@
 package pushover
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/pushover/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/pushover/v1"
 	"github.com/grafana/alerting/receivers/schema"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/pushover/v0mimir1/config.go
+++ b/receivers/pushover/v0mimir1/config.go
@@ -246,3 +246,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		httpcfg.V0HttpConfigOption(),
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.PushoverType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+	},
+}

--- a/receivers/pushover/v1/config.go
+++ b/receivers/pushover/v1/config.go
@@ -179,3 +179,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.PushoverType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/sensugo/schema.go
+++ b/receivers/sensugo/schema.go
@@ -1,6 +1,7 @@
 package sensugo
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	v1 "github.com/grafana/alerting/receivers/sensugo/v1"
 )
@@ -17,3 +18,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/sensugo/v1/config.go
+++ b/receivers/sensugo/v1/config.go
@@ -98,3 +98,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.SensuGoType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/slack/schema.go
+++ b/receivers/slack/schema.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/slack/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/slack/v1"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/slack/v0mimir1/config.go
+++ b/receivers/slack/v0mimir1/config.go
@@ -372,6 +372,22 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	},
 })
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.SlackType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+	},
+}
+
 // SlackAction configures a single Slack action that is sent with each notification.
 // See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons
 // for more information.

--- a/receivers/slack/v1/config.go
+++ b/receivers/slack/v1/config.go
@@ -214,3 +214,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.SlackType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.GrafanaVersion), nil
+	},
+}

--- a/receivers/sns/schema.go
+++ b/receivers/sns/schema.go
@@ -1,6 +1,7 @@
 package sns
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/sns/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/sns/v1"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/sns/v0mimir1/config.go
+++ b/receivers/sns/v0mimir1/config.go
@@ -234,3 +234,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		httpcfg.V0HttpConfigOption(),
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.SNSType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+	},
+}

--- a/receivers/sns/v1/config.go
+++ b/receivers/sns/v1/config.go
@@ -182,3 +182,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.SNSType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Logger), nil
+	},
+}

--- a/receivers/teams/schema.go
+++ b/receivers/teams/schema.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/teams/v0mimir1"
 	"github.com/grafana/alerting/receivers/teams/v0mimir2"
@@ -21,3 +22,5 @@ var Schema = schema.InitSchema(
 	v0mimir2.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v0mimir2.Factory, v1.Factory)

--- a/receivers/teams/v0mimir1/config.go
+++ b/receivers/teams/v0mimir1/config.go
@@ -114,10 +114,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    TypeAlias,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/teams/v0mimir1/config.go
+++ b/receivers/teams/v0mimir1/config.go
@@ -109,6 +109,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    TypeAlias,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	TypeAlias: TypeAlias,
 	Version:   Version,

--- a/receivers/teams/v0mimir2/config.go
+++ b/receivers/teams/v0mimir2/config.go
@@ -112,10 +112,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    TypeAlias,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/teams/v0mimir2/config.go
+++ b/receivers/teams/v0mimir2/config.go
@@ -107,6 +107,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    TypeAlias,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	TypeAlias: TypeAlias,
 	Version:   Version,

--- a/receivers/teams/v1/config.go
+++ b/receivers/teams/v1/config.go
@@ -43,10 +43,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.TeamsType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/teams/v1/config.go
+++ b/receivers/teams/v1/config.go
@@ -38,6 +38,26 @@ func NewConfig(jsonData json.RawMessage, _ receivers.DecryptFunc) (Config, error
 	return settings, nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.TeamsType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger)
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: true,

--- a/receivers/telegram/schema.go
+++ b/receivers/telegram/schema.go
@@ -1,6 +1,7 @@
 package telegram
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/telegram/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/telegram/v1"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/telegram/v0mimir1/config.go
+++ b/receivers/telegram/v0mimir1/config.go
@@ -125,6 +125,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.TelegramType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: false,

--- a/receivers/telegram/v0mimir1/config.go
+++ b/receivers/telegram/v0mimir1/config.go
@@ -130,10 +130,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.TelegramType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/telegram/v1/config.go
+++ b/receivers/telegram/v1/config.go
@@ -82,10 +82,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.TelegramType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/telegram/v1/config.go
+++ b/receivers/telegram/v1/config.go
@@ -77,6 +77,26 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	return settings, nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.TelegramType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger)
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: true,

--- a/receivers/threema/schema.go
+++ b/receivers/threema/schema.go
@@ -1,6 +1,7 @@
 package threema
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	v1 "github.com/grafana/alerting/receivers/threema/v1"
 )
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/threema/v1/config.go
+++ b/receivers/threema/v1/config.go
@@ -111,3 +111,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.ThreemaType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger), nil
+	},
+}

--- a/receivers/victorops/schema.go
+++ b/receivers/victorops/schema.go
@@ -1,6 +1,7 @@
 package victorops
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/victorops/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/victorops/v1"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/victorops/v0mimir1/config.go
+++ b/receivers/victorops/v0mimir1/config.go
@@ -128,10 +128,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.VictorOpsType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/victorops/v0mimir1/config.go
+++ b/receivers/victorops/v0mimir1/config.go
@@ -123,6 +123,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.VictorOpsType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: false,

--- a/receivers/victorops/v1/config.go
+++ b/receivers/victorops/v1/config.go
@@ -45,6 +45,26 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	return settings, nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.VictorOpsType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.GrafanaVersion)
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: true,

--- a/receivers/victorops/v1/config.go
+++ b/receivers/victorops/v1/config.go
@@ -50,10 +50,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.VictorOpsType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/webex/schema.go
+++ b/receivers/webex/schema.go
@@ -1,6 +1,7 @@
 package webex
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/webex/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/webex/v1"
@@ -20,3 +21,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/webex/v0mimir1/config.go
+++ b/receivers/webex/v0mimir1/config.go
@@ -102,10 +102,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.WebexType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/webex/v0mimir1/config.go
+++ b/receivers/webex/v0mimir1/config.go
@@ -97,6 +97,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.WebexType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: false,

--- a/receivers/webex/v1/config.go
+++ b/receivers/webex/v1/config.go
@@ -52,6 +52,26 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 	return settings, err
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.WebexType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.OrgID)
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: true,

--- a/receivers/webex/v1/config.go
+++ b/receivers/webex/v1/config.go
@@ -57,10 +57,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.WebexType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/webhook/schema.go
+++ b/receivers/webhook/schema.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/webhook/v0mimir1"
 	v1 "github.com/grafana/alerting/receivers/webhook/v1"
@@ -19,3 +20,5 @@ var Schema = schema.InitSchema(
 	v1.Schema,
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory, v1.Factory)

--- a/receivers/webhook/v0mimir1/config.go
+++ b/receivers/webhook/v0mimir1/config.go
@@ -111,6 +111,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.WebhookType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: false,

--- a/receivers/webhook/v0mimir1/config.go
+++ b/receivers/webhook/v0mimir1/config.go
@@ -116,10 +116,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.WebhookType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/webhook/v1/config.go
+++ b/receivers/webhook/v1/config.go
@@ -189,6 +189,26 @@ func OmitRestrictedHeaders(headers map[string]string) (map[string]string, []stri
 	return safeHeaders, omitted
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.WebhookType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch := New(cfg, m, opts.Template, opts.Sender, opts.Images, opts.Logger, opts.OrgID)
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: true,

--- a/receivers/webhook/v1/config.go
+++ b/receivers/webhook/v1/config.go
@@ -194,10 +194,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.WebhookType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/wechat/schema.go
+++ b/receivers/wechat/schema.go
@@ -1,6 +1,7 @@
 package wechat
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/wechat/v0mimir1"
 )
@@ -18,3 +19,5 @@ var Schema = schema.InitSchema(
 	},
 	v0mimir1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v0mimir1.Factory)

--- a/receivers/wechat/v0mimir1/config.go
+++ b/receivers/wechat/v0mimir1/config.go
@@ -132,10 +132,7 @@ var Factory = receivers.IntegrationVersionFactory{
 	Type:    schema.WeChatType,
 	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
 		_, err := NewConfig(message, decryptFunc)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
 		cfg, err := NewConfig(message, decryptFunc)

--- a/receivers/wechat/v0mimir1/config.go
+++ b/receivers/wechat/v0mimir1/config.go
@@ -127,6 +127,29 @@ func (c *Config) validate() error {
 	return nil
 }
 
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.WeChatType,
+	ValidateConfig: func(message json.RawMessage, decryptFunc receivers.DecryptFunc) error {
+		_, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+	NewNotifier: func(message json.RawMessage, decryptFunc receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(message, decryptFunc)
+		if err != nil {
+			return nil, err
+		}
+		ch, err := New(&cfg, opts.Template.Template, opts.Logger, opts.HttpOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return ch, nil
+	},
+}
+
 var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 	Version:   Version,
 	CanCreate: false,

--- a/receivers/wecom/schema.go
+++ b/receivers/wecom/schema.go
@@ -1,6 +1,7 @@
 package wecom
 
 import (
+	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	v1 "github.com/grafana/alerting/receivers/wecom/v1"
 )
@@ -17,3 +18,5 @@ var Schema = schema.InitSchema(
 	},
 	v1.Schema,
 )
+
+var Manifest = receivers.NewManifest(Schema, v1.Factory)

--- a/receivers/wecom/v1/config.go
+++ b/receivers/wecom/v1/config.go
@@ -176,3 +176,19 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 		},
 	},
 })
+
+var Factory = receivers.IntegrationVersionFactory{
+	Version: Version,
+	Type:    schema.WeComType,
+	ValidateConfig: func(raw json.RawMessage, decryptFn receivers.DecryptFunc) error {
+		_, err := NewConfig(raw, decryptFn)
+		return err
+	},
+	NewNotifier: func(raw json.RawMessage, decryptFn receivers.DecryptFunc, m receivers.Metadata, opts receivers.NotifierOpts) (receivers.NotificationChannel, error) {
+		cfg, err := NewConfig(raw, decryptFn)
+		if err != nil {
+			return nil, err
+		}
+		return New(cfg, m, opts.Template, opts.Sender, opts.Logger), nil
+	},
+}


### PR DESCRIPTION
## Summary
Note: this is brand new code, the branching happens on the high level, in Alertmanager and controlled by a new flag `BuildWithManifestBuilder`.

- Introduces `IntegrationVersionFactory` and `Manifest` types in `receivers/factory.go`,
  giving each integration version a `ValidateConfig` and `NewNotifier` function
- Adds a `Factory` variable to every versioned integration config (V1, V0mimir1, V0mimir2)
  and wires them into a top-level `Manifest` per integration
- Migrates `allSchemas` in `notify/schema.go` to be keyed on `Manifest` (schema + factories combined)
- Adds `BuildReceiverIntegrationsWithManifests` — a factory function that builds Grafana
  integrations via the manifest registry instead of the typed-config switch in
  `BuildReceiverConfiguration` + `BuildGrafanaReceiverIntegrations`
- Introduces a setting `BuildWithManifestBuilder` in Alertmanager options, which controls how integrations are built. This is more a safety in case we need to switch back to old way. It will be controlled via feature flag in Grafana



## Test plan

- [ ] `TestBuildReceiverIntegrationsWithManifests` — all known configs across all versions
  (V1, V0mimir1, V0mimir2) build without error; wrap function called once per integration;
  unknown type/version return errors
- [ ] `TestGetFactoryForIntegrationVersion` — every registered type+version returns a factory;
  unknown type and unknown version return false
- [ ] Existing `notify` test suite passes

Related https://github.com/grafana/alerting-squad/issues/1214

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new, optionally enabled integration-construction path that changes how notifiers are instantiated and validated across multiple receiver versions, which could affect notification delivery if a factory/manifest is miswired. Behavior is gated by a flag but touches core alerting integration plumbing.
> 
> **Overview**
> Adds a **manifest-based integration factory** (`receivers.Manifest` + per-version `IntegrationVersionFactory`) and wires every integration/version to provide `ValidateConfig` and `NewNotifier` functions.
> 
> Updates `notify` to optionally build Grafana integrations via the manifest registry (`BuildReceiverIntegrationsWithManifests`) with per-type indexing and version-aware template selection, and threads a new `BuildWithManifestBuilder`/`useManifestBuilder` flag through `GrafanaAlertmanager` and receiver building to allow switching between the new and legacy builders.
> 
> Introduces new validation helpers (`ValidateAPIReceiver`/`ValidateIntegrationConfig`) that validate configs via the per-version factories, expands test fixtures to cover *all known* integrations across `V1`/`V0mimir1`/`V0mimir2`, and adds targeted unit tests for the manifest builder and factory lookup. Also includes a small Loki client cleanup (directly returning `handleLokiResponse` error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8705c8cdb5c97b760a4ecdbf80570873ade84f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->