### PR TITLE
Historian: Add plumbing for a minimal operator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vendor
 .idea
 
 testing/alerting-gen/alerting-gen
+apps/historian/historian-operator

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 PATH := $(CURDIR)/.tools/bin:$(PATH)
 SHELL := /usr/bin/env bash
 
+.PHONY: build
+build:
+	$(MAKE) -C apps/historian build
+
 .PHONY: clean
 clean:
 	@# go mod makes the modules read-only, so before deletion we need to make them deleteable
@@ -11,6 +15,8 @@ clean:
 .PHONY: test
 test:
 	go test -tags netgo -timeout 30m -race -count 1 ./...
+	$(MAKE) -C apps/historian test
+	$(MAKE) -C testing/alerting-gen test
 
 .PHONY: lint
 lint: .tools/bin/misspell .tools/bin/faillint .tools/bin/golangci-lint

--- a/apps/historian/Makefile
+++ b/apps/historian/Makefile
@@ -1,3 +1,13 @@
+.PHONY: build # Build the historian operator
+build:
+	go build -tags netgo ./cmd/historian-operator
+
+.PHONY: test # Run unit tests
+# NOTE: -race is intentionally omitted for now: grafana-app-sdk's operator.Runner
+# has an internal data race on startup that the operator bring-up test would trip.
+test:
+	go test -tags netgo -timeout 30m -count 1 ./...
+
 include ../sdk.mk
 
 .PHONY: generate # Run Grafana App SDK code generation

--- a/apps/historian/cmd/historian-operator/config.go
+++ b/apps/historian/cmd/historian-operator/config.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/grafana/grafana-app-sdk/operator"
+	"github.com/spf13/pflag"
+
+	historianconfig "github.com/grafana/alerting/apps/historian/pkg/app/config"
+)
+
+// config is the top-level configuration for the historian operator, covering
+// the webhook server, the metrics server, and the historian app itself.
+type config struct {
+	Webhook webhookConfig
+	Metrics metricsConfig
+	App     historianconfig.RuntimeConfig
+}
+
+func (c *config) AddFlags(flags *pflag.FlagSet) {
+	c.Webhook.AddFlags(flags)
+	c.Metrics.AddFlags(flags)
+	c.App.AddFlags(flags)
+}
+
+type webhookConfig struct {
+	operator.RunnerWebhookConfig
+}
+
+func (c *webhookConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.IntVar(&c.Port, "webhook.port", 8443, "Port on which to serve the webhook and custom route server")
+	flags.StringVar(&c.TLSConfig.CertPath, "webhook.tls.cert-path", "", "Path to the TLS certificate to use for the webhook server")
+	flags.StringVar(&c.TLSConfig.KeyPath, "webhook.tls.key-path", "", "Path to the TLS private key to use for the webhook server")
+}
+
+type metricsConfig struct {
+	operator.RunnerMetricsConfig
+}
+
+func (c *metricsConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.BoolVar(&c.Enabled, "metrics.enabled", true, "Enable the Prometheus metrics server")
+	flags.IntVar(&c.Port, "metrics.port", 0, "Port on which to serve Prometheus metrics (0 uses the default)")
+}

--- a/apps/historian/cmd/historian-operator/main.go
+++ b/apps/historian/cmd/historian-operator/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana-app-sdk/operator"
@@ -48,8 +49,8 @@ func Main(args []string) error {
 		return fmt.Errorf("failed to create operator runner: %w", err)
 	}
 
-	// Context and cancel for the operator's Run method.
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	// Cancel on SIGINT (Ctrl-C) and SIGTERM (Kubernetes pod stop) for graceful shutdown.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	provider := simple.NewAppProvider(historianapis.LocalManifest(), cfg.App, historianapp.New)

