### PR TITLE
notify/historian: redact URLs in persisted notification errors

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -209,6 +209,16 @@ func redactURL(err error) error {
 	return e
 }
 
+// RedactError returns err as a string with any embedded request URL redacted,
+// suitable for persisting to notification history. Reuses redactURL, so it
+// handles *url.Error values (including wrapped ones). Returns "" for nil.
+func RedactError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return redactURL(err).Error()
+}
+
 func GetBasicAuthHeader(user string, password string) string {
 	var userAndPass = user + ":" + password
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(userAndPass))

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -553,3 +553,38 @@ func TestToHTTPClientOption(t *testing.T) {
 	// You need to increase the number of fields covered in this test, if you add a new field to the configuration struct.
 	require.Equalf(t, 3, tp.NumField(), "Not all fields are converted to HTTPClientOption, which means that the configuration will not be supported in upstream integrations")
 }
+
+func TestRedactError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error returns empty string",
+			err:  nil,
+			want: "",
+		},
+		{
+			name: "url.Error redacts the whole URL, incl. path token",
+			err:  &url.Error{Op: "Post", URL: "https://hooks.slack.com/services/T00/B00/XXXXTOKEN", Err: errors.New("dial tcp: i/o timeout")},
+			want: `Post "<redacted>": dial tcp: i/o timeout`,
+		},
+		{
+			name: "wrapped url.Error is unwrapped and redacted",
+			err:  fmt.Errorf("send failed: %w", &url.Error{Op: "Post", URL: "https://secret.example.com/x", Err: errors.New("EOF")}),
+			want: `Post "<redacted>": EOF`,
+		},
+		{
+			name: "non-url error passes through unchanged",
+			err:  errors.New("connection refused"),
+			want: "connection refused",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, RedactError(tc.err))
+		})
+	}
+}

--- a/notify/historian/historian.go
+++ b/notify/historian/historian.go
@@ -17,6 +17,7 @@ import (
 	prometheusModel "github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel/trace"
 
+	alertinghttp "github.com/grafana/alerting/http"
 	alertingInstrument "github.com/grafana/alerting/http/instrument"
 	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/historian/lokiclient"
@@ -181,10 +182,7 @@ func (h *NotificationHistorian) prepareStreams(nhe nfstatus.NotificationHistoryE
 		folderUIDsMap[folderUID] = struct{}{}
 	}
 
-	notificationErrStr := ""
-	if nhe.NotificationErr != nil {
-		notificationErrStr = nhe.NotificationErr.Error()
-	}
+	notificationErrStr := alertinghttp.RedactError(nhe.NotificationErr)
 
 	as := make([]*types.Alert, len(nhe.Alerts))
 	for i := range nhe.Alerts {


### PR DESCRIPTION
Notification errors persisted to the history can contain the destination URL (e.g. transport failures surface the full request URL). This redacts URLs from the error string before it's written, reusing the existing `redactURL` helper.