### PR TITLE
receivers: apply extra data to remaining v1 integrations

### DIFF
--- a/receivers/dingding/v1/dingding.go
+++ b/receivers/dingding/v1/dingding.go
@@ -40,7 +40,9 @@ func (dd *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	dingDingURL := buildDingDingURL(dd.tmpl.ExternalURL, l)
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, dd.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, dd.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	message := tmpl(dd.settings.Message)
 	title := tmpl(dd.settings.Title)

--- a/receivers/dingding/v1/dingding_test.go
+++ b/receivers/dingding/v1/dingding_test.go
@@ -207,3 +207,63 @@ func TestNotify(t *testing.T) {
 		})
 	}
 }
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		URL:         "http://localhost",
+		MessageType: defaultDingdingMsgType,
+		Title:       templates.DefaultMessageTitleEmbed,
+		Message:     `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}

--- a/receivers/discord/v1/discord.go
+++ b/receivers/discord/v1/discord.go
@@ -116,7 +116,9 @@ func (d Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) 
 	}
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, d.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, d.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	messageContent := tmpl(d.settings.Message)
 	if tmplErr != nil {

--- a/receivers/discord/v1/discord_test.go
+++ b/receivers/discord/v1/discord_test.go
@@ -926,3 +926,66 @@ Silence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=aler
 		require.Equal(tt, expEmbeds, embeds)
 	})
 }
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	appVersion := fmt.Sprintf("%d.0.0", rand.Uint32())
+
+	settings := Config{
+		Title:      templates.DefaultMessageTitleEmbed,
+		Message:    `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		WebhookURL: "http://localhost",
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	dn := &Notifier{
+		Base:       receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:         webhookSender,
+		tmpl:       tmpl,
+		settings:   settings,
+		images:     &images.UnavailableProvider{},
+		appVersion: appVersion,
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := dn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}

