### PR TITLE
CI: Add TruffleHog secret scanning workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,26 @@
+name: TruffleHog Secret Scanning
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  id-token: write
+
+jobs:
+  secret-scan:
+    name: TruffleHog Secret Scan
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@73f4e8cf63fe15bc68de25bd769c4874b82a8d4d # main 2025-05-26
+    with:
+      fail-on-verified: "true"
+      fail-on-unverified: "false"
+      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
+    secrets: inherit


### PR DESCRIPTION
Adds a TruffleHog secret scanning CI workflow that runs on PRs, pushes to main, and merge queue.

The workflow calls the reusable scanner from `grafana/security-github-actions`, which:
- Scans only changed files on PRs (full filesystem on push to main)
- Posts PR comments with findings and remediation instructions
- Applies org-wide exclude patterns (vendor dirs, lock files, etc.)
- Supports repo-local `.trufflehogignore` for additional exclusions
- Uploads scan artifacts for triage

Configuration:
- **Blocks on verified secrets** (`fail-on-verified: true`)
- **Does not block on unverified secrets** (`fail-on-unverified: false`)
- Sends scan metrics to Prometheus via Grafana Bench

