### PR TITLE
notify: add version label to grafana_alerting_alertmanager_integrations metric

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -877,7 +877,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 		receivers = append(receivers, nfstatus.NewReceiver(name, isActive, integrationsMap[name]))
 	}
 
-	am.setReceiverMetrics(receivers, len(activeReceivers))
+	am.setReceiverMetrics(cfg.Receivers, len(activeReceivers))
 	am.setInhibitionRulesMetrics(cfg.InhibitRules)
 
 	am.receivers = receivers
@@ -904,19 +904,19 @@ func (am *GrafanaAlertmanager) setInhibitionRulesMetrics(r []InhibitRule) {
 	am.opts.Metrics.configuredInhibitionRules.WithLabelValues(am.tenantString()).Set(float64(len(r)))
 }
 
-func (am *GrafanaAlertmanager) setReceiverMetrics(receivers []*nfstatus.Receiver, countActiveReceivers int) {
+func (am *GrafanaAlertmanager) setReceiverMetrics(cfgReceivers []models.ReceiverConfig, countActiveReceivers int) {
 	am.opts.Metrics.configuredReceivers.WithLabelValues(am.tenantString(), ActiveStateLabelValue).Set(float64(countActiveReceivers))
-	am.opts.Metrics.configuredReceivers.WithLabelValues(am.tenantString(), InactiveStateLabelValue).Set(float64(len(receivers) - countActiveReceivers))
+	am.opts.Metrics.configuredReceivers.WithLabelValues(am.tenantString(), InactiveStateLabelValue).Set(float64(len(cfgReceivers) - countActiveReceivers))
 
-	integrationsByType := make(map[string]int, len(receivers))
-	for _, r := range receivers {
-		for _, i := range r.Integrations() {
-			integrationsByType[i.Name()]++
+	type typeVersion struct{ t, v string }
+	byTypeVersion := make(map[typeVersion]int)
+	for _, r := range cfgReceivers {
+		for _, i := range r.Integrations {
+			byTypeVersion[typeVersion{string(i.Type), string(i.Version)}]++
 		}
 	}
-
-	for t, count := range integrationsByType {
-		am.opts.Metrics.configuredIntegrations.WithLabelValues(am.tenantString(), t).Set(float64(count))
+	for tv, count := range byTypeVersion {
+		am.opts.Metrics.configuredIntegrations.WithLabelValues(am.tenantString(), tv.t, tv.v).Set(float64(count))
 	}
 }
 

--- a/notify/grafana_alertmanager_metrics.go
+++ b/notify/grafana_alertmanager_metrics.go
@@ -36,7 +36,7 @@ func NewGrafanaAlertmanagerMetrics(r prometheus.Registerer, l log.Logger) *Grafa
 			Subsystem: subsystem,
 			Name:      "alertmanager_integrations",
 			Help:      "Number of configured integrations.",
-		}, []string{"org", "type"}),
+		}, []string{"org", "type", "version"}),
 		configuredInhibitionRules: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/models"
-	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/templates"
@@ -606,28 +605,28 @@ func TestGrafanaAlertmanager_setInhibitionRulesMetrics(t *testing.T) {
 }
 
 func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
-	fn := &fakeNotifier{}
-	integrations := []*nfstatus.Integration{
-		nfstatus.NewIntegration(fn, fn, "grafana-oncall", 0, "test-grafana-oncall", nil, log.NewNopLogger()),
-		nfstatus.NewIntegration(fn, fn, "sns", 1, "test-sns", nil, log.NewNopLogger()),
-	}
-
 	am, reg := setupAMTest(t)
 
-	receivers := []*nfstatus.Receiver{
-		nfstatus.NewReceiver("ActiveNoIntegrations", true, nil),
-		nfstatus.NewReceiver("InactiveNoIntegrations", false, nil),
-		nfstatus.NewReceiver("ActiveMultipleIntegrations", true, integrations),
-		nfstatus.NewReceiver("InactiveMultipleIntegrations", false, integrations),
+	cfgReceivers := []models.ReceiverConfig{
+		{Name: "ActiveNoIntegrations"},
+		{Name: "InactiveNoIntegrations"},
+		{Name: "ActiveMultipleIntegrations", Integrations: []*models.IntegrationConfig{
+			{Type: schema.OnCallType, Version: schema.V1},
+			{Type: schema.SNSType, Version: schema.V1},
+		}},
+		{Name: "InactiveMultipleIntegrations", Integrations: []*models.IntegrationConfig{
+			{Type: schema.OnCallType, Version: schema.V1},
+			{Type: schema.SNSType, Version: schema.V1},
+		}},
 	}
 
-	am.setReceiverMetrics(receivers, 2)
+	am.setReceiverMetrics(cfgReceivers, 2)
 
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
         	            	# HELP grafana_alerting_alertmanager_integrations Number of configured integrations.
         	            	# TYPE grafana_alerting_alertmanager_integrations gauge
-        	            	grafana_alerting_alertmanager_integrations{org="1",type="grafana-oncall"} 2
-        	            	grafana_alerting_alertmanager_integrations{org="1",type="sns"} 2
+        	            	grafana_alerting_alertmanager_integrations{org="1",type="oncall",version="v1"} 2
+        	            	grafana_alerting_alertmanager_integrations{org="1",type="sns",version="v1"} 2
         	            	# HELP grafana_alerting_alertmanager_receivers Number of configured receivers by state. It is considered active if used within a route.
         	            	# TYPE grafana_alerting_alertmanager_receivers gauge
         	            	grafana_alerting_alertmanager_receivers{org="1",state="active"} 2

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -6,9 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/alertmanager/types"
-
-	"github.com/grafana/alerting/notify/nfstatus"
 	receiversTesting "github.com/grafana/alerting/receivers/testing"
 	"github.com/grafana/alerting/templates"
 )
@@ -84,15 +81,6 @@ func (f *FakeConfig) Raw() []byte {
 	panic("implement me")
 }
 
-type fakeNotifier struct{}
-
-func (f *fakeNotifier) Notify(_ context.Context, _ ...*types.Alert) (nfstatus.NotifyInfo, bool, error) {
-	return nfstatus.NotifyInfo{}, true, nil
-}
-
-func (f *fakeNotifier) SendResolved() bool {
-	return true
-}
 
 func GetDecryptedValueFnForTesting(_ context.Context, sjd map[string][]byte, key string, fallback string) string {
 	v, _ := receiversTesting.DecryptForTesting(sjd)(key, fallback)

--- a/notify/testing.go
+++ b/notify/testing.go
@@ -81,7 +81,6 @@ func (f *FakeConfig) Raw() []byte {
 	panic("implement me")
 }
 
-
 func GetDecryptedValueFnForTesting(_ context.Context, sjd map[string][]byte, key string, fallback string) string {
 	v, _ := receiversTesting.DecryptForTesting(sjd)(key, fallback)
 	return v


### PR DESCRIPTION
Adds a `version` label (e.g. `v0mimir1`, `v0mimir2`, `v1`) to the
`grafana_alerting_alertmanager_integrations` gauge so consumers can
distinguish integration counts by schema version.

Integration counts are now derived from the raw `cfg.Receivers` config
rather than the already-built nfstatus receivers, which avoids threading
version through the integration stack. Accepted trade-off: if two
receivers share the same name (a misconfiguration), all their integrations
are counted rather than just the surviving one.