### PR TITLE
Add per-tenant notification rate limiting primitives

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
 
 	commoncfg "github.com/prometheus/common/config"
 
@@ -24,10 +25,17 @@ import (
 
 var ErrInvalidMethod = errors.New("webhook only supports HTTP methods PUT or POST")
 
+// ErrWebhookRateLimited is returned from SendWebhook when a rate limiter rejects the call.
+// Mirrors ErrEmailRateLimited semantics: reject immediately, do not retry.
+var ErrWebhookRateLimited = errors.New("webhook notifications are rate limited")
+
 type clientConfiguration struct {
 	userAgent    string
 	dialer       net.Dialer // We use Dialer here instead of DialContext as our mqtt client doesn't support DialContext.
 	customDialer bool
+	// rateLimiter, when non-nil, is consulted once per SendWebhook call.
+	// The caller owns the limiter and may mutate its rate/burst at runtime.
+	rateLimiter *rate.Limiter
 }
 
 // defaultDialTimeout is the default timeout for the dialer, 30 seconds to match http.DefaultTransport.
@@ -38,14 +46,18 @@ type Client struct {
 	oauth2TokenSource oauth2.TokenSource
 }
 
-func NewClient(httpClientConfig *HTTPClientConfig, opts ...ClientOption) (*Client, error) {
+// NewClient builds a Client for a specific integration type. The integrationType is passed
+// through to each ClientOption so options can vary their behavior per integration (e.g.
+// WithRateLimiterByType selects a limiter from a per-type map). Pass "" for standalone
+// clients that are not tied to a particular integration.
+func NewClient(httpClientConfig *HTTPClientConfig, integrationType string, opts ...ClientOption) (*Client, error) {
 	cfg := clientConfiguration{
 		userAgent: "Grafana",
 		dialer:    net.Dialer{},
 	}
 	for _, opt := range opts {
 		if opt != nil {
-			opt(&cfg)
+			opt(&cfg, integrationType)
 		}
 	}
 	if cfg.dialer.Timeout == 0 {
@@ -73,18 +85,54 @@ func NewClient(httpClientConfig *HTTPClientConfig, opts ...ClientOption) (*Clien
 	return client, nil
 }
 
-type ClientOption func(*clientConfiguration)
+// ClientOption configures a Client. The second argument is the integration type the
+// Client is being built for (e.g. "slack", "webhook"); most options ignore it, but
+// options like WithRateLimiterByType use it to select per-type behavior. For standalone
+// clients not tied to a specific integration, NewClient is called with "".
+type ClientOption func(*clientConfiguration, string)
 
 func WithUserAgent(userAgent string) ClientOption {
-	return func(c *clientConfiguration) {
+	return func(c *clientConfiguration, _ string) {
 		c.userAgent = userAgent
 	}
 }
 
 func WithDialer(dialer net.Dialer) ClientOption {
-	return func(c *clientConfiguration) {
+	return func(c *clientConfiguration, _ string) {
 		c.dialer = dialer
 		c.customDialer = true
+	}
+}
+
+// WithRateLimiter installs a rate limiter on the client unconditionally. Each SendWebhook
+// call consumes one token via Allow(); when no token is available the call is rejected
+// with ErrWebhookRateLimited without contacting the upstream. A nil limiter disables
+// rate limiting (same as not passing this option).
+//
+// The caller owns the limiter's lifetime and may reconfigure it in place via
+// SetLimit/SetBurst. Use WithRateLimiterByType instead when the limiter should be chosen
+// per integration type.
+func WithRateLimiter(limiter *rate.Limiter) ClientOption {
+	return func(c *clientConfiguration, _ string) {
+		c.rateLimiter = limiter
+	}
+}
+
+// WithRateLimiterByType installs a rate limiter chosen from the given map by the Client's
+// integration type. When the type has no entry, the option is a no-op and no rate limiting
+// is applied to that Client. The typical use is a per-tenant map of limiters (one bucket
+// per integration type) that the factory consults when building Clients for each
+// receiver — giving a single shared bucket per integration type independent of how many
+// receivers reuse the same integration.
+//
+// The caller owns each limiter's lifetime and may reconfigure it in place via
+// SetLimit/SetBurst. To avoid data races, pass a snapshot of the map when the underlying
+// source can mutate concurrently (the option retains the reference).
+func WithRateLimiterByType(limiters map[string]*rate.Limiter) ClientOption {
+	return func(c *clientConfiguration, integrationType string) {
+		if lim, ok := limiters[integrationType]; ok && lim != nil {
+			c.rateLimiter = lim
+		}
 	}
 }
 
@@ -94,7 +142,10 @@ func ToHTTPClientOption(option ...ClientOption) []commoncfg.HTTPClientOption {
 		if opt == nil {
 			continue
 		}
-		opt(&cfg)
+		// No integration type context at conversion time — options that depend on the type
+		// have no effect here, which is correct: ToHTTPClientOption converts only to the
+		// subset supported by upstream (user-agent, dialer).
+		opt(&cfg, "")
 	}
 	result := make([]commoncfg.HTTPClientOption, 0, len(option))
 	if cfg.userAgent != "" {
@@ -107,6 +158,9 @@ func ToHTTPClientOption(option ...ClientOption) []commoncfg.HTTPClientOption {
 }
 
 func (ns *Client) SendWebhook(ctx context.Context, l log.Logger, webhook *receivers.SendWebhookSettings) error {
+	if ns.cfg.rateLimiter != nil && !ns.cfg.rateLimiter.Allow() {
+		return ErrWebhookRateLimited
+	}
 	// This method was moved from https://github.com/grafana/grafana/blob/71d04a326be9578e2d678f23c1efa61768e0541f/pkg/services/notifications/webhook.go#L38
 	if webhook.HTTPMethod == "" {
 		webhook.HTTPMethod = http.MethodPost

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -17,26 +17,27 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 
 	"github.com/grafana/alerting/receivers"
 )
 
 func TestClient(t *testing.T) {
 	t.Run("NewClient", func(t *testing.T) {
-		client, err := NewClient(nil)
+		client, err := NewClient(nil, "")
 		require.NoError(t, err)
 		require.NotNil(t, client)
 	})
 
 	t.Run("WithUserAgent", func(t *testing.T) {
-		client, err := NewClient(nil, WithUserAgent("TEST"))
+		client, err := NewClient(nil, "", WithUserAgent("TEST"))
 		require.NoError(t, err)
 		require.Equal(t, "TEST", client.cfg.userAgent)
 	})
 
 	t.Run("WithDialer with timeout", func(t *testing.T) {
 		dialer := net.Dialer{Timeout: 5 * time.Second}
-		client, err := NewClient(nil, WithDialer(dialer))
+		client, err := NewClient(nil, "", WithDialer(dialer))
 		require.NoError(t, err)
 		require.Equal(t, dialer, client.cfg.dialer)
 	})
@@ -44,7 +45,7 @@ func TestClient(t *testing.T) {
 	t.Run("WithDialer missing timeout should use default", func(t *testing.T) {
 		// Mostly defensive to ensure that some timeout is set.
 		dialer := net.Dialer{LocalAddr: &net.TCPAddr{IP: net.ParseIP("::")}}
-		client, err := NewClient(nil, WithDialer(dialer))
+		client, err := NewClient(nil, "", WithDialer(dialer))
 		require.NoError(t, err)
 
 		expectedDialer := dialer
@@ -60,7 +61,7 @@ func TestClient(t *testing.T) {
 		}
 		client, err := NewClient(&HTTPClientConfig{
 			OAuth2: oauth2Config,
-		})
+		}, "")
 		require.NoError(t, err)
 
 		require.NotNil(t, client.oauth2TokenSource)
@@ -77,7 +78,7 @@ func TestClient(t *testing.T) {
 		}
 		_, err := NewClient(&HTTPClientConfig{
 			OAuth2: oauth2Config,
-		})
+		}, "")
 		require.ErrorIs(t, err, ErrOAuth2TLSConfigInvalid)
 	})
 }
@@ -92,7 +93,7 @@ func TestSendWebhook(t *testing.T) {
 		got = r
 		w.WriteHeader(http.StatusOK)
 	}))
-	s, err := NewClient(nil, WithUserAgent("TEST"))
+	s, err := NewClient(nil, "", WithUserAgent("TEST"))
 	require.NoError(t, err)
 
 	// The method should be either POST or PUT.
@@ -177,7 +178,7 @@ func TestSendWebhookHMAC(t *testing.T) {
 		server := initServer(httptest.NewServer)
 		defer server.Close()
 
-		client, err := NewClient(nil)
+		client, err := NewClient(nil, "")
 		require.NoError(t, err)
 		webhook := &receivers.SendWebhookSettings{
 			URL:        server.URL,
@@ -209,7 +210,7 @@ func TestSendWebhookHMAC(t *testing.T) {
 		cfg, err := tlsConfig.ToCryptoTLSConfig()
 		require.NoError(t, err)
 
-		client, err := NewClient(nil)
+		client, err := NewClient(nil, "")
 		require.NoError(t, err)
 		webhook := &receivers.SendWebhookSettings{
 			URL:        server.URL,
@@ -492,7 +493,7 @@ func TestSendWebhookOAuth2(t *testing.T) {
 				expectedProxyRequestCnt = 1
 			}
 
-			client, err := NewClient(&HTTPClientConfig{OAuth2: &oauthConfig}, tc.otherClientOpts...)
+			client, err := NewClient(&HTTPClientConfig{OAuth2: &oauthConfig}, "", tc.otherClientOpts...)
 			if tc.expClientError != nil {
 				assert.ErrorIs(t, err, tc.expClientError, "expected client creation error to match")
 				return
@@ -536,7 +537,7 @@ func TestToHTTPClientOption(t *testing.T) {
 		require.Empty(t, ToHTTPClientOption(nil))
 	})
 
-	var f ClientOption = func(configuration *clientConfiguration) {
+	var f ClientOption = func(configuration *clientConfiguration, _ string) {
 		configuration.userAgent = "test"
 		configuration.dialer = net.Dialer{Timeout: 5 * time.Second}
 		configuration.customDialer = true
@@ -547,5 +548,92 @@ func TestToHTTPClientOption(t *testing.T) {
 	// Verify number of fields using reflection
 	tp := reflect.TypeOf(clientConfiguration{})
 	// You need to increase the number of fields covered in this test, if you add a new field to the configuration struct.
-	require.Equalf(t, 3, tp.NumField(), "Not all fields are converted to HTTPClientOption, which means that the configuration will not be supported in upstream integrations")
+	// rateLimiter is intentionally not converted: it only gates Client.SendWebhook, which upstream integrations do not use.
+	require.Equalf(t, 4, tp.NumField(), "Not all fields are converted to HTTPClientOption, which means that the configuration will not be supported in upstream integrations")
+}
+
+func TestSendWebhookRateLimiter(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Run("nil limiter passes every request", func(t *testing.T) {
+		calls = 0
+		c, err := NewClient(nil, "", WithRateLimiter(nil))
+		require.NoError(t, err)
+		for i := 0; i < 3; i++ {
+			require.NoError(t, c.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL}))
+		}
+		require.Equal(t, 3, calls)
+	})
+
+	t.Run("shared limiter rejects with ErrWebhookRateLimited once burst is drained", func(t *testing.T) {
+		calls = 0
+		// burst 1, very slow refill: exactly one send allowed in the test window.
+		lim := rate.NewLimiter(rate.Limit(0.0001), 1)
+		c, err := NewClient(nil, "", WithRateLimiter(lim))
+		require.NoError(t, err)
+
+		require.NoError(t, c.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL}))
+		require.Equal(t, 1, calls)
+
+		// Bucket is drained; the next call must reject fast without hitting the server.
+		err = c.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL})
+		require.ErrorIs(t, err, ErrWebhookRateLimited)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("separate clients share a limiter", func(t *testing.T) {
+		// This is the multi-receiver property we rely on: two Clients built from the same
+		// *rate.Limiter drain one bucket together, so N configured receivers of the same
+		// integration type do not multiply the effective throughput.
+		calls = 0
+		lim := rate.NewLimiter(rate.Limit(0.0001), 1)
+		c1, err := NewClient(nil, "", WithRateLimiter(lim))
+		require.NoError(t, err)
+		c2, err := NewClient(nil, "", WithRateLimiter(lim))
+		require.NoError(t, err)
+
+		require.NoError(t, c1.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL}))
+		err = c2.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL})
+		require.ErrorIs(t, err, ErrWebhookRateLimited)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("WithRateLimiterByType selects by integration type", func(t *testing.T) {
+		// Two Clients built from the same map with different integration types must drain
+		// independent buckets. This is the per-type isolation property the factory relies on.
+		calls = 0
+		slackLim := rate.NewLimiter(rate.Limit(0.0001), 1)
+		webhookLim := rate.NewLimiter(rate.Limit(0.0001), 1)
+		limiters := map[string]*rate.Limiter{
+			"slack":   slackLim,
+			"webhook": webhookLim,
+		}
+
+		cSlack, err := NewClient(nil, "slack", WithRateLimiterByType(limiters))
+		require.NoError(t, err)
+		cWebhook, err := NewClient(nil, "webhook", WithRateLimiterByType(limiters))
+		require.NoError(t, err)
+		cOther, err := NewClient(nil, "pagerduty", WithRateLimiterByType(limiters))
+		require.NoError(t, err)
+
+		// slack and webhook each get one token; draining one must not affect the other.
+		require.NoError(t, cSlack.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL}))
+		err = cSlack.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL})
+		require.ErrorIs(t, err, ErrWebhookRateLimited)
+
+		require.NoError(t, cWebhook.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL}))
+		err = cWebhook.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL})
+		require.ErrorIs(t, err, ErrWebhookRateLimited)
+
+		// pagerduty has no entry in the map — no limit, every call passes.
+		for i := 0; i < 3; i++ {
+			require.NoError(t, cOther.SendWebhook(context.Background(), log.NewNopLogger(), &receivers.SendWebhookSettings{URL: server.URL}))
+		}
+		require.Equal(t, 5, calls) // 1 slack + 1 webhook + 3 pagerduty
+	})
 }

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -88,7 +88,7 @@ func BuildGrafanaReceiverIntegrations(
 		integrations []*Integration
 		errs         error
 		ci           = func(idx int, cfg receivers.Metadata, httpClientConfig *http.HTTPClientConfig, newInt func(cli *http.Client) notificationChannel) {
-			client, err := http.NewClient(httpClientConfig, httpClientOptions...)
+			client, err := http.NewClient(httpClientConfig, cfg.Type, httpClientOptions...)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed to create HTTP client for %q notifier %q (UID: %q): %w", cfg.Type, cfg.Name, cfg.UID, err))
 				return

--- a/receivers/email_rate_limiter.go
+++ b/receivers/email_rate_limiter.go
@@ -1,0 +1,38 @@
+package receivers
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/time/rate"
+)
+
+// ErrEmailRateLimited is returned by a rate-limited EmailSender when the
+// configured rate limit has been exceeded and a notification is dropped.
+var ErrEmailRateLimited = errors.New("email notifications are rate limited")
+
+// NewRateLimitedEmailSender wraps inner so that each SendEmail call consumes
+// one token from limiter. When no token is available the call is rejected
+// with ErrEmailRateLimited instead of being delayed, matching the existing
+// alertmanager rate-limited notifier semantics (no retry, drop the send).
+//
+// The caller owns limiter and may mutate it at runtime via SetLimit/SetBurst.
+// A nil limiter disables rate limiting.
+func NewRateLimitedEmailSender(inner EmailSender, limiter *rate.Limiter) EmailSender {
+	if limiter == nil {
+		return inner
+	}
+	return &rateLimitedEmailSender{inner: inner, limiter: limiter}
+}
+
+type rateLimitedEmailSender struct {
+	inner   EmailSender
+	limiter *rate.Limiter
+}
+
+func (s *rateLimitedEmailSender) SendEmail(ctx context.Context, cmd *SendEmailSettings) error {
+	if !s.limiter.Allow() {
+		return ErrEmailRateLimited
+	}
+	return s.inner.SendEmail(ctx, cmd)
+}

--- a/receivers/email_rate_limiter_test.go
+++ b/receivers/email_rate_limiter_test.go
@@ -1,0 +1,66 @@
+package receivers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+type fakeEmailSender struct {
+	calls int
+	err   error
+}
+
+func (f *fakeEmailSender) SendEmail(_ context.Context, _ *SendEmailSettings) error {
+	f.calls++
+	return f.err
+}
+
+func TestNewRateLimitedEmailSender_NilLimiterReturnsInner(t *testing.T) {
+	inner := &fakeEmailSender{}
+	got := NewRateLimitedEmailSender(inner, nil)
+	require.Same(t, inner, got)
+}
+
+func TestRateLimitedEmailSender_BlocksAllWhenRateZero(t *testing.T) {
+	inner := &fakeEmailSender{}
+	s := NewRateLimitedEmailSender(inner, rate.NewLimiter(0, 0))
+
+	err := s.SendEmail(context.Background(), &SendEmailSettings{})
+	require.ErrorIs(t, err, ErrEmailRateLimited)
+	require.Equal(t, 0, inner.calls)
+}
+
+func TestRateLimitedEmailSender_PassesThroughWhenUnlimited(t *testing.T) {
+	inner := &fakeEmailSender{}
+	s := NewRateLimitedEmailSender(inner, rate.NewLimiter(rate.Inf, 0))
+
+	for range 5 {
+		require.NoError(t, s.SendEmail(context.Background(), &SendEmailSettings{}))
+	}
+	require.Equal(t, 5, inner.calls)
+}
+
+func TestRateLimitedEmailSender_EnforcesBurst(t *testing.T) {
+	inner := &fakeEmailSender{}
+	// 1 token/sec, burst=2: first two calls succeed, third is rejected.
+	s := NewRateLimitedEmailSender(inner, rate.NewLimiter(1, 2))
+
+	require.NoError(t, s.SendEmail(context.Background(), &SendEmailSettings{}))
+	require.NoError(t, s.SendEmail(context.Background(), &SendEmailSettings{}))
+	require.ErrorIs(t, s.SendEmail(context.Background(), &SendEmailSettings{}), ErrEmailRateLimited)
+	require.Equal(t, 2, inner.calls)
+}
+
+func TestRateLimitedEmailSender_PropagatesInnerError(t *testing.T) {
+	sentinel := errors.New("boom")
+	inner := &fakeEmailSender{err: sentinel}
+	s := NewRateLimitedEmailSender(inner, rate.NewLimiter(rate.Inf, 0))
+
+	err := s.SendEmail(context.Background(), &SendEmailSettings{})
+	require.ErrorIs(t, err, sentinel)
+	require.Equal(t, 1, inner.calls)
+}


### PR DESCRIPTION
## Summary

Adds two primitives that let callers apply per-tenant rate limits to alert notifications. Both decorate existing code paths without changing default behavior (a nil limiter or absent map entry is a no-op).

- **SMTP layer**: `NewRateLimitedEmailSender` decorates an `EmailSender` so each `SendEmail` call consumes one token from a caller-provided `*rate.Limiter`. Rejected sends return `ErrEmailRateLimited` (drop, no retry), matching the upstream alertmanager rate-limited-notifier semantics.

- **HTTP layer**: `ClientOption` is widened to take the integration type as a second arg, so options can vary per integration. `NewClient` now takes the integration type positionally; existing options (`WithUserAgent`, `WithDialer`) ignore it. Two new options:
  - `WithRateLimiter(*rate.Limiter)` - unconditional.
  - `WithRateLimiterByType(map[string]*rate.Limiter)` - selects the limiter for the Client's integration type; no-op for unmapped types.

  `SendWebhook` consults the limiter once per call before dialing; rejected calls return `ErrWebhookRateLimited`.

Callers own limiter lifetimes and may reconfigure them in place via `SetLimit`/`SetBurst`. To avoid data races when the backing map is mutated concurrently, callers should pass a snapshot into `WithRateLimiterByType`.

## Breaking changes

- `NewClient` signature: `NewClient(cfg, opts...)` - `NewClient(cfg, integrationType, opts...)`. Pass `""` when the client is not tied to a specific integration.
- `ClientOption` signature: `func(*clientConfiguration)` - `func(*clientConfiguration, string)`. Existing custom options need to add `_ string` to their closure.

## Test plan

- [x] `go test ./...` passes
- [x] `TestSendWebhookRateLimiter` covers: `Allow` accept/reject, `WithRateLimiterByType` selects by integration type, nil limiter is a no-op
- [x] `TestNewRateLimitedEmailSender` covers: accept, reject with `ErrEmailRateLimited`, nil limiter passthrough, in-place reconfig via `SetLimit`/`SetBurst`