### PR TITLE
fix(receivers): treat JSON null as empty in OptionalNumber

### DIFF
--- a/receivers/number.go
+++ b/receivers/number.go
@@ -24,6 +24,10 @@ func (o OptionalNumber) Int64() (int64, error) {
 }
 
 func (o *OptionalNumber) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		*o = ""
+		return nil
+	}
 	str := string(bytes)
 	*o = OptionalNumber(strings.Trim(str, "\""))
 	return nil

--- a/receivers/number_test.go
+++ b/receivers/number_test.go
@@ -39,6 +39,11 @@ func TestNumberDecode(t *testing.T) {
 			json:     `{ "num" : "12345555555" } `,
 			expected: 12345555555,
 		},
+		{
+			name:     "null value = 0",
+			json:     `{ "num" : null} `,
+			expected: 0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
\`OptionalNumber.UnmarshalJSON\` previously decoded a JSON \`null\` value as the literal string \`"null"\` (via \`strings.Trim\`), which would slip past downstream empty-string validation checks.

This adds a null guard so that \`null\` decodes to an empty \`OptionalNumber\` instead, consistent with how absent fields behave.

Adds a test case covering the null input.

Needed by #558.