### PR TITLE
notify/historian: preserve outer context when redacting wrapped errors

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -224,8 +224,15 @@ func RedactError(err error) string {
 		redacted := *ue
 		redacted.URL = "<redacted>"
 		// Replace the url.Error's rendering within the full message so any
-		// outer wrapper context is retained.
-		msg = strings.Replace(msg, ue.Error(), redacted.Error(), 1)
+		// outer wrapper context is retained. If the wrapper renders the inner
+		// error differently (e.g. quoted/escaped), fall back to redacting the
+		// raw URL string to avoid leaking secrets.
+		origMsg := msg
+		origUE := ue.Error()
+		msg = strings.Replace(msg, origUE, redacted.Error(), 1)
+		if msg == origMsg && ue.URL != "" {
+			msg = strings.ReplaceAll(origMsg, ue.URL, "<redacted>")
+		}
 	}
 	return msg
 }

--- a/http/client.go
+++ b/http/client.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -210,19 +211,23 @@ func redactURL(err error) error {
 }
 
 // RedactError returns err as a string with any embedded request URL redacted,
-// for persisting to notification history. It does not mutate err, which may be
-// shared with concurrent readers. Returns "" for nil.
+// for persisting to notification history. It preserves any outer context
+// wrapping an embedded *url.Error and does not mutate err, which may be shared
+// with concurrent readers. Returns "" for nil.
 func RedactError(err error) string {
 	if err == nil {
 		return ""
 	}
+	msg := err.Error()
 	var ue *url.Error
 	if errors.As(err, &ue) {
 		redacted := *ue
 		redacted.URL = "<redacted>"
-		return redacted.Error()
+		// Replace the url.Error's rendering within the full message so any
+		// outer wrapper context is retained.
+		msg = strings.Replace(msg, ue.Error(), redacted.Error(), 1)
 	}
-	return err.Error()
+	return msg
 }
 
 func GetBasicAuthHeader(user string, password string) string {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -571,9 +571,9 @@ func TestRedactError(t *testing.T) {
 			want: `Post "<redacted>": dial tcp: i/o timeout`,
 		},
 		{
-			name: "wrapped url.Error is unwrapped and redacted",
+			name: "wrapped url.Error is redacted and keeps outer context",
 			err:  fmt.Errorf("send failed: %w", &url.Error{Op: "Post", URL: "https://secret.example.com/x", Err: errors.New("EOF")}),
-			want: `Post "<redacted>": EOF`,
+			want: `send failed: Post "<redacted>": EOF`,
 		},
 		{
 			name: "non-url error passes through unchanged",


### PR DESCRIPTION
Follow-up to #607. `RedactError` collapsed a wrapped `*url.Error` to its inner segment, dropping outer wrapper context that was stored before #606 (e.g. the `alertmanager` receiver's `failed to send alert to Alertmanager:` prefix). It now redacts the URL within the full error string, preserving the wrapper.

Still non-mutating; test updated; passes with `-race`.