### PR TITLE
Copy PostableMimirReceiverToPostableGrafanaReceiver from Grafana

### DIFF
--- a/notify/compat.go
+++ b/notify/compat.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"reflect"
 	"slices"
 
@@ -48,6 +49,59 @@ func PostableGrafanaReceiverToIntegrationConfig(r *definition.PostableGrafanaRec
 		Settings:              json.RawMessage(r.Settings),
 		SecureSettings:        r.SecureSettings,
 	}
+}
+
+// PostableMimirReceiverToPostableGrafanaReceiver converts all legacy models to apimodels.PostableGrafanaReceiver.
+// If receiver does not have any legacy receivers, returns the original receiver.
+// Otherwise, returns a copy that contains converted integrations (and shallow copy of existing Grafana integrations).
+func PostableMimirReceiverToPostableGrafanaReceiver(r *definition.PostableApiReceiver) (*definition.PostableApiReceiver, error) {
+	if !r.HasMimirIntegrations() {
+		return r, nil
+	}
+	v0, err := ConfigReceiverToMimirIntegrations(r.Receiver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert v0 receiver to integrations: %w", err)
+	}
+	result := &definition.PostableApiReceiver{
+		Receiver: definition.Receiver{
+			Name: r.Name,
+		},
+		PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+			GrafanaManagedReceivers: make([]*definition.PostableGrafanaReceiver, 0, len(v0)+len(r.GrafanaManagedReceivers)),
+		},
+	}
+	result.GrafanaManagedReceivers = append(result.GrafanaManagedReceivers, r.GrafanaManagedReceivers...)
+	typeCount := make(map[string]int)
+	for _, config := range v0 {
+		integrationType := string(config.Schema.Type())
+		idx := typeCount[integrationType]
+		typeCount[integrationType]++
+		integration, err := MimirIntegrationConfigToPostableGrafanaReceiver(config, r.Name, idx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert Mimir integration config to PostableGrafanaReceiver: %w", err)
+		}
+		result.GrafanaManagedReceivers = append(result.GrafanaManagedReceivers, integration)
+	}
+	return result, nil
+}
+
+// MimirIntegrationConfigToPostableGrafanaReceiver Converts a Mimir integration configuration to a PostableGrafanaReceiver. All settings are unencrypted. Needs to be encrypted later.
+func MimirIntegrationConfigToPostableGrafanaReceiver(config MimirIntegrationConfig, receiverName string, idx int) (*definition.PostableGrafanaReceiver, error) {
+	raw, err := config.ConfigJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	return &definition.PostableGrafanaReceiver{
+		// mimirIntegrationUID generates a stable, fixed-length UID for a converted Mimir integration that passes ValidateUID, 40-char limit for long names in particular
+		UID:                   mimirIntegrationUID(receiverName, string(config.Schema.Type()), idx),
+		Name:                  receiverName,
+		Type:                  string(config.Schema.Type()),
+		Version:               string(config.Schema.Version),
+		DisableResolveMessage: false, // V0 ignore this flag as they have their own SendResolved one.
+		Settings:              raw,
+		SecureSettings:        nil,
+	}, nil
 }
 
 // PostableAPITemplateToTemplateDefinition converts a definition.PostableApiTemplate to a templates.TemplateDefinition
@@ -128,4 +182,10 @@ func ConfigReceiverToMimirIntegrations(receiver ConfigReceiver) ([]MimirIntegrat
 		}
 	}
 	return result, nil
+}
+
+func mimirIntegrationUID(receiverName string, integrationType string, idx int) string {
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "%s-%s-%d", receiverName, integrationType, idx)
+	return fmt.Sprintf("%016x", h.Sum64())
 }

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/alerting/receivers/teams"
 	teams_v0mimir1 "github.com/grafana/alerting/receivers/teams/v0mimir1"
 	teams_v0mimir2 "github.com/grafana/alerting/receivers/teams/v0mimir2"
+	webhookV0 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
 )
 
 func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
