### PR TITLE
notify/historian: avoid mutating shared error in RedactError

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -210,13 +210,19 @@ func redactURL(err error) error {
 }
 
 // RedactError returns err as a string with any embedded request URL redacted,
-// suitable for persisting to notification history. Reuses redactURL, so it
-// handles *url.Error values (including wrapped ones). Returns "" for nil.
+// for persisting to notification history. It does not mutate err, which may be
+// shared with concurrent readers. Returns "" for nil.
 func RedactError(err error) string {
 	if err == nil {
 		return ""
 	}
-	return redactURL(err).Error()
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		redacted := *ue
+		redacted.URL = "<redacted>"
+		return redacted.Error()
+	}
+	return err.Error()
 }
 
 func GetBasicAuthHeader(user string, password string) string {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -588,3 +588,16 @@ func TestRedactError(t *testing.T) {
 		})
 	}
 }
+
+// TestRedactError_DoesNotMutate guards against regressing to a mutating
+// implementation: the notification error is shared with concurrent readers, so
+// RedactError must not modify the underlying *url.Error in place.
+func TestRedactError_DoesNotMutate(t *testing.T) {
+	const original = "https://hooks.slack.com/services/T00/B00/XXXXTOKEN"
+	ue := &url.Error{Op: "Post", URL: original, Err: errors.New("EOF")}
+
+	got := RedactError(ue)
+
+	assert.Equal(t, `Post "<redacted>": EOF`, got)
+	assert.Equal(t, original, ue.URL, "RedactError must not mutate the shared *url.Error")
+}


### PR DESCRIPTION
`RedactError` reused `redactURL`, which mutates the `*url.Error` in place. The notification error is shared with concurrent readers (the integration's `lastNotifyAttemptError`, read via `GetReport`) while history is recorded from a separate goroutine, so the mutation is a data race. Redact a shallow copy instead — output is unchanged. Adds a regression test.

Follow-up to #606.