### PR TITLE
notify: add grafana_alerting_alertmanager_templates metric

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -879,6 +879,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 
 	am.setReceiverMetrics(receivers, len(activeReceivers))
 	am.setInhibitionRulesMetrics(cfg.InhibitRules)
+	am.setTemplateMetrics(cfg.Templates)
 
 	am.receivers = receivers
 
@@ -902,6 +903,16 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 
 func (am *GrafanaAlertmanager) setInhibitionRulesMetrics(r []InhibitRule) {
 	am.opts.Metrics.configuredInhibitionRules.WithLabelValues(am.tenantString()).Set(float64(len(r)))
+}
+
+func (am *GrafanaAlertmanager) setTemplateMetrics(cfgTemplates []templates.TemplateDefinition) {
+	byKind := make(map[templates.Kind]int)
+	for _, t := range cfgTemplates {
+		byKind[t.Kind]++
+	}
+	for kind, count := range byKind {
+		am.opts.Metrics.configuredTemplates.WithLabelValues(am.tenantString(), kind.String()).Set(float64(count))
+	}
 }
 
 func (am *GrafanaAlertmanager) setReceiverMetrics(receivers []*nfstatus.Receiver, countActiveReceivers int) {

--- a/notify/grafana_alertmanager_metrics.go
+++ b/notify/grafana_alertmanager_metrics.go
@@ -18,6 +18,7 @@ type GrafanaAlertmanagerMetrics struct {
 	configuredReceivers       *prometheus.GaugeVec
 	configuredIntegrations    *prometheus.GaugeVec
 	configuredInhibitionRules *prometheus.GaugeVec
+	configuredTemplates       *prometheus.GaugeVec
 }
 
 // NewGrafanaAlertmanagerMetrics creates a set of metrics for the Alertmanager.
@@ -43,5 +44,11 @@ func NewGrafanaAlertmanagerMetrics(r prometheus.Registerer, l log.Logger) *Grafa
 			Name:      "alertmanager_inhibition_rules",
 			Help:      "Number of configured inhibition rules.",
 		}, []string{"org"}),
+		configuredTemplates: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "alertmanager_templates",
+			Help:      "Number of configured templates by kind.",
+		}, []string{"org", "kind"}),
 	}
 }

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -605,6 +605,24 @@ func TestGrafanaAlertmanager_setInhibitionRulesMetrics(t *testing.T) {
 `), "grafana_alerting_alertmanager_inhibition_rules"))
 }
 
+func TestGrafanaAlertmanager_setTemplateMetrics(t *testing.T) {
+	am, reg := setupAMTest(t)
+
+	cfgTemplates := []templates.TemplateDefinition{
+		{Name: "grafana-1", Kind: templates.GrafanaKind},
+		{Name: "grafana-2", Kind: templates.GrafanaKind},
+		{Name: "mimir-1", Kind: templates.MimirKind},
+	}
+	am.setTemplateMetrics(cfgTemplates)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+        	            	# HELP grafana_alerting_alertmanager_templates Number of configured templates by kind.
+        	            	# TYPE grafana_alerting_alertmanager_templates gauge
+        	            	grafana_alerting_alertmanager_templates{kind="Grafana",org="1"} 2
+        	            	grafana_alerting_alertmanager_templates{kind="Mimir",org="1"} 1
+`), "grafana_alerting_alertmanager_templates"))
+}
+
 func TestGrafanaAlertmanager_setReceiverMetrics(t *testing.T) {
 	fn := &fakeNotifier{}
 	integrations := []*nfstatus.Integration{


### PR DESCRIPTION
Adds a new gauge `grafana_alerting_alertmanager_templates` with labels
`{org, kind}` that tracks the number of configured templates by kind
(Grafana or Mimir) after each config apply.