### PR TITLE
Include HTTP client response in contact point errors

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -22,7 +22,7 @@ import (
 	"github.com/grafana/alerting/receivers"
 )
 
-const maxResponseBodyInError = 1024
+const maxErrorResponseSize = 1024
 
 var ErrInvalidMethod = errors.New("webhook only supports HTTP methods PUT or POST")
 
@@ -176,30 +176,28 @@ func (ns *Client) SendWebhook(ctx context.Context, l log.Logger, webhook *receiv
 		}
 	}()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	if webhook.Validation != nil {
-		err := webhook.Validation(body, resp.StatusCode)
-		if err != nil {
-			level.Debug(l).Log("msg", "Webhook failed validation", "url", url.Redacted(), "status_code", resp.Status, "body", string(body), "err", err)
-			return fmt.Errorf("webhook failed validation: %w", err)
-		}
-	}
-
 	if resp.StatusCode/100 == 2 {
+		if webhook.Validation != nil {
+			// Some integrations can return 2xx status codes but error responses.
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			if err := webhook.Validation(body, resp.StatusCode); err != nil {
+				level.Debug(l).Log("msg", "Webhook failed validation", "url", url.Redacted(), "status_code", resp.Status, "body", string(body), "err", err)
+				return fmt.Errorf("webhook failed validation: %w", err)
+			}
+		}
 		level.Debug(l).Log("msg", "Webhook succeeded", "url", url.Redacted(), "status_code", resp.Status)
 		return nil
 	}
 
-	level.Debug(l).Log("msg", "Webhook failed", "url", url.Redacted(), "status_code", resp.Status, "body", string(body))
-	truncatedBody := string(body)
-	if len(truncatedBody) > maxResponseBodyInError {
-		truncatedBody = truncatedBody[:maxResponseBodyInError] + "... (truncated)"
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseSize))
+	if err != nil {
+		return err
 	}
-	return fmt.Errorf("webhook response status %v: %s", resp.Status, truncatedBody)
+	level.Debug(l).Log("msg", "Webhook failed", "url", url.Redacted(), "status_code", resp.Status, "body", string(body))
+	return fmt.Errorf("webhook response status %v: %s", resp.Status, string(body))
 }
 
 func redactURL(err error) error {

--- a/http/client.go
+++ b/http/client.go
@@ -22,6 +22,8 @@ import (
 	"github.com/grafana/alerting/receivers"
 )
 
+const maxResponseBodyInError = 1024
+
 var ErrInvalidMethod = errors.New("webhook only supports HTTP methods PUT or POST")
 
 type clientConfiguration struct {
@@ -182,18 +184,22 @@ func (ns *Client) SendWebhook(ctx context.Context, l log.Logger, webhook *receiv
 	if webhook.Validation != nil {
 		err := webhook.Validation(body, resp.StatusCode)
 		if err != nil {
-			level.Debug(l).Log("msg", "Webhook failed validation", "url", url.Redacted(), "statuscode", resp.Status, "body", string(body), "err", err)
+			level.Debug(l).Log("msg", "Webhook failed validation", "url", url.Redacted(), "status_code", resp.Status, "body", string(body), "err", err)
 			return fmt.Errorf("webhook failed validation: %w", err)
 		}
 	}
 
 	if resp.StatusCode/100 == 2 {
-		level.Debug(l).Log("msg", "Webhook succeeded", "url", url.Redacted(), "statuscode", resp.Status)
+		level.Debug(l).Log("msg", "Webhook succeeded", "url", url.Redacted(), "status_code", resp.Status)
 		return nil
 	}
 
-	level.Debug(l).Log("msg", "Webhook failed", "url", url.Redacted(), "statuscode", resp.Status, "body", string(body))
-	return fmt.Errorf("webhook response status %v", resp.Status)
+	level.Debug(l).Log("msg", "Webhook failed", "url", url.Redacted(), "status_code", resp.Status, "body", string(body))
+	truncatedBody := string(body)
+	if len(truncatedBody) > maxResponseBodyInError {
+		truncatedBody = truncatedBody[:maxResponseBodyInError] + "... (truncated)"
+	}
+	return fmt.Errorf("webhook response status %v: %s", resp.Status, truncatedBody)
 }
 
 func redactURL(err error) error {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -87,6 +87,7 @@ func TestSendWebhook(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/error" {
 			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("Invalid routing key"))
 			return
 		}
 		got = r
@@ -153,11 +154,14 @@ func TestSendWebhook(t *testing.T) {
 
 	require.ErrorIs(t, s.SendWebhook(context.Background(), log.NewNopLogger(), &cmd), testErr)
 
-	// A non-200 status code should cause an error.
+	// A non-200 status code should cause an error that includes the response body.
 	cmd = receivers.SendWebhookSettings{
 		URL: server.URL + "/error",
 	}
-	require.Error(t, s.SendWebhook(context.Background(), log.NewNopLogger(), &cmd))
+	err = s.SendWebhook(context.Background(), log.NewNopLogger(), &cmd)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "400 Bad Request")
+	require.ErrorContains(t, err, "Invalid routing key")
 }
 
 func TestSendWebhookHMAC(t *testing.T) {


### PR DESCRIPTION
If a webhook fails, we only show (e.g.) _"webhook response status 400"_ in the UI, no error message. This PR adds the response body (truncated) to the error we return.