### PR TITLE
notify: add error returns to PostableAPIReceiver conversion functions

### DIFF
--- a/notify/compat.go
+++ b/notify/compat.go
@@ -13,39 +13,55 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func PostableAPIReceiversToReceiverConfigs(r []*definition.PostableApiReceiver) []models.ReceiverConfig {
+func PostableAPIReceiversToReceiverConfigs(r []*definition.PostableApiReceiver) ([]models.ReceiverConfig, error) {
 	result := make([]models.ReceiverConfig, 0, len(r))
 	for _, receiver := range r {
-		result = append(result, PostableAPIReceiverToReceiverConfig(receiver))
+		recv, err := PostableAPIReceiverToReceiverConfig(receiver)
+		if err != nil {
+			return nil, fmt.Errorf("invalid receiver %s: %w", receiver.Name, err)
+		}
+		result = append(result, recv)
 	}
-	return result
+	return result, nil
 }
 
-func PostableAPIReceiverToReceiverConfig(r *definition.PostableApiReceiver) models.ReceiverConfig {
+func PostableAPIReceiverToReceiverConfig(r *definition.PostableApiReceiver) (models.ReceiverConfig, error) {
 	result := models.ReceiverConfig{
 		Name:         r.Name,
 		Integrations: make([]*models.IntegrationConfig, 0, len(r.GrafanaManagedReceivers)),
 	}
-	for _, p := range r.GrafanaManagedReceivers {
-		result.Integrations = append(result.Integrations, PostableGrafanaReceiverToIntegrationConfig(p))
+	for idx, p := range r.GrafanaManagedReceivers {
+		i, err := PostableGrafanaReceiverToIntegrationConfig(p)
+		if err != nil {
+			return models.ReceiverConfig{}, fmt.Errorf("invalid integration at index %d: %w", idx, err)
+		}
+		result.Integrations = append(result.Integrations, i)
 	}
-	return result
+	return result, nil
 }
 
-func PostableGrafanaReceiverToIntegrationConfig(r *definition.PostableGrafanaReceiver) *models.IntegrationConfig {
+func PostableGrafanaReceiverToIntegrationConfig(r *definition.PostableGrafanaReceiver) (*models.IntegrationConfig, error) {
 	version := schema.V1
 	if r.Version != "" {
 		version = schema.Version(r.Version)
 	}
+	iType, err := IntegrationTypeFromString(r.Type)
+	if err != nil {
+		return nil, err
+	}
+	_, ok := GetSchemaVersionForIntegration(iType, version)
+	if !ok {
+		return nil, fmt.Errorf("invalid version %s of integration %s", version, iType)
+	}
 	return &models.IntegrationConfig{
 		UID:                   r.UID,
 		Name:                  r.Name,
-		Type:                  schema.IntegrationType(r.Type), // TODO validate type/version here
+		Type:                  iType, // TODO validate type/version here
 		Version:               version,
 		DisableResolveMessage: r.DisableResolveMessage,
 		Settings:              json.RawMessage(r.Settings),
 		SecureSettings:        r.SecureSettings,
-	}
+	}, nil
 }
 
 // PostableMimirReceiverToPostableGrafanaReceiver converts all legacy models to apimodels.PostableGrafanaReceiver.

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -56,7 +56,7 @@ func PostableGrafanaReceiverToIntegrationConfig(r *definition.PostableGrafanaRec
 	return &models.IntegrationConfig{
 		UID:                   r.UID,
 		Name:                  r.Name,
-		Type:                  iType, // TODO validate type/version here
+		Type:                  iType,
 		Version:               version,
 		DisableResolveMessage: r.DisableResolveMessage,
 		Settings:              json.RawMessage(r.Settings),

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -124,6 +124,17 @@ func TestPostableGrafanaReceiverToGrafanaIntegrationConfig(t *testing.T) {
 			"test": "data",
 		},
 	}, *actual)
+
+	t.Run("normalizes type casing", func(t *testing.T) {
+		r := &definition.PostableGrafanaReceiver{
+			UID:  "test-uid",
+			Name: "test-name",
+			Type: "SLACK",
+		}
+		actual, err := PostableGrafanaReceiverToIntegrationConfig(r)
+		require.NoError(t, err)
+		require.Equal(t, schema.SlackType, actual.Type)
+	})
 }
 
 func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {

--- a/notify/compat_test.go
+++ b/notify/compat_test.go
@@ -27,7 +27,8 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 				Name: "test-receiver",
 			},
 		}
-		actual := PostableAPIReceiverToReceiverConfig(r)
+		actual, err := PostableAPIReceiverToReceiverConfig(r)
+		require.NoError(t, err)
 		require.Empty(t, actual.Integrations)
 		require.Equal(t, r.Name, actual.Name)
 	})
@@ -61,11 +62,41 @@ func TestPostableAPIReceiverToAPIReceiver(t *testing.T) {
 				},
 			},
 		}
-		actual := PostableAPIReceiverToReceiverConfig(r)
+		actual, err := PostableAPIReceiverToReceiverConfig(r)
+		require.NoError(t, err)
 		require.Len(t, actual.Integrations, 2)
 		require.Equal(t, r.Name, actual.Name)
