### PR TITLE
docs: add policy for when a new first-class integration is acceptable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,35 @@ flow][github-flow] guide from GitHub.
 
 [github-flow]: https://guides.github.com/introduction/flow/
 
+## Adding a new integration
+
+Before proposing a new first-class integration (a receiver under `receivers/`),
+check whether the templated [webhook] integration already covers your target.
+The webhook lets you set the URL, HTTP method, authorization, and a Go-templated
+payload, so it can talk to most HTTP-based notification services without any code
+changes.
+
+Every first-class integration is a long-term maintenance commitment: we have to
+track the upstream API, keep the config and schema in sync, and carry the test
+surface. To keep that cost in check, we default to the webhook and add a
+dedicated integration only when the webhook genuinely cannot do the job.
+
+A dedicated integration is accepted when it:
+
+* **Cannot be expressed with webhook templates** — e.g. the protocol is not plain
+  templated HTTP, the payload needs binary encoding, or the service requires
+  request signing the webhook can't produce.
+
+* **Requires a multi-step flow** — e.g. an auth handshake, token refresh, or a
+  sequence of dependent API calls that a single webhook request can't model.
+
+If your target fits the webhook, please ship it as a documented webhook
+configuration instead of a code change. If you're unsure which side of the line
+you're on, open an issue or a draft PR describing the target API and ask before
+investing in a full integration — we're happy to help you decide.
+
+[webhook]: ./receivers/webhook
+
 You are welcome to create draft PRs at any stage of readiness - this can be
 helpful to ask for assistance or to develop an idea. But before a piece of work
 is finished it should:


### PR DESCRIPTION
## What

Adds an "Adding a new integration" section to CONTRIBUTING.md describing
when a dedicated (first-class) receiver is acceptable versus using the
templated webhook integration.

## Why

In #533 the team reached consensus to avoid growing the set of first-class
integrations — each one is a long-term maintenance commitment (tracking
upstream APIs, keeping config/schema in sync, carrying the test surface).
The templated webhook already covers most HTTP-based notification targets.

This documents the decision so future contributors get the guidance up
front, rather than after investing in a full integration.

## Policy

Default to the webhook. A dedicated integration is accepted only when it:
- cannot be expressed with webhook templates (non-HTTP protocol, binary
  payload, request signing), or
- requires a multi-step flow (auth handshake, token refresh, dependent
  API calls).

Related: #533

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, config, or security impact.
> 
> **Overview**
> **CONTRIBUTING.md** gains a new **Adding a new integration** section that codifies when to add a first-class receiver under `receivers/` versus using the templated **webhook** integration.
> 
> Contributors are told to default to webhook (URL, method, auth, Go-templated payload) because each dedicated integration is ongoing maintenance. A first-class integration is acceptable only when webhook templates cannot express the protocol (e.g. non-HTTP, binary payloads, signing) or when a **multi-step flow** is required (auth handshake, token refresh, chained API calls). Otherwise they should document a webhook config or ask via issue/draft PR before building a full integration. A link to `./receivers/webhook` is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0706ebed9bee0144a421cd0e5ba972fcb24c29b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->