### PR TITLE
Allow empty receiver names in validation

### DIFF
--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -258,9 +258,9 @@ func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decode De
 
 func ValidateAPIReceiver(ctx context.Context, api *APIReceiver, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
 	var errs []error
-	if api.Name == "" {
-		errs = append(errs, fmt.Errorf("receiver name is required"))
-	}
+	// if api.Name == "" {
+	// 	errs = append(errs, fmt.Errorf("receiver name is required"))
+	// }
 	if err := api.Validate(); err != nil {
 		errs = append(errs, err)
 	}

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -675,12 +675,12 @@ func TestValidateAPIReceiver(t *testing.T) {
 		}
 	})
 
-	t.Run("returns error when receiver name is empty", func(t *testing.T) {
-		api := &APIReceiver{}
-		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "receiver name is required")
-	})
+	// t.Run("returns error when receiver name is empty", func(t *testing.T) {
+	// 	api := &APIReceiver{}
+	// 	err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
+	// 	require.Error(t, err)
+	// 	require.ErrorContains(t, err, "receiver name is required")
+	// })
 
 	t.Run("returns error for unknown integration type", func(t *testing.T) {
 		raw := &models.IntegrationConfig{


### PR DESCRIPTION
Revert check for empty name of receivers 

Related to #534 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes validation to allow unnamed receivers, which may change downstream assumptions about receiver identification and could surface as subtle runtime or UX issues if names are expected elsewhere.
> 
> **Overview**
> `ValidateAPIReceiver` no longer enforces a non-empty receiver `Name`, allowing API receivers to pass validation even when unnamed.
> 
> The corresponding unit test asserting an error for empty receiver names is disabled to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a364ae6fb910e38e8412ea394c867831ec1e2bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->