### PR TITLE
Remove support for building integrations from Prometheus models

### DIFF
--- a/models/integration.go
+++ b/models/integration.go
@@ -17,5 +17,6 @@ type IntegrationConfig struct {
 }
 
 type ReceiverConfig struct {
+	Name         string               `yaml:"name" json:"name"`
 	Integrations []*IntegrationConfig `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
 }

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -13,10 +13,10 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func PostableAPIReceiversToAPIReceivers(r []*definition.PostableApiReceiver) []models.ReceiverConfig {
+func PostableAPIReceiversToReceiverConfigs(r []*definition.PostableApiReceiver) []models.ReceiverConfig {
 	result := make([]models.ReceiverConfig, 0, len(r))
 	for _, receiver := range r {
-		result = append(result, PostableAPIReceiverToAPIReceiver(receiver))
+		result = append(result, PostableAPIReceiverToReceiverConfig(receiver))
 	}
 	return result
 }

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -13,26 +13,23 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func PostableAPIReceiversToAPIReceivers(r []*definition.PostableApiReceiver) []*APIReceiver {
-	result := make([]*APIReceiver, 0, len(r))
+func PostableAPIReceiversToAPIReceivers(r []*definition.PostableApiReceiver) []models.ReceiverConfig {
+	result := make([]models.ReceiverConfig, 0, len(r))
 	for _, receiver := range r {
 		result = append(result, PostableAPIReceiverToAPIReceiver(receiver))
 	}
 	return result
 }
 
-func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) *APIReceiver {
-	integrations := models.ReceiverConfig{
+func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) models.ReceiverConfig {
+	result := models.ReceiverConfig{
+		Name:         r.Name,
 		Integrations: make([]*models.IntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
 	}
 	for _, p := range r.GrafanaManagedReceivers {
-		integrations.Integrations = append(integrations.Integrations, PostableGrafanaReceiverToIntegrationConfig(p))
+		result.Integrations = append(result.Integrations, PostableGrafanaReceiverToIntegrationConfig(p))
 	}
-
-	return &APIReceiver{
-		ConfigReceiver: r.Receiver,
-		ReceiverConfig: integrations,
-	}
+	return result
 }
 
 func PostableGrafanaReceiverToIntegrationConfig(r *definition.PostableGrafanaReceiver) *models.IntegrationConfig {

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -21,7 +21,7 @@ func PostableAPIReceiversToAPIReceivers(r []*definition.PostableApiReceiver) []m
 	return result
 }
 
-func PostableAPIReceiverToAPIReceiver(r *definition.PostableApiReceiver) models.ReceiverConfig {
+func PostableAPIReceiverToReceiverConfig(r *definition.PostableApiReceiver) models.ReceiverConfig {
 	result := models.ReceiverConfig{
 		Name:         r.Name,
 		Integrations: make([]*models.IntegrationConfig, 0, len(r.GrafanaManagedReceivers)),

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -29,7 +29,7 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 		}
 		actual := PostableAPIReceiverToAPIReceiver(r)
 		require.Empty(t, actual.Integrations)
-		require.Equal(t, r.Receiver, actual.ConfigReceiver)
+		require.Equal(t, r.Receiver.Name, actual.Name)
 	})
 	t.Run("converts receivers", func(t *testing.T) {
 		r := &definition.PostableApiReceiver{
@@ -63,7 +63,7 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 		}
 		actual := PostableAPIReceiverToAPIReceiver(r)
 		require.Len(t, actual.Integrations, 2)
-		require.Equal(t, r.Receiver, actual.ConfigReceiver)
+		require.Equal(t, r.Receiver.Name, actual.Name)
 		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[0]), *actual.Integrations[0])
 		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[1]), *actual.Integrations[1])
 	})

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -27,7 +27,7 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 				Name: "test-receiver",
 			},
 		}
-		actual := PostableAPIReceiverToAPIReceiver(r)
+		actual := PostableAPIReceiverToReceiverConfig(r)
 		require.Empty(t, actual.Integrations)
 		require.Equal(t, r.Name, actual.Name)
 	})
@@ -61,7 +61,7 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 				},
 			},
 		}
-		actual := PostableAPIReceiverToAPIReceiver(r)
+		actual := PostableAPIReceiverToReceiverConfig(r)
 		require.Len(t, actual.Integrations, 2)
 		require.Equal(t, r.Name, actual.Name)
 		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[0]), *actual.Integrations[0])
@@ -96,7 +96,7 @@ func TestPostableGrafanaReceiverToGrafanaIntegrationConfig(t *testing.T) {
 
 func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
 	t.Run("returns empty when no receivers", func(t *testing.T) {
-		actual := PostableAPIReceiversToAPIReceivers(nil)
+		actual := PostableAPIReceiversToReceiverConfigs(nil)
 		require.Empty(t, actual)
 	})
 	receivers := []*definition.PostableApiReceiver{
@@ -139,11 +139,11 @@ func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
 			},
 		},
 	}
-	actual := PostableAPIReceiversToAPIReceivers(receivers)
+	actual := PostableAPIReceiversToReceiverConfigs(receivers)
 
 	require.Len(t, actual, 2)
-	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[0]), actual[0])
-	require.Equal(t, PostableAPIReceiverToAPIReceiver(receivers[1]), actual[1])
+	require.Equal(t, PostableAPIReceiverToReceiverConfig(receivers[0]), actual[0])
+	require.Equal(t, PostableAPIReceiverToReceiverConfig(receivers[1]), actual[1])
 }
 
 func TestConfigReceiverToMimirIntegrations(t *testing.T) {

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -29,7 +29,7 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 		}
 		actual := PostableAPIReceiverToAPIReceiver(r)
 		require.Empty(t, actual.Integrations)
-		require.Equal(t, r.Receiver.Name, actual.Name)
+		require.Equal(t, r.Name, actual.Name)
 	})
 	t.Run("converts receivers", func(t *testing.T) {
 		r := &definition.PostableApiReceiver{
@@ -63,7 +63,7 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 		}
 		actual := PostableAPIReceiverToAPIReceiver(r)
 		require.Len(t, actual.Integrations, 2)
-		require.Equal(t, r.Receiver.Name, actual.Name)
+		require.Equal(t, r.Name, actual.Name)
 		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[0]), *actual.Integrations[0])
 		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[1]), *actual.Integrations[1])
 	})

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -4,20 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/types"
-	commoncfg "github.com/prometheus/common/config"
 
-	"github.com/prometheus/alertmanager/template"
-
-	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/images"
+	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/receivers"
 	alertmanager "github.com/grafana/alerting/receivers/alertmanager/v1"
@@ -45,22 +40,6 @@ import (
 	webhook "github.com/grafana/alerting/receivers/webhook/v1"
 	wecom "github.com/grafana/alerting/receivers/wecom/v1"
 	"github.com/grafana/alerting/templates"
-
-	discord_v0mimir1 "github.com/grafana/alerting/receivers/discord/v0mimir1"
-	email_v0mimir1 "github.com/grafana/alerting/receivers/email/v0mimir1"
-	jira_v0mimir1 "github.com/grafana/alerting/receivers/jira/v0mimir1"
-	opsgenie_v0mimir1 "github.com/grafana/alerting/receivers/opsgenie/v0mimir1"
-	pagerduty_v0mimir1 "github.com/grafana/alerting/receivers/pagerduty/v0mimir1"
-	pushover_v0mimir1 "github.com/grafana/alerting/receivers/pushover/v0mimir1"
-	slack_v0mimir1 "github.com/grafana/alerting/receivers/slack/v0mimir1"
-	sns_v0mimir1 "github.com/grafana/alerting/receivers/sns/v0mimir1"
-	teams_v0mimir1 "github.com/grafana/alerting/receivers/teams/v0mimir1"
-	teams_v0mimir2 "github.com/grafana/alerting/receivers/teams/v0mimir2"
-	telegram_v0mimir1 "github.com/grafana/alerting/receivers/telegram/v0mimir1"
-	victorops_v0mimir1 "github.com/grafana/alerting/receivers/victorops/v0mimir1"
-	webex_v0mimir1 "github.com/grafana/alerting/receivers/webex/v0mimir1"
-	webhook_v0mimir1 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
-	wechat_v0mimir1 "github.com/grafana/alerting/receivers/wechat/v0mimir1"
 )
 
 type WrapNotifierFunc func(integrationName string, notifier nfstatus.Notifier) nfstatus.Notifier
@@ -219,105 +198,12 @@ func BuildGrafanaReceiverIntegrations(
 	return integrations, errs
 }
 
-// BuildPrometheusReceiverIntegrations builds a list of integration notifiers off of a receiver config.
-// Taken from https://github.com/grafana/mimir/blob/fa489e696481fe0b7b97598077565dc5027afa84/pkg/alertmanager/alertmanager.go#L754
-// which is taken from https://github.com/prometheus/alertmanager/blob/94d875f1227b29abece661db1a68c001122d1da5/cmd/alertmanager/main.go#L112-L159.
-func BuildPrometheusReceiverIntegrations(
-	nc definition.Receiver,
-	tmplProvider TemplatesProvider,
-	httpClientOptions []http.ClientOption,
-	logger log.Logger,
-	wrapper WrapNotifierFunc,
-	notificationHistorian nfstatus.NotificationHistorian,
-) ([]*nfstatus.Integration, error) {
-	var (
-		errs         types.MultiError
-		integrations []*nfstatus.Integration
-		tmpl         *template.Template
-		httpOps      []commoncfg.HTTPClientOption
-		initOnce     = sync.OnceFunc(func() { // lazy evaluate template so we do not create one if we don't need it
-			httpOps = http.ToHTTPClientOption(httpClientOptions...)
-			t, err := tmplProvider.GetTemplate(templates.MimirKind)
-			if err != nil {
-				errs.Add(err)
-				return
-			}
-			tmpl = t.Template
-		})
-		add = func(name string, i int, rs notify.ResolvedSender, f func(l log.Logger) (notify.Notifier, error)) {
-			initOnce()
-			integrationLogger := log.With(logger, "integration", name)
-			n, err := f(integrationLogger)
-			if err != nil {
-				errs.Add(err)
-				return
-			}
-			nw := nfstatus.NewNotifierAdapter(n)
-			if wrapper != nil {
-				nw = wrapper(name, nw)
-			}
-			integrations = append(integrations, nfstatus.NewIntegration(nw, rs, name, i, nc.Name, notificationHistorian, integrationLogger))
-		}
-	)
-
-	for i, c := range nc.WebhookConfigs {
-		add("webhook", i, c, func(l log.Logger) (notify.Notifier, error) { return webhook_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.EmailConfigs {
-		add("email", i, c, func(l log.Logger) (notify.Notifier, error) { return email_v0mimir1.New(c, tmpl, l), nil })
-	}
-	for i, c := range nc.PagerdutyConfigs {
-		add("pagerduty", i, c, func(l log.Logger) (notify.Notifier, error) { return pagerduty_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.OpsGenieConfigs {
-		add("opsgenie", i, c, func(l log.Logger) (notify.Notifier, error) { return opsgenie_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.WechatConfigs {
-		add("wechat", i, c, func(l log.Logger) (notify.Notifier, error) { return wechat_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.SlackConfigs {
-		add("slack", i, c, func(l log.Logger) (notify.Notifier, error) { return slack_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.VictorOpsConfigs {
-		add("victorops", i, c, func(l log.Logger) (notify.Notifier, error) { return victorops_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.PushoverConfigs {
-		add("pushover", i, c, func(l log.Logger) (notify.Notifier, error) { return pushover_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.SNSConfigs {
-		add("sns", i, c, func(l log.Logger) (notify.Notifier, error) { return sns_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.TelegramConfigs {
-		add("telegram", i, c, func(l log.Logger) (notify.Notifier, error) { return telegram_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.DiscordConfigs {
-		add("discord", i, c, func(l log.Logger) (notify.Notifier, error) { return discord_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.WebexConfigs {
-		add("webex", i, c, func(l log.Logger) (notify.Notifier, error) { return webex_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.MSTeamsConfigs {
-		add("msteams", i, c, func(l log.Logger) (notify.Notifier, error) { return teams_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.MSTeamsV2Configs {
-		add("msteamsv2", i, c, func(l log.Logger) (notify.Notifier, error) { return teams_v0mimir2.New(c, tmpl, l, httpOps...) })
-	}
-	for i, c := range nc.JiraConfigs {
-		add("jira", i, c, func(l log.Logger) (notify.Notifier, error) { return jira_v0mimir1.New(c, tmpl, l, httpOps...) })
-	}
-	// If we add support for more integrations, we need to add them to validation as well. See validation.allowedIntegrationNames field.
-	if errs.Len() > 0 {
-		return nil, &errs
-	}
-	return integrations, nil
-}
-
 // BuildReceiversIntegrations builds integrations for the provided API receivers and returns them mapped by receiver name.
 // It ensures uniqueness of receivers by the name, overwriting duplicates and logs warnings.
 // Returns an error if any integration fails during its construction.
 func BuildReceiversIntegrations(
 	tenantID int64,
-	apiReceivers []*APIReceiver,
+	receivers []models.ReceiverConfig,
 	templ TemplatesProvider,
 	images images.Provider,
 	decryptFn GetDecryptedValueFn,
@@ -330,8 +216,8 @@ func BuildReceiversIntegrations(
 	notificationHistorian nfstatus.NotificationHistorian,
 	useManifestBuilder bool,
 ) (map[string][]*Integration, error) {
-	nameToReceiver := make(map[string]*APIReceiver, len(apiReceivers))
-	for _, receiver := range apiReceivers {
+	nameToReceiver := make(map[string]models.ReceiverConfig, len(receivers))
+	for _, receiver := range receivers {
 		if existing, ok := nameToReceiver[receiver.Name]; ok {
 			itypes := make([]string, 0, len(existing.Integrations))
 			for _, i := range existing.Integrations {
@@ -342,7 +228,7 @@ func BuildReceiversIntegrations(
 		nameToReceiver[receiver.Name] = receiver
 	}
 
-	integrationsMap := make(map[string][]*Integration, len(apiReceivers))
+	integrationsMap := make(map[string][]*Integration, len(receivers))
 	for name, apiReceiver := range nameToReceiver {
 		var integrations []*Integration
 		var err error
@@ -363,7 +249,7 @@ func BuildReceiversIntegrations(
 // It supports both Prometheus and Grafana integrations and ensures that both of them use only templates dedicated for the kind.
 func BuildReceiverIntegrations(
 	tenantID int64,
-	receiver *APIReceiver,
+	receiver models.ReceiverConfig,
 	tmpls TemplatesProvider,
 	images images.Provider,
 	decryptFn GetDecryptedValueFn,
@@ -401,23 +287,16 @@ func BuildReceiverIntegrations(
 			return nil, err
 		}
 	}
-	mimir, err := BuildPrometheusReceiverIntegrations(receiver.ConfigReceiver, tmpls, httpClientOptions, logger, wrapNotifierFunc, notificationHistorian)
-	if err != nil {
-		return nil, err
-	}
-	integrations = append(integrations, mimir...)
-
 	return integrations, nil
 }
 
 // BuildReceiverIntegrationsWithManifests builds integrations for the provided API receiver using
 // the manifest-based factory for v1 (Grafana) integrations instead of the typed config switch.
-// Prometheus integrations are still built via BuildPrometheusReceiverIntegrations.
 // Unlike BuildGrafanaReceiverIntegrations, this function is fail-fast: it returns on the first
 // error without returning partial results.
 func BuildReceiverIntegrationsWithManifests(
 	tenantID int64,
-	receiver *APIReceiver,
+	receiver models.ReceiverConfig,
 	tmpls TemplatesProvider,
 	images images.Provider,
 	decryptFn GetDecryptedValueFn,
@@ -512,10 +391,5 @@ func BuildReceiverIntegrationsWithManifests(
 			integrations = append(integrations, NewIntegration(wrapped, n, string(cfg.Type), idx, cfg.Name, notificationHistorian, logger))
 		}
 	}
-	mimir, err := BuildPrometheusReceiverIntegrations(receiver.ConfigReceiver, tmpls, httpClientOptions, logger, wrapNotifierFunc, notificationHistorian)
-	if err != nil {
-		return nil, err
-	}
-	integrations = append(integrations, mimir...)
 	return integrations, nil
 }

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -246,7 +246,6 @@ func BuildReceiversIntegrations(
 }
 
 // BuildReceiverIntegrations builds integrations for the provided API receiver and returns them.
-// It supports both Prometheus and Grafana integrations and ensures that both of them use only templates dedicated for the kind.
 func BuildReceiverIntegrations(
 	tenantID int64,
 	receiver models.ReceiverConfig,

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -15,17 +15,13 @@ import (
 
 	"github.com/prometheus/alertmanager/notify"
 
-	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/http"
-	"github.com/grafana/alerting/http/v0mimir"
-	"github.com/grafana/alerting/http/v0mimir/v0mimirtest"
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
-	webhook_v0mimir1 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
 	"github.com/grafana/alerting/templates"
 )
 
@@ -42,7 +38,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	}
 
 	getFullConfig := func(t *testing.T) (GrafanaReceiverConfig, int) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
@@ -141,25 +137,11 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 	emailService := receivers.MockNotificationService()
 
 	t.Run("should build receivers", func(t *testing.T) {
-		apiReceivers := []*APIReceiver{
+		apiReceivers := []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "test1",
-					WebhookConfigs: []*webhook_v0mimir1.Config{
-						{
-							HTTPConfig: &v0mimir.DefaultHTTPClientConfig,
-						},
-					},
-				},
-			},
-			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "test2",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test2"),
-					},
+				Name: "test2",
+				Integrations: []*models.IntegrationConfig{
+					notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test2"),
 				},
 			},
 		}
@@ -182,8 +164,6 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			true,
 		)
 		require.NoError(t, err)
-		require.Contains(t, actual, "test1")
-		require.Equal(t, "webhook[0]", actual["test1"][0].String())
 		require.Contains(t, actual, "test2")
 		require.Equal(t, "email[0]", actual["test2"][0].String())
 
@@ -206,33 +186,24 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 				false,
 			)
 			require.NoError(t, err)
-			require.Contains(t, actual, "test1")
-			require.Equal(t, "webhook[0]", actual["test1"][0].String())
 			require.Contains(t, actual, "test2")
 			require.Equal(t, "email[0]", actual["test2"][0].String())
 		})
 	})
 
 	t.Run("should ignore duplicates", func(t *testing.T) {
-		apiReceivers := []*APIReceiver{
+		apiReceivers := []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "test",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test"),
-					},
+
+				Name: "test",
+				Integrations: []*models.IntegrationConfig{
+					notifytest.AllKnownV1ConfigsForTesting["email"].GetRawNotifierConfig("test"),
 				},
 			},
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "test",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						notifytest.AllKnownV1ConfigsForTesting["webhook"].GetRawNotifierConfig("test"),
-					},
+				Name: "test",
+				Integrations: []*models.IntegrationConfig{
+					notifytest.AllKnownV1ConfigsForTesting["webhook"].GetRawNotifierConfig("test"),
 				},
 			},
 		}
@@ -274,7 +245,7 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 
 	noopWrapper := func(_ string, n nfstatus.Notifier) nfstatus.Notifier { return n }
 
-	build := func(t *testing.T, receiver *APIReceiver, wrapper WrapNotifierFunc) ([]*Integration, error) {
+	build := func(t *testing.T, receiver models.ReceiverConfig, wrapper WrapNotifierFunc) ([]*Integration, error) {
 		t.Helper()
 		return BuildReceiverIntegrationsWithManifests(
 			orgID, receiver, tmpl, imageProvider,
@@ -284,7 +255,7 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 	}
 
 	t.Run("should build all known integrations across all versions", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, c := range notifytest.AllKnownConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, c.GetRawNotifierConfig(""))
 		}
@@ -300,12 +271,10 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 	})
 
 	t.Run("should return error for unknown integration type", func(t *testing.T) {
-		recCfg := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{
-				Integrations: []*models.IntegrationConfig{
-					{UID: "uid", Name: "test", Type: "unknown-type", Version: schema.V1, Settings: json.RawMessage(`{}`)},
-				},
+		recCfg := models.ReceiverConfig{
+			Name: "test-receiver",
+			Integrations: []*models.IntegrationConfig{
+				{UID: "uid", Name: "test", Type: "unknown-type", Version: schema.V1, Settings: json.RawMessage(`{}`)},
 			},
 		}
 		_, err := build(t, recCfg, noopWrapper)
@@ -313,12 +282,10 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 	})
 
 	t.Run("should return error for unknown version", func(t *testing.T) {
-		recCfg := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{
-				Integrations: []*models.IntegrationConfig{
-					{UID: "uid", Name: "test", Type: schema.WebhookType, Version: "v99", Settings: json.RawMessage(`{}`)},
-				},
+		recCfg := models.ReceiverConfig{
+			Name: "test-receiver",
+			Integrations: []*models.IntegrationConfig{
+				{UID: "uid", Name: "test", Type: schema.WebhookType, Version: "v99", Settings: json.RawMessage(`{}`)},
 			},
 		}
 		_, err := build(t, recCfg, noopWrapper)
@@ -326,7 +293,7 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 	})
 
 	t.Run("should not produce any integrations when receiver has no Grafana integrations", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		integrations, err := build(t, recCfg, noopWrapper)
 		require.NoError(t, err)
 		require.Empty(t, integrations)
@@ -335,14 +302,12 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 	t.Run("should use per-type index for integrations of the same type", func(t *testing.T) {
 		webhookCfg := notifytest.AllKnownV1ConfigsForTesting[schema.WebhookType]
 		emailCfg := notifytest.AllKnownV1ConfigsForTesting[schema.EmailType]
-		recCfg := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{
-				Integrations: []*models.IntegrationConfig{
-					webhookCfg.GetRawNotifierConfig("webhook-0"),
-					emailCfg.GetRawNotifierConfig("email-0"),
-					webhookCfg.GetRawNotifierConfig("webhook-1"),
-				},
+		recCfg := models.ReceiverConfig{
+			Name: "test-receiver",
+			Integrations: []*models.IntegrationConfig{
+				webhookCfg.GetRawNotifierConfig("webhook-0"),
+				emailCfg.GetRawNotifierConfig("email-0"),
+				webhookCfg.GetRawNotifierConfig("webhook-1"),
 			},
 		}
 		integrations, err := build(t, recCfg, noopWrapper)
@@ -352,18 +317,4 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 		require.Equal(t, "email[0]", integrations[1].String())
 		require.Equal(t, "webhook[1]", integrations[2].String())
 	})
-}
-
-func TestBuildPrometheusReceiverIntegrations(t *testing.T) {
-	receiver, err := notifytest.GetMimirReceiverWithAllIntegrations(v0mimirtest.WithTLS, v0mimirtest.WithAuthorization, v0mimirtest.WithOAuth2)
-	require.NoError(t, err)
-	err = definition.ValidateAlertmanagerConfig(receiver)
-	require.NoError(t, err)
-	cfg, err := templates.NewConfig("1", "http://localhost", "", templates.DefaultLimits)
-	require.NoError(t, err)
-	tmpl, err := templates.NewFactory(nil, cfg, log.NewNopLogger())
-	require.NoError(t, err)
-	integrations, err := BuildPrometheusReceiverIntegrations(receiver, tmpl, nil, log.NewNopLogger(), NoWrap, nil)
-	require.NoError(t, err)
-	require.Len(t, integrations, 15)
 }

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -157,7 +157,7 @@ type NotificationsConfiguration struct {
 	MuteTimeIntervals []MuteTimeInterval
 	TimeIntervals     []TimeInterval
 	Templates         []templates.TemplateDefinition
-	Receivers         []*APIReceiver
+	Receivers         []models.ReceiverConfig
 
 	Limits DynamicLimits
 }
@@ -526,7 +526,7 @@ type result struct {
 	Error        error
 }
 
-func newTestReceiversResult(alert types.Alert, results []result, receivers []*APIReceiver, notifiedAt time.Time) (*TestReceiversResult, int) {
+func newTestReceiversResult(alert types.Alert, results []result, receivers []models.ReceiverConfig, notifiedAt time.Time) (*TestReceiversResult, int) {
 	var numBadRequests, numTimeouts, numUnknownErrors int
 
 	m := make(map[string]TestReceiverResult)
@@ -603,7 +603,7 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []*AP
 func TestReceivers(
 	ctx context.Context,
 	c TestReceiversConfigBodyParams,
-	buildIntegrationsFunc func(*APIReceiver, TemplatesProvider) ([]*nfstatus.Integration, error),
+	buildIntegrationsFunc func(models.ReceiverConfig, TemplatesProvider) ([]*nfstatus.Integration, error),
 	tmplProvider TemplatesProvider,
 ) (*TestReceiversResult, int, error) {
 	now := time.Now() // The start time of the test
@@ -618,13 +618,9 @@ func TestReceivers(
 		for _, intg := range receiver.Integrations {
 			// Create an APIReceiver with a single integration so we
 			// can identify invalid receiver integration configs
-			singleIntReceiver := &APIReceiver{
-				ConfigReceiver: definition.Receiver{
-					Name: receiver.Name,
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{intg},
-				},
+			singleIntReceiver := models.ReceiverConfig{
+				Name:         receiver.Name,
+				Integrations: []*models.IntegrationConfig{intg},
 			}
 			integrations, err := buildIntegrationsFunc(singleIntReceiver, tmplProvider)
 			if err != nil || len(integrations) == 0 {
@@ -1076,7 +1072,7 @@ func (am *GrafanaAlertmanager) tenantString() string {
 	return fmt.Sprintf("%d", am.opts.TenantID)
 }
 
-func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver *APIReceiver, tmpls TemplatesProvider) ([]*Integration, error) {
+func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver models.ReceiverConfig, tmpls TemplatesProvider) ([]*Integration, error) {
 	if am.opts.BuildWithManifestBuilder {
 		return BuildReceiverIntegrationsWithManifests(
 			am.opts.TenantID,

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -698,7 +698,7 @@ func TestSilenceCleanup(t *testing.T) {
 
 func TestStatusForTestReceivers(t *testing.T) {
 	t.Run("assert HTTP 400 Status Bad Request for no receivers", func(t *testing.T) {
-		_, status := newTestReceiversResult(types.Alert{}, []result{}, []*APIReceiver{}, time.Now())
+		_, status := newTestReceiversResult(types.Alert{}, []result{}, []models.ReceiverConfig{}, time.Now())
 		require.Equal(t, http.StatusBadRequest, status)
 	})
 
@@ -720,25 +720,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Err:         errors.New("error 2"),
 				},
 			},
-		}, []*APIReceiver{
+		}, []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 1",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 1"},
-					},
+				Name: "receiver 1",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 1"},
 				},
 			},
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 2",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 2"},
-					},
+				Name: "receiver 2",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 2"},
 				},
 			},
 		}, time.Now())
@@ -763,25 +755,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Err:         errors.New("error 2"),
 				},
 			},
-		}, []*APIReceiver{
+		}, []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 1",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 1"},
-					},
+				Name: "receiver 1",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 1"},
 				},
 			},
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 2",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 2"},
-					},
+				Name: "receiver 2",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 2"},
 				},
 			},
 		}, time.Now())
@@ -806,25 +790,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 					Err:         errors.New("error 2"),
 				},
 			},
-		}, []*APIReceiver{
+		}, []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 1",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 1"},
-					},
+				Name: "receiver 1",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 1"},
 				},
 			},
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 2",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 2"},
-					},
+				Name: "receiver 2",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 2"},
 				},
 			},
 		}, time.Now())
@@ -841,25 +817,17 @@ func TestStatusForTestReceivers(t *testing.T) {
 				ReceiverName: "receiver 2",
 				Config:       &models.IntegrationConfig{Name: "integration 2"},
 			},
-		}, []*APIReceiver{
+		}, []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 1",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 1"},
-					},
+				Name: "receiver 1",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 1"},
 				},
 			},
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "receiver 2",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{Name: "integration 2"},
-					},
+				Name: "receiver 2",
+				Integrations: []*models.IntegrationConfig{
+					{Name: "integration 2"},
 				},
 			},
 		}, time.Now())
@@ -934,7 +902,7 @@ func TestCalculateConfigFingerprint(t *testing.T) {
 			name:  "receivers",
 			field: "Receivers",
 			mutator: func(cfg *NotificationsConfiguration) {
-				cfg.Receivers[0].ReceiverConfig.Integrations[0].Name = "primary-webhook-v2"
+				cfg.Receivers[0].Integrations[0].Name = "primary-webhook-v2"
 			},
 		},
 		{
@@ -1138,54 +1106,46 @@ func richNotificationsConfiguration(t *testing.T, rootReceiver string) Notificat
 				Kind:     templates.MimirKind,
 			},
 		},
-		Receivers: []*APIReceiver{
+		Receivers: []models.ReceiverConfig{
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "grafana-default",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{
-							UID:                   "integration-webhook-main",
-							Name:                  "primary-webhook",
-							Type:                  schema.WebhookType,
-							Version:               schema.V1,
-							DisableResolveMessage: false,
-							Settings:              []byte(`{"url":"https://example.org/hooks/primary","httpMethod":"POST","maxAlerts":10}`),
-							SecureSettings: map[string]string{
-								"authorizationHeader": "Bearer token-a",
-								"password":            "secret-a",
-							},
+				Name: "grafana-default",
+				Integrations: []*models.IntegrationConfig{
+					{
+						UID:                   "integration-webhook-main",
+						Name:                  "primary-webhook",
+						Type:                  schema.WebhookType,
+						Version:               schema.V1,
+						DisableResolveMessage: false,
+						Settings:              []byte(`{"url":"https://example.org/hooks/primary","httpMethod":"POST","maxAlerts":10}`),
+						SecureSettings: map[string]string{
+							"authorizationHeader": "Bearer token-a",
+							"password":            "secret-a",
 						},
-						{
-							UID:                   "integration-slack-main",
-							Name:                  "primary-slack",
-							Type:                  schema.SlackType,
-							Version:               schema.V1,
-							DisableResolveMessage: true,
-							Settings:              []byte(`{"recipient":"#alerts-prod","title":"Critical alert","mentionUsers":"oncall"}`),
-							SecureSettings: map[string]string{
-								"url": "https://hooks.slack.com/services/T000/B000/XXX",
-							},
+					},
+					{
+						UID:                   "integration-slack-main",
+						Name:                  "primary-slack",
+						Type:                  schema.SlackType,
+						Version:               schema.V1,
+						DisableResolveMessage: true,
+						Settings:              []byte(`{"recipient":"#alerts-prod","title":"Critical alert","mentionUsers":"oncall"}`),
+						SecureSettings: map[string]string{
+							"url": "https://hooks.slack.com/services/T000/B000/XXX",
 						},
 					},
 				},
 			},
 			{
-				ConfigReceiver: ConfigReceiver{
-					Name: "grafana-fallback",
-				},
-				ReceiverConfig: models.ReceiverConfig{
-					Integrations: []*models.IntegrationConfig{
-						{
-							UID:                   "integration-email-fallback",
-							Name:                  "fallback-email",
-							Type:                  schema.EmailType,
-							DisableResolveMessage: false,
-							Settings:              []byte(`{"singleEmail":true,"addresses":"oncall@example.org;ops@example.org"}`),
-							SecureSettings: map[string]string{
-								"password": "smtp-secret",
-							},
+				Name: "grafana-fallback",
+				Integrations: []*models.IntegrationConfig{
+					{
+						UID:                   "integration-email-fallback",
+						Name:                  "fallback-email",
+						Type:                  schema.EmailType,
+						DisableResolveMessage: false,
+						Settings:              []byte(`{"singleEmail":true,"addresses":"oncall@example.org;ops@example.org"}`),
+						SecureSettings: map[string]string{
+							"password": "smtp-secret",
 						},
 					},
 				},

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -71,14 +71,9 @@ type TestIntegrationConfigResult struct {
 
 type ConfigReceiver = definition.Receiver
 
-type APIReceiver struct {
-	ConfigReceiver        `yaml:",inline"`
-	models.ReceiverConfig `yaml:",inline"`
-}
-
 type TestReceiversConfigBodyParams struct {
 	Alert     *models.TestReceiversConfigAlertParams `yaml:"alert,omitempty" json:"alert,omitempty"`
-	Receivers []*APIReceiver                         `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	Receivers []models.ReceiverConfig                `yaml:"receivers,omitempty" json:"receivers,omitempty"`
 }
 
 type IntegrationTimeoutError struct {
@@ -240,7 +235,7 @@ func NoopDecrypt(_ context.Context, sjd map[string][]byte, key string, fallback 
 }
 
 // BuildReceiverConfiguration parses, decrypts and validates the APIReceiver.
-func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) (GrafanaReceiverConfig, error) {
+func BuildReceiverConfiguration(ctx context.Context, api models.ReceiverConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) (GrafanaReceiverConfig, error) {
 	result := GrafanaReceiverConfig{
 		Name: api.Name,
 	}
@@ -256,13 +251,10 @@ func BuildReceiverConfiguration(ctx context.Context, api *APIReceiver, decode De
 	return result, nil
 }
 
-func ValidateAPIReceiver(ctx context.Context, api *APIReceiver, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
+func ValidateAPIReceiver(ctx context.Context, api models.ReceiverConfig, decode DecodeSecretsFn, decrypt GetDecryptedValueFn) error {
 	var errs []error
 	if api.Name == "" {
 		errs = append(errs, fmt.Errorf("receiver name is required"))
-	}
-	if err := api.Validate(); err != nil {
-		errs = append(errs, err)
 	}
 	for idx, integration := range api.Integrations {
 		err := ValidateIntegrationConfig(ctx, integration, decode, decrypt)

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -106,7 +106,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		_, missing := allReceivers(&GrafanaReceiverConfig{})
 		require.Greaterf(t, missing, 0, "all notifier types should be missing, allReceivers may no longer be reliable, missing: %d", missing)
 
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
@@ -116,7 +116,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.Equalf(t, 0, missing, "all notifier types should be present, missing: %d", missing)
 	})
 	t.Run("should decode secrets from base64", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
@@ -129,7 +129,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.Greater(t, counter, 0)
 	})
 	t.Run("should fail if at least one config is invalid", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
@@ -152,13 +152,13 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.ErrorContains(t, err, fmt.Sprintf(`failed to validate integration "%s" (UID %s) of type "%s"`, bad.Name, bad.UID, bad.Type))
 	})
 	t.Run("should accept empty config", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, decrypt)
 		require.NoError(t, err)
 		require.Equal(t, recCfg.Name, parsed.Name)
 	})
 	t.Run("should support non-base64-encoded secrets", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		// We decode all the secureSettings from base64 and then build then receivers. The test is to ensure that
 		// BuildReceiverConfiguration can handle the already decoded secrets correctly.
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
@@ -185,7 +185,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 
 	})
 	t.Run("should fail if notifier type is unknown", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
@@ -208,7 +208,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		require.ErrorContains(t, err, fmt.Sprintf("invalid integration type: %s", bad.Type))
 	})
 	t.Run("should recognize all known types", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
 		}