@@ -181,5 +182,96 @@ func TestConfigReceiverToMimirIntegrations(t *testing.T) {
 		actual, err = ConfigReceiverToMimirIntegrations(ConfigReceiver{Name: "empty"})
 		require.NoError(t, err)
 		require.Empty(t, actual)
+	})
+}
+
+func TestPostableMimirReceiverToPostableGrafanaReceiver(t *testing.T) {
+	t.Run("returns original pointer when receiver has only Grafana integrations", func(t *testing.T) {
+		receiver := &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{Name: "test"},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+					{UID: "grafana-uid", Name: "test", Type: "email"},
+				},
+			},
+		}
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		assert.Same(t, receiver, result)
+	})
+
+	t.Run("converts Mimir integrations to Grafana integrations", func(t *testing.T) {
+		wh := webhookV0.GetFullValidConfig()
+		receiver := &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name:           "test-receiver",
+				WebhookConfigs: []*webhookV0.Config{&wh},
+			},
+		}
+
+		mimirConfigs, err := ConfigReceiverToMimirIntegrations(receiver.Receiver)
+		require.NoError(t, err)
+		require.Len(t, mimirConfigs, 1)
+		expectedJSON, err := mimirConfigs[0].ConfigJSON()
+		require.NoError(t, err)
+
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotSame(t, receiver, result)
+		require.Len(t, result.GrafanaManagedReceivers, 1)
+
+		converted := result.GrafanaManagedReceivers[0]
+		assert.Equal(t, "test-receiver", result.Name)
+		assert.Equal(t, "test-receiver", converted.Name)
+		assert.Equal(t, mimirIntegrationUID("test-receiver", "webhook", 0), converted.UID)
+		assert.JSONEq(t, string(expectedJSON), string(converted.Settings))
+		assert.False(t, converted.DisableResolveMessage)
+		assert.Nil(t, converted.SecureSettings)
+		assert.False(t, result.HasMimirIntegrations())
+	})
+
+	t.Run("existing Grafana integrations appear before converted Mimir ones", func(t *testing.T) {
+		wh := webhookV0.GetFullValidConfig()
+		grafanaRecv := &definition.PostableGrafanaReceiver{
+			UID:  "existing-uid",
+			Name: "existing",
+			Type: "email",
+		}
+		receiver := &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name:           "mixed-receiver",
+				WebhookConfigs: []*webhookV0.Config{&wh},
+			},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{grafanaRecv},
+			},
+		}
+
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		require.Len(t, result.GrafanaManagedReceivers, 2)
+		assert.Same(t, grafanaRecv, result.GrafanaManagedReceivers[0])
+		assert.Equal(t, "webhook", result.GrafanaManagedReceivers[1].Type)
+	})
+
+	t.Run("assigns per-type UIDs to converted Mimir integrations", func(t *testing.T) {
+		// UIDs are indexed per integration type, so each type starts at 0.
+		em := email_v0mimir1.GetFullValidConfig()
+		wh := webhookV0.GetFullValidConfig()
+		receiver := &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name:           "multi-receiver",
+				EmailConfigs:   []*email_v0mimir1.Config{&em},
+				WebhookConfigs: []*webhookV0.Config{&wh},
+			},
+		}
+
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		require.Len(t, result.GrafanaManagedReceivers, 2)
+
+		assert.Equal(t, mimirIntegrationUID("multi-receiver", "email", 0), result.GrafanaManagedReceivers[0].UID)
+		assert.Equal(t, mimirIntegrationUID("multi-receiver", "webhook", 0), result.GrafanaManagedReceivers[1].UID)
 	})
 }


### PR DESCRIPTION
Copies conversion logic for upstream Receiver integrations into Grafana integrations from Grafana  https://github.com/grafana/grafana/blob/eb69281eea3851d27768311f15ef82630ef35d9b/pkg/services/ngalert/notifier/legacy_storage/compat.go#L137

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new conversion logic that mutates how legacy (Mimir) receiver integrations are represented and assigns new deterministic UIDs, which can affect notification routing/migrations if assumptions differ. Covered by unit tests but still touches alerting receiver compatibility paths.
> 
> **Overview**
> Adds `PostableMimirReceiverToPostableGrafanaReceiver` to convert legacy Mimir receiver integration fields into `GrafanaManagedReceivers` when `HasMimirIntegrations()` is true, leaving Grafana-only receivers untouched.
> 
> Converted integrations are emitted with unencrypted `Settings`, `SecureSettings=nil`, `DisableResolveMessage=false`, and a deterministic 16-hex UID generated via FNV hash (`mimirIntegrationUID`) using receiver name, integration type, and a per-type index; existing Grafana integrations are preserved and kept first.
> 
> Extends `compat_test.go` with coverage for no-op behavior, conversion correctness/ordering, and UID indexing across multiple integration types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada07ed67cceb93b403517fe6f3147a4408004c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->