-		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[0]), *actual.Integrations[0])
-		require.Equal(t, *PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[1]), *actual.Integrations[1])
+		expected0, err := PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[0])
+		require.NoError(t, err)
+		expected1, err := PostableGrafanaReceiverToIntegrationConfig(r.GrafanaManagedReceivers[1])
+		require.NoError(t, err)
+		require.Equal(t, *expected0, *actual.Integrations[0])
+		require.Equal(t, *expected1, *actual.Integrations[1])
+	})
+	t.Run("returns error for unknown integration type", func(t *testing.T) {
+		r := &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{Name: "test-receiver"},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+					{UID: "uid", Name: "name", Type: "unknown_type"},
+				},
+			},
+		}
+		_, err := PostableAPIReceiverToReceiverConfig(r)
+		require.ErrorContains(t, err, "invalid integration at index 0")
+	})
+	t.Run("returns error for invalid version", func(t *testing.T) {
+		r := &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{Name: "test-receiver"},
+			PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+					{UID: "uid", Name: "name", Type: "slack", Version: "v99"},
+				},
+			},
+		}
+		_, err := PostableAPIReceiverToReceiverConfig(r)
+		require.ErrorContains(t, err, "invalid integration at index 0")
+		require.ErrorContains(t, err, "invalid version v99")
 	})
 }
 
@@ -80,7 +111,8 @@ func TestPostableGrafanaReceiverToGrafanaIntegrationConfig(t *testing.T) {
 			"test": "data",
 		},
 	}
-	actual := PostableGrafanaReceiverToIntegrationConfig(r)
+	actual, err := PostableGrafanaReceiverToIntegrationConfig(r)
+	require.NoError(t, err)
 	require.Equal(t, models.IntegrationConfig{
 		UID:                   "test-uid",
 		Name:                  "test-name",
@@ -96,8 +128,9 @@ func TestPostableGrafanaReceiverToGrafanaIntegrationConfig(t *testing.T) {
 
 func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
 	t.Run("returns empty when no receivers", func(t *testing.T) {
-		actual := PostableAPIReceiversToReceiverConfigs(nil)
+		actual, err := PostableAPIReceiversToReceiverConfigs(nil)
 		require.Empty(t, actual)
+		require.NoError(t, err)
 	})
 	receivers := []*definition.PostableApiReceiver{
 		{
@@ -139,11 +172,31 @@ func TestPostableApiAlertingConfigToApiReceivers(t *testing.T) {
 			},
 		},
 	}
-	actual := PostableAPIReceiversToReceiverConfigs(receivers)
+	actual, err := PostableAPIReceiversToReceiverConfigs(receivers)
+	require.NoError(t, err)
+
+	t.Run("returns error when a receiver has invalid integration", func(t *testing.T) {
+		invalid := []*definition.PostableApiReceiver{
+			{
+				Receiver: definition.Receiver{Name: "bad-receiver"},
+				PostableGrafanaReceivers: definition.PostableGrafanaReceivers{
+					GrafanaManagedReceivers: []*definition.PostableGrafanaReceiver{
+						{UID: "uid", Name: "name", Type: "unknown_type"},
+					},
+				},
+			},
+		}
+		_, err := PostableAPIReceiversToReceiverConfigs(invalid)
+		require.ErrorContains(t, err, "invalid receiver bad-receiver")
+	})
 
 	require.Len(t, actual, 2)
-	require.Equal(t, PostableAPIReceiverToReceiverConfig(receivers[0]), actual[0])
-	require.Equal(t, PostableAPIReceiverToReceiverConfig(receivers[1]), actual[1])
+	expected0, err := PostableAPIReceiverToReceiverConfig(receivers[0])
+	require.NoError(t, err)
+	expected1, err := PostableAPIReceiverToReceiverConfig(receivers[1])
+	require.NoError(t, err)
+	require.Equal(t, expected0, actual[0])
+	require.Equal(t, expected1, actual[1])
 }
 
 func TestConfigReceiverToMimirIntegrations(t *testing.T) {


### PR DESCRIPTION
## Summary
- `PostableGrafanaReceiverToIntegrationConfig`, `PostableAPIReceiverToAPIReceiver`, and `PostableAPIReceiversToAPIReceivers` now return errors instead of silently producing invalid results
- Validation also normalizes the integration type: `IntegrationConfig.Type` is always set to the canonical type string (resolving case differences), so downstream code receives consistent data regardless of input casing
- Updated all call sites in tests and added error-case and normalization test coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes conversion function signatures to return errors and adds stricter validation of integration `Type`/`Version`, which can cause previously accepted (invalid) configs to fail fast and may require updating downstream call sites.
> 
> **Overview**
> Adds error-returning, validating conversions for postable receivers: `PostableAPIReceiversToReceiverConfigs`, `PostableAPIReceiverToReceiverConfig`, and `PostableGrafanaReceiverToIntegrationConfig` now fail fast on unknown integration types and unsupported schema versions, and normalize `Type` to the canonical integration enum.
> 
> Updates tests to handle the new `(value, error)` signatures and adds coverage for invalid-type/invalid-version errors and type-casing normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5808266543a35dd688c21ddfc733db89b8d15a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->