@@ -252,7 +252,7 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		})
 	})
 	t.Run("should recognize type in any case", func(t *testing.T) {
-		recCfg := &APIReceiver{ConfigReceiver: ConfigReceiver{Name: "test-receiver"}}
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
 		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
 			notifierRaw := cfg.GetRawNotifierConfig("")
 			notifierRaw.Type = schema.IntegrationType(strings.ToUpper(string(notifierRaw.Type)))
@@ -283,9 +283,9 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		cfg := notifytest.AllKnownV1ConfigsForTesting[schema.LineType]
 		raw := cfg.GetRawNotifierConfig("")
 		raw.Type = "line" // alias, not canonical type
-		recCfg := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		recCfg := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, decrypt)
 		require.NoError(t, err)
@@ -295,9 +295,9 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		cfg := notifytest.AllKnownV1ConfigsForTesting[schema.WebhookType]
 		raw := cfg.GetRawNotifierConfig("")
 		raw.Version = "v99"
-		recCfg := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		recCfg := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		_, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, decrypt)
 		require.Error(t, err)
@@ -307,9 +307,9 @@ func TestBuildReceiverConfiguration(t *testing.T) {
 		cfg := notifytest.AllKnownV1ConfigsForTesting[schema.TeamsType]
 		raw := cfg.GetRawNotifierConfig("")
 		raw.Version = schema.V0mimir1
-		recCfg := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		recCfg := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		_, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, decrypt)
 		require.Error(t, err)
