### PR TITLE
fix(telegram): accept numeric chatid and message_thread_id

### DIFF
--- a/receivers/telegram/v1/config.go
+++ b/receivers/telegram/v1/config.go
@@ -32,32 +32,51 @@ type Config struct {
 }
 
 func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Config, error) {
-	settings := Config{}
-	err := json.Unmarshal(jsonData, &settings)
-	if err != nil {
-		return settings, fmt.Errorf("failed to unmarshal settings: %w", err)
+	raw := struct {
+		BotToken              string                   `json:"bottoken,omitempty" yaml:"bottoken,omitempty"`
+		ChatID                receivers.OptionalNumber `json:"chatid,omitempty" yaml:"chatid,omitempty"`
+		MessageThreadID       receivers.OptionalNumber `json:"message_thread_id,omitempty" yaml:"message_thread_id,omitempty"`
+		Message               string                   `json:"message,omitempty" yaml:"message,omitempty"`
+		ParseMode             string                   `json:"parse_mode,omitempty" yaml:"parse_mode,omitempty"`
+		DisableWebPagePreview bool                     `json:"disable_web_page_preview,omitempty" yaml:"disable_web_page_preview,omitempty"`
+		ProtectContent        bool                     `json:"protect_content,omitempty" yaml:"protect_content,omitempty"`
+		DisableNotifications  bool                     `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty"`
+	}{}
+	if err := json.Unmarshal(jsonData, &raw); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
-	settings.BotToken = decryptFn.Get("bottoken", settings.BotToken)
+
+	settings := Config{
+		Message:               raw.Message,
+		ParseMode:             raw.ParseMode,
+		DisableWebPagePreview: raw.DisableWebPagePreview,
+		ProtectContent:        raw.ProtectContent,
+		DisableNotifications:  raw.DisableNotifications,
+	}
+
+	settings.BotToken = decryptFn.Get("bottoken", raw.BotToken)
 	if settings.BotToken == "" {
 		return settings, errors.New("could not find Bot Token in settings")
 	}
+
+	settings.ChatID = raw.ChatID.String()
 	if settings.ChatID == "" {
 		return settings, errors.New("could not find Chat Id in settings")
 	}
+
 	if settings.Message == "" {
 		settings.Message = templates.DefaultMessageEmbed
 	}
 
-	var messageThreadID int
-	if settings.MessageThreadID != "" {
-		messageThreadID, err = strconv.Atoi(settings.MessageThreadID)
+	if raw.MessageThreadID != "" {
+		messageThreadID, err := strconv.Atoi(raw.MessageThreadID.String())
 		if err != nil {
 			return settings, errors.New("message thread id must be an integer")
 		}
-
 		if messageThreadID != int(int32(messageThreadID)) {
 			return settings, errors.New("message thread id must be an int32")
 		}
+		settings.MessageThreadID = raw.MessageThreadID.String()
 	}
 	// if field is missing, then we fall back to the previous default: HTML
 	if settings.ParseMode == "" {

--- a/receivers/telegram/v1/config_test.go
+++ b/receivers/telegram/v1/config_test.go
@@ -38,7 +38,19 @@ func TestNewConfig(t *testing.T) {
 			settings:          `{ "bottoken" : "12345" }`,
 			expectedInitError: `could not find Chat Id in settings`,
 		},
-
+		{
+			name:     "should be able to parse an int ChatID",
+			settings: `{"chatid": 12345678}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:  "test-token",
+				ChatID:    "12345678",
+				Message:   templates.DefaultMessageEmbed,
+				ParseMode: DefaultTelegramParseMode,
+			},
+		},
 		{
 			name:     "Minimal valid configuration",
 			settings: `{ "bottoken": "test-token", "chatid": "test-chat-id" }`,
@@ -191,6 +203,20 @@ func TestNewConfig(t *testing.T) {
 			},
 		},
 		{
+			name:     "should be able to parse an int MessageThreadID",
+			settings: `{"chatid": -1312, "message_thread_id": 12345678}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedConfig: Config{
+				BotToken:        "test-token",
+				ChatID:          "-1312",
+				MessageThreadID: "12345678",
+				Message:         templates.DefaultMessageEmbed,
+				ParseMode:       DefaultTelegramParseMode,
+			},
+		},
+		{
 			name:     "should fail if message_thread_id is not an int",
 			settings: `{"chatid": "12345678", "message_thread_id": "notanint"}`,
 			secureSettings: map[string][]byte{
@@ -201,6 +227,14 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:     "should fail if message_thread_id is not a valid int32",
 			settings: `{"chatid": "12345678", "message_thread_id": "21474836471"}`,
+			secureSettings: map[string][]byte{
+				"bottoken": []byte("test-token"),
+			},
+			expectedInitError: "message thread id must be an int32",
+		},
+		{
+			name:     "should fail if numeric message_thread_id is not a valid int32",
+			settings: `{"chatid": -1312, "message_thread_id": 21474836471}`,
 			secureSettings: map[string][]byte{
 				"bottoken": []byte("test-token"),
 			},


### PR DESCRIPTION
Fixes parsing of Telegram's `chatid` and `message_thread_id` fields when provisioned via environment variables. Grafana evaluates `ENV="1"` as the integer `1` since grafana/grafana#63085, which caused:

```
json: cannot unmarshal number into Go struct field Config.chatid of type string
```

This ports the fix from #198 to the current versioned package structure (`receivers/telegram/v1`), using the existing `receivers.OptionalNumber` type — which already handles string-or-number JSON fields — rather than an ad-hoc `any` type switch.

Fixes grafana/grafana#69950