### PR TITLE
notify: remove MuteTimeIntervals from NotificationsConfiguration

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -152,12 +152,11 @@ type DynamicLimits struct {
 type NotifyReceiver = nfstatus.Receiver
 
 type NotificationsConfiguration struct {
-	RoutingTree       *Route
-	InhibitRules      []InhibitRule
-	MuteTimeIntervals []MuteTimeInterval
-	TimeIntervals     []TimeInterval
-	Templates         []templates.TemplateDefinition
-	Receivers         []models.ReceiverConfig
+	RoutingTree   *Route
+	InhibitRules  []InhibitRule
+	TimeIntervals []TimeInterval
+	Templates     []templates.TemplateDefinition
+	Receivers     []models.ReceiverConfig
 
 	Limits DynamicLimits
 }
@@ -166,13 +165,12 @@ type NotificationsConfiguration struct {
 type ConfigFingerprint struct {
 	Overall uint64
 
-	RoutingTree       uint64
-	InhibitRules      uint64
-	MuteTimeIntervals uint64
-	TimeIntervals     uint64
-	Templates         uint64
-	Receivers         uint64
-	Limits            uint64
+	RoutingTree   uint64
+	InhibitRules  uint64
+	TimeIntervals uint64
+	Templates     uint64
+	Receivers     uint64
+	Limits        uint64
 }
 
 func (f ConfigFingerprint) String() string {
@@ -187,13 +185,12 @@ func CalculateConfigFingerprint(cfg NotificationsConfiguration) ConfigFingerprin
 		return h.Sum64()
 	}
 	fp := ConfigFingerprint{
-		RoutingTree:       fieldHash(cfg.RoutingTree),
-		InhibitRules:      fieldHash(cfg.InhibitRules),
-		MuteTimeIntervals: fieldHash(cfg.MuteTimeIntervals),
-		TimeIntervals:     fieldHash(cfg.TimeIntervals),
-		Templates:         fieldHash(cfg.Templates),
-		Receivers:         fieldHash(cfg.Receivers),
-		Limits:            fieldHash(cfg.Limits),
+		RoutingTree:   fieldHash(cfg.RoutingTree),
+		InhibitRules:  fieldHash(cfg.InhibitRules),
+		TimeIntervals: fieldHash(cfg.TimeIntervals),
+		Templates:     fieldHash(cfg.Templates),
+		Receivers:     fieldHash(cfg.Receivers),
+		Limits:        fieldHash(cfg.Limits),
 	}
 
 	// Incorporate all field hashes together into an overall hash.
@@ -210,7 +207,6 @@ func CalculateConfigFingerprint(cfg NotificationsConfiguration) ConfigFingerprin
 	fp.Overall = overallHash(
 		fp.RoutingTree,
 		fp.InhibitRules,
-		fp.MuteTimeIntervals,
 		fp.TimeIntervals,
 		fp.Templates,
 		fp.Receivers,
@@ -791,12 +787,9 @@ func (am *GrafanaAlertmanager) WithLock(fn func()) {
 	fn()
 }
 
-func (am *GrafanaAlertmanager) buildTimeIntervals(timeIntervals []config.TimeInterval, muteTimeIntervals []config.MuteTimeInterval) map[string][]timeinterval.TimeInterval {
-	muteTimes := make(map[string][]timeinterval.TimeInterval, len(timeIntervals)+len(muteTimeIntervals))
+func (am *GrafanaAlertmanager) buildTimeIntervals(timeIntervals []config.TimeInterval) map[string][]timeinterval.TimeInterval {
+	muteTimes := make(map[string][]timeinterval.TimeInterval, len(timeIntervals))
 	for _, ti := range timeIntervals {
-		muteTimes[ti.Name] = ti.TimeIntervals
-	}
-	for _, ti := range muteTimeIntervals {
 		muteTimes[ti.Name] = ti.TimeIntervals
 	}
 	return muteTimes
@@ -847,7 +840,7 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 	}
 
 	am.inhibitor = inhibit.NewInhibitor(am.alerts, cfg.InhibitRules, am.marker, am.logger)
-	am.timeIntervals = am.buildTimeIntervals(cfg.TimeIntervals, cfg.MuteTimeIntervals)
+	am.timeIntervals = am.buildTimeIntervals(cfg.TimeIntervals)
 	am.silencer = silence.NewSilencer(am.silences, am.marker, am.logger)
 
 	meshStage := notify.NewGossipSettleStage(am.opts.Peer)

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -848,13 +848,12 @@ func TestCalculateConfigFingerprint(t *testing.T) {
 	require.Equal(t, CalculateConfigFingerprint(baseA), CalculateConfigFingerprint(baseB))
 
 	fieldGetters := map[string]func(ConfigFingerprint) uint64{
-		"RoutingTree":       func(fp ConfigFingerprint) uint64 { return fp.RoutingTree },
-		"InhibitRules":      func(fp ConfigFingerprint) uint64 { return fp.InhibitRules },
-		"MuteTimeIntervals": func(fp ConfigFingerprint) uint64 { return fp.MuteTimeIntervals },
-		"TimeIntervals":     func(fp ConfigFingerprint) uint64 { return fp.TimeIntervals },
-		"Templates":         func(fp ConfigFingerprint) uint64 { return fp.Templates },
-		"Receivers":         func(fp ConfigFingerprint) uint64 { return fp.Receivers },
-		"Limits":            func(fp ConfigFingerprint) uint64 { return fp.Limits },
+		"RoutingTree":   func(fp ConfigFingerprint) uint64 { return fp.RoutingTree },
+		"InhibitRules":  func(fp ConfigFingerprint) uint64 { return fp.InhibitRules },
+		"TimeIntervals": func(fp ConfigFingerprint) uint64 { return fp.TimeIntervals },
+		"Templates":     func(fp ConfigFingerprint) uint64 { return fp.Templates },
+		"Receivers":     func(fp ConfigFingerprint) uint64 { return fp.Receivers },
+		"Limits":        func(fp ConfigFingerprint) uint64 { return fp.Limits },
 	}
 
 	cases := []struct {
@@ -874,13 +873,6 @@ func TestCalculateConfigFingerprint(t *testing.T) {
 			field: "InhibitRules",
 			mutator: func(cfg *NotificationsConfiguration) {
 				cfg.InhibitRules[0].Equal[0] = "service"
-			},
-		},
-		{
-			name:  "mute time intervals",
-			field: "MuteTimeIntervals",
-			mutator: func(cfg *NotificationsConfiguration) {
-				cfg.MuteTimeIntervals[0].TimeIntervals[0].Times[0].StartMinute++
 			},
 		},
 		{
@@ -1028,7 +1020,7 @@ func richNotificationsConfiguration(t *testing.T, rootReceiver string) Notificat
 				Equal: []string{"alertname", "cluster", "namespace"},
 			},
 		},
-		MuteTimeIntervals: []MuteTimeInterval{
+		TimeIntervals: []TimeInterval{
 			{
 				Name: "non_business_hours",
 				TimeIntervals: []timeinterval.TimeInterval{
@@ -1068,8 +1060,6 @@ func richNotificationsConfiguration(t *testing.T, rootReceiver string) Notificat
 					},
 				},
 			},
-		},
-		TimeIntervals: []TimeInterval{
 			{
 				Name: "business_hours",
 				TimeIntervals: []timeinterval.TimeInterval{


### PR DESCRIPTION
## Summary

- Removes `MuteTimeIntervals []MuteTimeInterval` from `NotificationsConfiguration` — callers should place all intervals (mute and active) in `TimeIntervals`
- Removes `MuteTimeIntervals` from `ConfigFingerprint` and its hash computation (it was never being computed)
- Simplifies `buildTimeIntervals` to accept only `[]TimeInterval`
- Updates tests to use `TimeIntervals` for all interval entries