@@ -337,12 +337,10 @@ func TestHTTPConfig(t *testing.T) {
 				// Config should include http_config if the notifier supports it, but let's sanity check.
 				require.Containsf(t, string(config.Settings), "http_config", "notifier %s does not contain http_config", notifierType)
 
-				recCfg := &APIReceiver{
-					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-					ReceiverConfig: models.ReceiverConfig{
-						Integrations: []*models.IntegrationConfig{
-							config,
-						},
+				recCfg := models.ReceiverConfig{
+					Name: "test-receiver",
+					Integrations: []*models.IntegrationConfig{
+						config,
 					},
 				}
 
@@ -522,12 +520,10 @@ func TestHTTPConfig(t *testing.T) {
 
 				config.Settings = newSettings
 
-				recCfg := &APIReceiver{
-					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-					ReceiverConfig: models.ReceiverConfig{
-						Integrations: []*models.IntegrationConfig{
-							config,
-						},
+				recCfg := models.ReceiverConfig{
+					Name: "test-receiver",
+					Integrations: []*models.IntegrationConfig{
+						config,
 					},
 				}
 
@@ -666,9 +662,9 @@ func TestValidateAPIReceiver(t *testing.T) {
 		for key, cfg := range notifytest.AllKnownConfigsForTesting {
 			t.Run(fmt.Sprintf("%s %s", key.Type, key.Version), func(t *testing.T) {
 				raw := cfg.GetRawNotifierConfig("")
-				api := &APIReceiver{
-					ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-					ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+				api := models.ReceiverConfig{
+					Name:         "test-receiver",
+					Integrations: []*models.IntegrationConfig{raw},
 				}
 				require.NoError(t, ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt))
 			})
@@ -676,7 +672,7 @@ func TestValidateAPIReceiver(t *testing.T) {
 	})
 
 	t.Run("returns error when receiver name is empty", func(t *testing.T) {
-		api := &APIReceiver{}
+		api := models.ReceiverConfig{}
 		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "receiver name is required")
@@ -689,9 +685,9 @@ func TestValidateAPIReceiver(t *testing.T) {
 			Version:  schema.V1,
 			Settings: json.RawMessage(`{}`),
 		}
-		api := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		api := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
 		require.ErrorContains(t, err, "invalid integration config at index 0")
@@ -705,9 +701,9 @@ func TestValidateAPIReceiver(t *testing.T) {
 			Version:  "v99",
 			Settings: json.RawMessage(`{}`),
 		}
-		api := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		api := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
 		require.ErrorContains(t, err, "invalid integration config at index 0")
@@ -722,9 +718,9 @@ func TestValidateAPIReceiver(t *testing.T) {
 			Version:  schema.V1,
 			Settings: json.RawMessage(`{"url": ""}`),
 		}
-		api := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		api := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
 		require.ErrorContains(t, err, "invalid integration config at index 0")
@@ -738,9 +734,9 @@ func TestValidateAPIReceiver(t *testing.T) {
 			Settings:       json.RawMessage(`{"url": "http://localhost"}`),
 			SecureSettings: map[string]string{"key": "not-valid-base64!!!"},
 		}
-		api := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{Integrations: []*models.IntegrationConfig{raw}},
+		api := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{raw},
 		}
 		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
 		require.ErrorContains(t, err, "invalid integration config at index 0")
@@ -755,11 +751,9 @@ func TestValidateAPIReceiver(t *testing.T) {
 				Settings: json.RawMessage(`{}`),
 			}
 		}
-		api := &APIReceiver{
-			ConfigReceiver: ConfigReceiver{Name: "test-receiver"},
-			ReceiverConfig: models.ReceiverConfig{
-				Integrations: []*models.IntegrationConfig{makeInvalid("a"), makeInvalid("b")},
-			},
+		api := models.ReceiverConfig{
+			Name:         "test-receiver",
+			Integrations: []*models.IntegrationConfig{makeInvalid("a"), makeInvalid("b")},
 		}
 		err := ValidateAPIReceiver(ctx, api, DecodeSecretsFromBase64, decrypt)
 		require.ErrorContains(t, err, "invalid integration config at index 0")

--- a/notify/test_receivers.go
+++ b/notify/test_receivers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/nfstatus"
 )
@@ -32,16 +31,12 @@ func TestIntegration(ctx context.Context,
 	receiverName string,
 	integrationConfig models.IntegrationConfig,
 	testAlert models.TestReceiversConfigAlertParams,
-	buildIntegrationsFunc func(*APIReceiver, TemplatesProvider) ([]*nfstatus.Integration, error),
+	buildIntegrationsFunc func(models.ReceiverConfig, TemplatesProvider) ([]*nfstatus.Integration, error),
 	tmplProvider TemplatesProvider,
 ) (models.IntegrationStatus, error) {
-	nf, err := buildIntegrationsFunc(&APIReceiver{
-		ConfigReceiver: definition.Receiver{
-			Name: receiverName,
-		},
-		ReceiverConfig: models.ReceiverConfig{
-			Integrations: []*models.IntegrationConfig{&integrationConfig},
-		},
+	nf, err := buildIntegrationsFunc(models.ReceiverConfig{
+		Name:         receiverName,
+		Integrations: []*models.IntegrationConfig{&integrationConfig},
 	}, tmplProvider)
 	if err != nil || len(nf) == 0 {
 		return models.IntegrationStatus{}, err


### PR DESCRIPTION
Part of https://github.com/grafana/alerting-squad/issues/1214

## Summary

- Removes the `APIReceiver` wrapper type (which combined `definition.Receiver`/`ConfigReceiver` with `models.ReceiverConfig`) in favor of using `models.ReceiverConfig` directly
- Updates all function signatures in `notify/` (`BuildReceiverConfiguration`, `ValidateAPIReceiver`, `newTestReceiversResult`, `TestReceivers`, `buildReceiverIntegrations`, etc.) to accept `models.ReceiverConfig` instead of `*APIReceiver`
- Updates `NotificationsConfiguration.Receivers` field type from `[]*APIReceiver` to `[]models.ReceiverConfig`
- Moves receiver name into `models.ReceiverConfig.Name`, removing the indirection through `ConfigReceiver`
- Removes `BuildPrometheusReceiverIntegrations`, which depended on the old type

## Test plan

- [ ] `make test` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it removes `BuildPrometheusReceiverIntegrations` and the `APIReceiver` wrapper, changing how receiver integrations are constructed and potentially dropping legacy Prometheus/Mimir receiver configs from notification delivery.
> 
> **Overview**
> Removes the `APIReceiver` wrapper (and embedded Prometheus `definition.Receiver` config) and standardizes receiver handling on `models.ReceiverConfig` with an explicit `Name` field.
> 
> Updates notify conversion/build/test paths (`PostableAPIReceiver*`, `BuildReceiversIntegrations`, `BuildReceiverConfiguration`, `ValidateAPIReceiver`, test-receiver flows, and `NotificationsConfiguration.Receivers`) to accept/return `models.ReceiverConfig` values instead of `*APIReceiver`.
> 
> Deletes legacy Prometheus/Mimir integration construction (`BuildPrometheusReceiverIntegrations`) and corresponding tests, so integration building now only considers Grafana-managed `Integrations` on `models.ReceiverConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8162d6866b26e0e1fb46d60dbf0e87ff14cc56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->