### PR TITLE
Email: constrain Labels/Annotations table column widths

### DIFF
--- a/templates/email/ng_alert_notification.html
+++ b/templates/email/ng_alert_notification.html
@@ -567,13 +567,13 @@
                               </tr>
                               <tr>
                                 <td align="left" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:fixed;width:100%;border:none;">
                                     <mj-raw>{{ range .Labels.SortedPairs }}</mj-raw>
                                     <tr>
-                                      <td>
+                                      <td width="40%" style="width:40%;word-break:break-word;">
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>{{ .Value }}</td>
+                                      <td width="60%" style="width:60%;word-break:break-word;">{{ .Value }}</td>
                                     </tr>
                                     <mj-raw>{{ end }}</mj-raw>
                                   </table>
@@ -587,14 +587,14 @@
                               </tr>
                               <tr>
                                 <td align="left" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:fixed;width:100%;border:none;">
                                     <mj-raw>{{ range .Annotations.SortedPairs }}</mj-raw>
                                     <mj-raw>{{ if and (ne .Name "description") (ne .Name "summary") }}</mj-raw>
                                     <tr>
-                                      <td>
+                                      <td width="40%" style="width:40%;word-break:break-word;">
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>{{ .Value }}</td>
+                                      <td width="60%" style="width:60%;word-break:break-word;">{{ .Value }}</td>
                                     </tr>
                                     <mj-raw>{{ end }}</mj-raw>
                                     <mj-raw>{{ end }}</mj-raw>
@@ -1058,13 +1058,13 @@
                               </tr>
                               <tr>
                                 <td align="left" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:fixed;width:100%;border:none;">
                                     <mj-raw>{{ range .Labels.SortedPairs }}</mj-raw>
                                     <tr>
-                                      <td>
+                                      <td width="40%" style="width:40%;word-break:break-word;">
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>{{ .Value }}</td>
+                                      <td width="60%" style="width:60%;word-break:break-word;">{{ .Value }}</td>
                                     </tr>
                                     <mj-raw>{{ end }}</mj-raw>
                                   </table>
@@ -1078,14 +1078,14 @@
                               </tr>
                               <tr>
                                 <td align="left" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                  <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Inter, Helvetica, Arial;font-size:13px;line-height:22px;table-layout:fixed;width:100%;border:none;">
                                     <mj-raw>{{ range .Annotations.SortedPairs }}</mj-raw>
                                     <mj-raw>{{ if and (ne .Name "description") (ne .Name "summary") }}</mj-raw>
                                     <tr>
-                                      <td>
+                                      <td width="40%" style="width:40%;word-break:break-word;">
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>{{ .Value }}</td>
+                                      <td width="60%" style="width:60%;word-break:break-word;">{{ .Value }}</td>
                                     </tr>
                                     <mj-raw>{{ end }}</mj-raw>
                                     <mj-raw>{{ end }}</mj-raw>

--- a/templates/email/template_test.go
+++ b/templates/email/template_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/grafana/alerting/templates"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +39,57 @@ func TestTemplateUndefinedTemplateReturnsError(t *testing.T) {
 	err := tmpl.ExecuteTemplate(&buf, "nonexistent_template", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is undefined")
+}
+
+// TestLabelsTableHasFixedLayout guards against regression of the rendering fix
+// for the Labels and Annotations key/value tables. table-layout:auto with no
+// column widths caused long unbreakable label names to expand the first column
+// and crush the second to a hairline in renderer-strict web-based email clients.
+func TestLabelsTableHasFixedLayout(t *testing.T) {
+	tmpl := Template()
+
+	longLabel := "ExceptionDetail_InnerException_InnerException_InnerException_Message"
+
+	data := map[string]any{
+		"Title":   "Test alert",
+		"Message": "",
+		"Status":  "firing",
+		"Alerts": templates.ExtendedAlerts{
+			{
+				Status:      "firing",
+				Labels:      templates.KV{longLabel: "short value"},
+				Annotations: templates.KV{"runbook": "https://example.com"},
+			},
+		},
+		"GroupLabels":       templates.KV{},
+		"CommonLabels":      templates.KV{},
+		"CommonAnnotations": templates.KV{},
+		"ExternalURL":       "https://example.com",
+		"RuleUrl":           "https://example.com/rule",
+		"AlertPageUrl":      "https://example.com/page",
+		"Subject":           map[string]any{"executed_template": "Test alert"},
+	}
+
+	var buf bytes.Buffer
+	err := tmpl.ExecuteTemplate(&buf, "ng_alert_notification.html", data)
+	require.NoError(t, err)
+
+	output := buf.String()
+
+	// Constrain column widths in the Labels / Annotations key/value tables to
+	// prevent runaway expansion in renderer-strict clients (New Outlook / OWA).
+	require.Contains(t, output, "table-layout:fixed",
+		"Labels/Annotations tables must use fixed layout (renderer-strict clients break otherwise)")
+	require.Contains(t, output, `width="40%"`,
+		"label-name <td> must have explicit width attribute")
+	require.Contains(t, output, `width="60%"`,
+		"label-value <td> must have explicit width attribute")
+	require.Contains(t, output, "word-break:break-word",
+		"<td> cells must allow long-string break to avoid horizontal overflow")
+	require.NotContains(t, output, "table-layout:auto",
+		"no Labels/Annotations table should use table-layout:auto anymore")
+
+	// Sanity check: the long label name should still appear in output
+	// (i.e., the fix doesn't silently strip data).
+	require.Contains(t, output, longLabel)
 }


### PR DESCRIPTION
## Summary

The default Labels and Annotations key/value tables in `ng_alert_notification.html` use `table-layout: auto` with no explicit `<td>` widths. Renderer-strict web-based email clients honor this literally: a long unbreakable label name expands the first column and crushes the value column to a near-hairline. Clients with more permissive table-layout handling silently rebalance and hide the issue.

This pins both `<td>` cells to 40%/60% widths with belt-and-braces (HTML `width` attribute + inline `style` + `word-break: break-word`) for cross-client compatibility, and switches the wrapping `<table>` to `table-layout: fixed`. Same change applied to all four occurrences (firing/resolved × Labels/Annotations).

Adds a render-output regression test that exercises a long label name and asserts the layout is preserved (previously the test file was parse-only).

## Test plan

- [x] `go test ./templates/email/...` — new test `TestLabelsTableHasFixedLayout` passes
- [x] `go test ./receivers/...` — no regressions
- [x] Rendered output verified in a real web-based email client (before vs after states)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to HTML email table styling and a unit test, with no impact on alert evaluation or data handling.
> 
> **Overview**
> Improves `ng_alert_notification.html` rendering in strict email clients by switching Labels/Annotations key/value tables to `table-layout:fixed` and explicitly pinning the name/value columns to 40%/60% with `word-break:break-word`.
> 
> Adds `TestLabelsTableHasFixedLayout` to render the template with a long label key and assert the fixed-layout/width attributes are present (and `table-layout:auto` is not), preventing regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc099ea496018ee2663ac32b1290cfaf87f710a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->