### PR TITLE
jira exclude already-closed issues from the resolve search

### DIFF
--- a/receivers/jira/v1/jira.go
+++ b/receivers/jira/v1/jira.go
@@ -278,7 +278,6 @@ func getSearchJql(conf Config, groupID string, firing bool) issueSearch {
 		jql.WriteString(fmt.Sprintf(`resolution != %q and `, conf.WontFixResolution))
 	}
 
-	// If the group is firing, do not search for closed issues unless a reopen transition is defined.
 	if firing {
 		if conf.ReopenTransition == "" {
 			jql.WriteString(`statusCategory != Done and `)
@@ -287,6 +286,8 @@ func getSearchJql(conf Config, groupID string, firing bool) issueSearch {
 		reopenDuration := int64(time.Duration(conf.ReopenDuration).Minutes())
 		if reopenDuration != 0 {
 			jql.WriteString(fmt.Sprintf(`(resolutiondate is EMPTY OR resolutiondate >= -%dm) and `, reopenDuration))
+		} else {
+			jql.WriteString(`statusCategory != Done and `)
 		}
 	}
 

--- a/receivers/jira/v1/jira_test.go
+++ b/receivers/jira/v1/jira_test.go
@@ -487,7 +487,7 @@ func TestGetSearchJql(t *testing.T) {
 				Project: "TEST",
 			},
 			firing:      false,
-			expectedJql: `labels = "ALERT{group1}" and project="TEST" order by status ASC,resolutiondate DESC`,
+			expectedJql: `statusCategory != Done and labels = "ALERT{group1}" and project="TEST" order by status ASC,resolutiondate DESC`,
 		},
 		{
 			name: "resolved and reopen duration specified",
@@ -505,7 +505,7 @@ func TestGetSearchJql(t *testing.T) {
 				WontFixResolution: "won't fix",
 			},
 			firing:      false,
-			expectedJql: `resolution != "won't fix" and labels = "ALERT{group1}" and project="TEST" order by status ASC,resolutiondate DESC`,
+			expectedJql: `resolution != "won't fix" and statusCategory != Done and labels = "ALERT{group1}" and project="TEST" order by status ASC,resolutiondate DESC`,
 		},
 		{
 			name: "resolved and custom dedup key field",
@@ -514,7 +514,7 @@ func TestGetSearchJql(t *testing.T) {
 				DedupKeyFieldName: "12345",
 			},
 			firing:      false,
-			expectedJql: `(labels = "ALERT{group1}" or cf[12345] ~ "group1") and project="TEST" order by status ASC,resolutiondate DESC`,
+			expectedJql: `statusCategory != Done and (labels = "ALERT{group1}" or cf[12345] ~ "group1") and project="TEST" order by status ASC,resolutiondate DESC`,
 		},
 	}
 


### PR DESCRIPTION
When an alert resolves, the Jira receiver searches Jira for the existing ticket to close. Without reopen_duration set, the search did not filter out tickets that were already in a Done status, so an old closed ticket sharing the same dedup label could sort ahead of the active ticket, since Jira orders statuses alphabetically and Closed comes before most active states. The receiver would then try to close the wrong ticket and the active one stayed open. Mirror the firing path and add statusCategory != Done to the resolve query when reopen_duration is unset, so only currently open tickets are considered. Refs grafana/grafana#123885.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JQL used to find existing Jira issues on alert resolution, which can affect which ticket is selected and transitioned. Scope is small and covered by updated unit tests, but impacts alert-to-ticket lifecycle behavior.
> 
> **Overview**
> Ensures the Jira receiver’s *resolve* lookup query excludes already-closed issues by adding `statusCategory != Done` when `reopen_duration` is not set, matching the existing firing-path behavior.
> 
> Updates `TestGetSearchJql` expectations to reflect the new filter for resolved alerts across default, wont-fix, and custom dedup-key configurations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ab111be797b04cd3eecb61b441c18d46ed6521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->