--- a/receivers/googlechat/v1/googlechat.go
+++ b/receivers/googlechat/v1/googlechat.go
@@ -50,9 +50,11 @@ func (gcn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, erro
 	level.Debug(l).Log("msg", "sending notification")
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, gcn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, gcn.tmpl, as, l, &tmplErr)
 
 	var widgets []widget
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	if msg := tmpl(gcn.settings.Message); msg != "" {
 		// Add a text paragraph widget for the message if there is a message.

--- a/receivers/googlechat/v1/googlechat_test.go
+++ b/receivers/googlechat/v1/googlechat_test.go
@@ -617,6 +617,69 @@ func TestNotify(t *testing.T) {
 	}
 }
 
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	appVersion := fmt.Sprintf("%d.0.0", rand.Uint32())
+
+	settings := Config{
+		Title:   templates.DefaultMessageTitleEmbed,
+		Message: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		URL:     "http://localhost",
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:       receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:         webhookSender,
+		tmpl:       tmpl,
+		settings:   settings,
+		images:     &images.UnavailableProvider{},
+		appVersion: appVersion,
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}
+
 // resetTimeNow resets the global variable timeNow to the default value, which is time.Now
 func resetTimeNow() {
 	timeNow = time.Now

--- a/receivers/jira/v1/jira.go
+++ b/receivers/jira/v1/jira.go
@@ -101,7 +101,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 func (n *Notifier) prepareIssueRequestBody(ctx context.Context, logger log.Logger, groupID string, as ...*types.Alert) issue {
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, n.tmpl, as, logger, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, n.tmpl, as, logger, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	renderOrDefault := func(fieldName, template, fallback string) string {
 		defer func() {

--- a/receivers/jira/v1/jira_test.go
+++ b/receivers/jira/v1/jira_test.go
@@ -1074,6 +1074,70 @@ func TestNotify(t *testing.T) {
 	})
 }
 
+func TestNotify_ExtraData(t *testing.T) {
+	ctx := notify.WithGroupKey(context.Background(), "test_group")
+	tmpl := templates.ForTests(t)
+	baseURL := "https://jira.example.com/2"
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	// Create context with extra data
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	u, _ := url.Parse(baseURL)
+	cfg := Config{
+		URL:         u,
+		Summary:     "sum",
+		Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		User:        "test",
+		Password:    "test",
+	}
+
+	mock := receivers.NewMockWebhookSender()
+	mock.SendWebhookFunc = func(_ context.Context, cmd *receivers.SendWebhookSettings) error {
+		switch cmd.URL {
+		case baseURL + "/search":
+			return cmd.Validation(mustMarshal(issueSearchResultV2{}), 200)
+		case baseURL + "/issue":
+			return cmd.Validation(nil, 201)
+		default:
+			t.Fatalf("unexpected url: %s", cmd.URL)
+			return nil
+		}
+	}
+
+	n := New(cfg, receivers.Metadata{}, tmpl, mock, log.NewNopLogger())
+	retry, err := n.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.False(t, retry)
+	require.Len(t, mock.Calls, 2)
+
+	// Verify that extra data is present in the submitted issue body (description field)
+	submitRequest := mock.Calls[1].Args[2].(*receivers.SendWebhookSettings)
+	require.Contains(t, submitRequest.Body, "customField")
+	require.Contains(t, submitRequest.Body, "customValue1")
+	require.Contains(t, submitRequest.Body, "customValue2")
+}
+
 func mustMarshal(v interface{}) []byte {
 	j, err := json.Marshal(v)
 	if err != nil {

--- a/receivers/kafka/v1/kafka.go
+++ b/receivers/kafka/v1/kafka.go
@@ -118,7 +118,9 @@ func (kn *Notifier) notifyWithAPIV2(ctx context.Context, as ...*types.Alert) (bo
 func (kn *Notifier) notifyWithAPIV3(ctx context.Context, as ...*types.Alert) (bool, error) {
 	l := kn.GetLogger(ctx)
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, kn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, kn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	// For v3 the Produce URL is like this,
 	// <Endpoint>/v3/clusters/<KafkaClusterID>/topics/<Topic>/records

--- a/receivers/kafka/v1/kafka.go
+++ b/receivers/kafka/v1/kafka.go
@@ -78,7 +78,9 @@ func (kn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 func (kn *Notifier) notifyWithAPIV2(ctx context.Context, as ...*types.Alert) (bool, error) {
 	l := kn.GetLogger(ctx)
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, kn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, kn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	topicURL := kn.settings.Endpoint + "/topics/" + tmpl(kn.settings.Topic)
 	if tmplErr != nil {

--- a/receivers/kafka/v1/kafka_test.go
+++ b/receivers/kafka/v1/kafka_test.go
@@ -418,56 +418,78 @@ func TestNotify_ExtraData(t *testing.T) {
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
 
-	settings := Config{
-		Endpoint:    "http://localhost",
-		Topic:       "sometopic",
-		Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
-		APIVersion:  apiVersionV2,
-	}
-
-	// Create test alerts
-	alerts := []*types.Alert{
+	cases := []struct {
+		name     string
+		settings Config
+	}{
 		{
-			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-				Annotations: model.LabelSet{"ann1": "annv1"},
+			name: "API version v2",
+			settings: Config{
+				Endpoint:    "http://localhost",
+				Topic:       "sometopic",
+				Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+				APIVersion:  apiVersionV2,
 			},
 		},
 		{
-			Alert: model.Alert{
-				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
-				Annotations: model.LabelSet{"ann1": "annv2"},
+			name: "API version v3",
+			settings: Config{
+				Endpoint:       "http://localhost:882",
+				Topic:          "myTopic",
+				Description:    `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+				APIVersion:     apiVersionV3,
+				KafkaClusterID: "lkc-abcd",
 			},
 		},
 	}
 
-	// Create extra data that will be passed via context
-	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
-	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
-	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create test alerts
+			alerts := []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				},
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			}
 
-	webhookSender := receivers.MockNotificationService()
+			// Create extra data that will be passed via context
+			extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+			extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+			extraDataSlice := []json.RawMessage{extraData1, extraData2}
 
-	pn := &Notifier{
-		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
-		ns:       webhookSender,
-		tmpl:     tmpl,
-		settings: settings,
-		images:   &images2.UnavailableProvider{},
+			webhookSender := receivers.MockNotificationService()
+
+			pn := &Notifier{
+				Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+				ns:       webhookSender,
+				tmpl:     tmpl,
+				settings: c.settings,
+				images:   &images2.UnavailableProvider{},
+			}
+
+			// Create context with extra data
+			ctx := notify.WithGroupKey(context.Background(), "alertname")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+			ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+			// Call Notify
+			ok, err := pn.Notify(ctx, alerts...)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			// Verify that extra data is present in the request body (description field)
+			require.Contains(t, webhookSender.Webhook.Body, "customField")
+			require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+			require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+		})
 	}
-
-	// Create context with extra data
-	ctx := notify.WithGroupKey(context.Background(), "alertname")
-	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
-
-	// Call Notify
-	ok, err := pn.Notify(ctx, alerts...)
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	// Verify that extra data is present in the request body (description field)
-	require.Contains(t, webhookSender.Webhook.Body, "customField")
-	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
-	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
 }

--- a/receivers/kafka/v1/kafka_test.go
+++ b/receivers/kafka/v1/kafka_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"testing"
@@ -408,4 +409,65 @@ func TestNotify(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		Endpoint:    "http://localhost",
+		Topic:       "sometopic",
+		Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		APIVersion:  apiVersionV2,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images2.UnavailableProvider{},
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (description field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
 }

--- a/receivers/line/v1/line.go
+++ b/receivers/line/v1/line.go
@@ -78,7 +78,9 @@ func (ln *Notifier) SendResolved() bool {
 
 func (ln *Notifier) buildLineMessage(ctx context.Context, l log.Logger, as ...*types.Alert) (string, error) {
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, ln.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, ln.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	body := fmt.Sprintf(
 		"%s\n%s",

--- a/receivers/line/v1/line_test.go
+++ b/receivers/line/v1/line_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand"
 	"net/url"
 	"strings"
@@ -203,4 +204,63 @@ func TestTruncatedNotify(t *testing.T) {
 			require.Len(t, webhookSender.Webhook.Body, lineMaxMessageLenRunes+len(title)+len("message=")+1)
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		Title:       templates.DefaultMessageTitleEmbed,
+		Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		Token:       "sometoken",
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (description field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
 }

--- a/receivers/pushover/v1/pushover.go
+++ b/receivers/pushover/v1/pushover.go
@@ -102,7 +102,9 @@ func (pn *Notifier) genPushoverBody(ctx context.Context, l log.Logger, as ...*ty
 	}
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, pn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, pn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	if err := w.WriteField("user", tmpl(pn.settings.UserKey)); err != nil {
 		return nil, b, fmt.Errorf("failed to write the user: %w", err)

--- a/receivers/pushover/v1/pushover_test.go
+++ b/receivers/pushover/v1/pushover_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -257,4 +258,65 @@ func TestNotify(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		UserKey:  "<userKey>",
+		APIToken: "<apiToken>",
+		Title:    templates.DefaultMessageTitleEmbed,
+		Message:  `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images2.UnavailableProvider{},
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
 }

--- a/receivers/sensugo/v1/sensugo.go
+++ b/receivers/sensugo/v1/sensugo.go
@@ -48,7 +48,9 @@ func (sn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	level.Debug(l).Log("msg", "sending Sensu Go result")
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, sn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, sn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	// Sensu Go alerts require an entity and a check. We set it to the user-specified
 	// value (optional), else we fallback and use the grafana rule anme  and ruleID.

--- a/receivers/sensugo/v1/sensugo_test.go
+++ b/receivers/sensugo/v1/sensugo_test.go
@@ -166,6 +166,66 @@ func TestNotify(t *testing.T) {
 	}
 }
 
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		URL:     "http://sensu-api.local:8080",
+		APIKey:  "<apikey>",
+		Message: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	sn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images2.UnavailableProvider{},
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := sn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (output field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}
+
 // resetTimeNow resets the global variable timeNow to the default value, which is time.Now
 func resetTimeNow() {
 	timeNow = time.Now

--- a/receivers/sns/v1/sns.go
+++ b/receivers/sns/v1/sns.go
@@ -23,27 +23,42 @@ import (
 
 const subjectSizeLimit = 100
 
+// snsClient is the subset of the Amazon SNS client used by the Notifier. It is
+// implemented by *sns.SNS and allows the client to be mocked in tests.
+type snsClient interface {
+	Publish(input *sns.PublishInput) (*sns.PublishOutput, error)
+}
+
 // Notifier is responsible for sending
 // alert notifications to Amazon SNS.
 type Notifier struct {
 	*receivers.Base
 	tmpl     *templates.Template
 	settings Config
+	// newSNSClient builds the SNS client used to publish the notification. It is
+	// a field so it can be overridden in tests.
+	newSNSClient func(tmpl func(string) string) (snsClient, error)
 }
 
 func New(cfg Config, meta receivers.Metadata, template *templates.Template, logger log.Logger) *Notifier {
-	return &Notifier{
+	n := &Notifier{
 		Base:     receivers.NewBase(meta, logger),
 		tmpl:     template,
 		settings: cfg,
 	}
+	n.newSNSClient = func(tmpl func(string) string) (snsClient, error) {
+		return n.createSNSClient(tmpl)
+	}
+	return n
 }
 
 // Notify sends the alert notification to sns.
 func (s *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	l := s.GetLogger(ctx)
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, s.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, s.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	level.Info(l).Log("msg", "Sending notification")
 
@@ -52,7 +67,7 @@ func (s *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return false, err
 	}
 
-	snsClient, err := s.createSNSClient(tmpl)
+	snsClient, err := s.newSNSClient(tmpl)
 	if err != nil {
 		return true, err
 	}

--- a/receivers/sns/v1/sns_test.go
+++ b/receivers/sns/v1/sns_test.go
@@ -2,10 +2,12 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -16,6 +18,17 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/templates"
 )
+
+// mockSNSClient is a mock implementation of snsClient that captures the
+// PublishInput passed to Publish.
+type mockSNSClient struct {
+	publishInput *sns.PublishInput
+}
+
+func (m *mockSNSClient) Publish(input *sns.PublishInput) (*sns.PublishOutput, error) {
+	m.publishInput = input
+	return &sns.PublishOutput{}, nil
+}
 
 func TestCreatePublishInput(t *testing.T) {
 	tmpl := templates.ForTests(t)
@@ -139,4 +152,63 @@ func TestCreatePublishInput(t *testing.T) {
 		require.Equal(t, stringWithManyCharacters[:100], *snsInput.Subject)
 		require.Equal(t, "true", *snsInput.MessageAttributes["subject_truncated"].StringValue)
 	})
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost/base")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		TopicARN: "arn:aws:sns:us-east-1:123456789:test",
+		Message:  `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	mockClient := &mockSNSClient{}
+
+	snsNotifier := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		tmpl:     tmpl,
+		settings: settings,
+		newSNSClient: func(_ func(string) string) (snsClient, error) {
+			return mockClient, nil
+		},
+	}
+
+	// Create context with extra data
+	ctx := context.WithValue(context.Background(), receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := snsNotifier.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the published message
+	require.NotNil(t, mockClient.publishInput)
+	require.Contains(t, *mockClient.publishInput.Message, "customField")
+	require.Contains(t, *mockClient.publishInput.Message, "customValue1")
+	require.Contains(t, *mockClient.publishInput.Message, "customValue2")
 }

--- a/receivers/teams/v1/teams.go
+++ b/receivers/teams/v1/teams.go
@@ -250,7 +250,9 @@ func New(cfg Config, meta receivers.Metadata, template *templates.Template, send
 func (tn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	l := tn.GetLogger(ctx)
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, tn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, tn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	card := NewAdaptiveCard()
 	card.AppendItem(AdaptiveCardTextBlockItem{

--- a/receivers/teams/v1/teams_test.go
+++ b/receivers/teams/v1/teams_test.go
@@ -291,6 +291,66 @@ func TestNotify(t *testing.T) {
 	}
 }
 
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		URL:     "http://localhost",
+		Message: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		Title:   templates.DefaultMessageTitleEmbed,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images.UnavailableProvider{},
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}
+
 func TestValidateWebhookResponse(t *testing.T) {
 	require.NoError(t, validateOfficeWebhookResponse([]byte("1"), rand.Int()))
 	err := validateOfficeWebhookResponse([]byte("some error message"), rand.Int())

--- a/receivers/telegram/v1/telegram.go
+++ b/receivers/telegram/v1/telegram.go
@@ -113,7 +113,9 @@ func (tn *Notifier) buildTelegramMessage(ctx context.Context, as []*types.Alert,
 		}
 	}()
 
-	tmpl, _ := templates.TmplText(ctx, tn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, tn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 	// Telegram supports 4096 chars max
 	messageText, truncated := receivers.TruncateInRunes(tmpl(tn.settings.Message), telegramMaxMessageLenRunes)
 	if truncated {

--- a/receivers/telegram/v1/telegram_test.go
+++ b/receivers/telegram/v1/telegram_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"mime"
@@ -257,4 +258,64 @@ Silence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=aler
 			}
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		BotToken: "abcdefgh0123456789",
+		ChatID:   "someid",
+		Message:  `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	notificationService := receivers.MockNotificationService()
+
+	n := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       notificationService,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images.UnavailableProvider{},
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := n.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, notificationService.Webhook.Body, "customField")
+	require.Contains(t, notificationService.Webhook.Body, "customValue1")
+	require.Contains(t, notificationService.Webhook.Body, "customValue2")
 }

--- a/receivers/threema/v1/threema.go
+++ b/receivers/threema/v1/threema.go
@@ -76,7 +76,9 @@ func (tn *Notifier) SendResolved() bool {
 
 func (tn *Notifier) buildMessage(ctx context.Context, l log.Logger, as ...*types.Alert) string {
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, tn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, tn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	message := fmt.Sprintf("%s%s\n\n*Message:*\n%s\n*URL:* %s\n",
 		selectEmoji(as...),

--- a/receivers/threema/v1/threema_test.go
+++ b/receivers/threema/v1/threema_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 	"testing"
 
@@ -126,4 +127,66 @@ func TestNotify(t *testing.T) {
 			require.Equal(t, c.expMsg, webhookSender.Webhook.Body)
 		})
 	}
+}
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		GatewayID:   "*1234567",
+		RecipientID: "87654321",
+		APISecret:   "supersecret",
+		Title:       templates.DefaultMessageTitleEmbed,
+		Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+		images:   &images2.UnavailableProvider{},
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
 }

--- a/receivers/victorops/v1/victorops.go
+++ b/receivers/victorops/v1/victorops.go
@@ -58,7 +58,9 @@ func (vn *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	level.Debug(l).Log("msg", "sending notification")
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, vn.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, vn.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	messageType := buildMessageType(l, tmpl, vn.settings.MessageType, as...)
 

--- a/receivers/victorops/v1/victorops_test.go
+++ b/receivers/victorops/v1/victorops_test.go
@@ -260,3 +260,65 @@ func TestNotify(t *testing.T) {
 		})
 	}
 }
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		URL:         "http://localhost",
+		MessageType: DefaultMessageType,
+		Title:       templates.DefaultMessageTitleEmbed,
+		Description: `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:       receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:         webhookSender,
+		tmpl:       tmpl,
+		settings:   settings,
+		images:     images2.NewFakeProvider(2),
+		appVersion: fmt.Sprintf("%d.0.0", rand.Uint64()),
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (state_message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}

--- a/receivers/wecom/v1/wecom.go
+++ b/receivers/wecom/v1/wecom.go
@@ -42,7 +42,9 @@ func (w *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	level.Debug(l).Log("msg", "sending notification")
 
 	var tmplErr error
-	tmpl, _ := templates.TmplText(ctx, w.tmpl, as, l, &tmplErr)
+	tmpl, data := templates.TmplText(ctx, w.tmpl, as, l, &tmplErr)
+
+	receivers.ApplyExtraData(ctx, data.Alerts)
 
 	bodyMsg := map[string]interface{}{
 		"msgtype": w.settings.MsgType,

--- a/receivers/wecom/v1/wecom_test.go
+++ b/receivers/wecom/v1/wecom_test.go
@@ -508,3 +508,66 @@ func TestGetAccessToken(t *testing.T) {
 		})
 	}
 }
+
+func TestNotify_ExtraData(t *testing.T) {
+	tmpl := templates.ForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	settings := Config{
+		Channel:     DefaultChannelType,
+		EndpointURL: weComEndpoint,
+		URL:         "http://localhost",
+		MsgType:     DefaultsgType,
+		Message:     `{{ range $i, $a := .Alerts }}Alert {{ $i }}: {{ printf "%s" $a.ExtraData }} {{ end }}`,
+		Title:       templates.DefaultMessageTitleEmbed,
+		ToUser:      DefaultToUser,
+	}
+
+	// Create test alerts
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+				Annotations: model.LabelSet{"ann1": "annv1"},
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels:      model.LabelSet{"alertname": "alert2", "lbl1": "val2"},
+				Annotations: model.LabelSet{"ann1": "annv2"},
+			},
+		},
+	}
+
+	// Create extra data that will be passed via context
+	extraData1 := json.RawMessage(`{"customField": "customValue1", "priority": "high"}`)
+	extraData2 := json.RawMessage(`{"customField": "customValue2", "priority": "medium"}`)
+	extraDataSlice := []json.RawMessage{extraData1, extraData2}
+
+	webhookSender := receivers.MockNotificationService()
+
+	pn := &Notifier{
+		Base:     receivers.NewBase(receivers.Metadata{}, log.NewNopLogger()),
+		ns:       webhookSender,
+		tmpl:     tmpl,
+		settings: settings,
+	}
+
+	// Create context with extra data
+	ctx := notify.WithGroupKey(context.Background(), "alertname")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+	ctx = context.WithValue(ctx, receivers.ExtraDataKey, extraDataSlice)
+
+	// Call Notify
+	ok, err := pn.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Verify that extra data is present in the request body (message field)
+	require.Contains(t, webhookSender.Webhook.Body, "customField")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue1")
+	require.Contains(t, webhookSender.Webhook.Body, "customValue2")
+}


### PR DESCRIPTION
## What

Wires up `receivers.ApplyExtraData` in the remaining v1 receivers so that extra data provided via context is applied to the alert data before templating, matching the integrations that already support it:

`dingding`, `discord`, `googlechat`, `jira`, `kafka`, `line`, `pushover`, `sensugo`, `sns`, `teams`, `telegram`, `threema`, `victorops`, `wecom`.

## Tests

Adds a `TestNotify_ExtraData` for each receiver following the established pattern used by the already-covered integrations (opsgenie, webex, pagerduty, slack, etc.): the message template renders `$a.ExtraData`, the extra data is passed via context, and the rendered request body is asserted to contain it.

For **SNS**, its existing tests only exercised `createPublishInput` directly — `Notify` built a real AWS SNS client with no injectable mock. To test the `ApplyExtraData` call in `Notify`, this introduces a small `snsClient` interface and an overridable client factory field on the `Notifier`, so `Notify` can run against a mock client that captures the published message. `New`'s signature is unchanged.

All modified receiver packages' test suites pass; `go vet` and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)