--- a/apps/historian/cmd/historian-operator/main.go
+++ b/apps/historian/cmd/historian-operator/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/operator"
+	"github.com/grafana/grafana-app-sdk/simple"
+	"github.com/spf13/pflag"
+
+	historianapis "github.com/grafana/alerting/apps/historian/pkg/apis"
+	historianapp "github.com/grafana/alerting/apps/historian/pkg/app"
+)
+
+func main() {
+	if err := Main(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func Main(args []string) error {
+	// Configure the default logger to use slog.
+	logging.DefaultLogger = logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	var cfg config
+
+	flags := pflag.NewFlagSet("historian-operator", pflag.ContinueOnError)
+	cfg.AddFlags(flags)
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	operatorConfig := operator.RunnerConfig{
+		WebhookConfig: cfg.Webhook.RunnerWebhookConfig,
+		MetricsConfig: cfg.Metrics.RunnerMetricsConfig,
+	}
+
+	runner, err := operator.NewRunner(operatorConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create operator runner: %w", err)
+	}
+
+	// Context and cancel for the operator's Run method.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	provider := simple.NewAppProvider(historianapis.LocalManifest(), cfg.App, historianapp.New)
+
+	manifest := provider.Manifest().ManifestData
+	logging.DefaultLogger.Info("Starting operator for app",
+		"name", manifest.AppName,
+		"group", manifest.Group)
+
+	if err := runner.Run(ctx, provider); err != nil {
+		return fmt.Errorf("operator exited with error: %w", err)
+	}
+
+	logging.DefaultLogger.Info("Normal operator exit")
+	return nil
+}

--- a/apps/historian/cmd/historian-operator/main_test.go
+++ b/apps/historian/cmd/historian-operator/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain_OperatorComesUp(t *testing.T) {
+	// The webhook server needs TLS (the app has custom routes), and the metrics
+	// server hosts the /readyz health endpoint on its own port over plain HTTP.
+	webhookPort := freePort(t)
+	metricsPort := freePort(t)
+	certPath, keyPath := writeTestCert(t)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Main([]string{
+			fmt.Sprintf("--webhook.port=%d", webhookPort),
+			"--webhook.tls.cert-path=" + certPath,
+			"--webhook.tls.key-path=" + keyPath,
+			fmt.Sprintf("--metrics.port=%d", metricsPort),
+			// Enable the notification API so the /notification/query route is served.
+			// The Loki URL is never reached: we send a malformed body, which the
+			// handler rejects before contacting Loki.
+			"--alerting.historian.notification.enabled=true",
+			"--alerting.historian.notification.loki.read-url=http://127.0.0.1:1/",
+		})
+	}()
+
+	// Poll the readiness endpoint until it reports OK; a 200 proves the operator
+	// came up and its runner is serving.
+	client := &http.Client{Timeout: time.Second}
+	readyz := fmt.Sprintf("http://127.0.0.1:%d/readyz", metricsPort)
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(readyz)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 50*time.Millisecond, "operator readiness endpoint never reported OK")
+
+	// Hit the /notification/query custom route on the webhook server (TLS). A
+	// malformed body proves the route is wired through to the app's handler: it
+	// returns 400 before any Loki interaction.
+	tlsClient := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	queryURL := fmt.Sprintf(
+		"https://127.0.0.1:%d/apis/historian.alerting.grafana.app/v0alpha1/namespaces/default/notification/query",
+		webhookPort,
+	)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = tlsClient.Post(queryURL, "application/json", strings.NewReader("not json"))
+		return err == nil
+	}, 10*time.Second, 50*time.Millisecond, "notification/query endpoint never responded")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// Trigger Main's signal-based shutdown and confirm a clean exit.
+	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGINT))
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("operator did not shut down after SIGINT")
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func writeTestCert(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	return certPath, keyPath
+}

--- a/apps/historian/cmd/historian-operator/main_test.go
+++ b/apps/historian/cmd/historian-operator/main_test.go
@@ -25,8 +25,8 @@ import (
 func TestMain_OperatorComesUp(t *testing.T) {
 	// The webhook server needs TLS (the app has custom routes), and the metrics
 	// server hosts the /readyz health endpoint on its own port over plain HTTP.
-	webhookPort := freePort(t)
-	metricsPort := freePort(t)
+	ports := freePorts(t, 2)
+	webhookPort, metricsPort := ports[0], ports[1]
 	certPath, keyPath := writeTestCert(t)
 
 	done := make(chan error, 1)
@@ -87,12 +87,24 @@ func TestMain_OperatorComesUp(t *testing.T) {
 	}
 }
 
-func freePort(t *testing.T) int {
+// freePorts returns n distinct free TCP ports. All listeners are held open
+// simultaneously so the kernel hands out distinct ports, then closed before
+// returning. There is still a small window before the caller binds them, but
+// the ports are guaranteed not to collide with each other.
+func freePorts(t *testing.T, n int) []int {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = l.Close() }()
-	return l.Addr().(*net.TCPAddr).Port
+	listeners := make([]net.Listener, 0, n)
+	ports := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		listeners = append(listeners, l)
+		ports = append(ports, l.Addr().(*net.TCPAddr).Port)
+	}
+	for _, l := range listeners {
+		_ = l.Close()
+	}
+	return ports
 }
 
 func writeTestCert(t *testing.T) (certPath, keyPath string) {


### PR DESCRIPTION
Add a standalone historian-operator command that runs the alerting historian
app via the grafana-app-sdk operator runner, and a bare bones unit test to
check it comes up and somewhat works. A more comprehensive integration test
would be preferable in the future.
