### PR TITLE
Historian: Add Docker image build for operator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/apps/historian/historian-operator
+testing/alerting-gen/alerting-gen
+.git/
+.github/

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,61 @@ mod-check:
 
 .tools/bin/golangci-lint: .tools
 	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+
+##
+## Docker image targets.
+##
+## The build context is this repository root so the parent
+## github.com/grafana/alerting module and go.work are available and images build
+## against this repo's source rather than a pinned published version (see
+## apps/historian/Dockerfile).
+##
+
+IMAGE_TAG ?= $(shell ./tools/image-tag)
+IMAGE_PLATFORM_OS ?= linux
+IMAGE_PLATFORM_ARCH ?= amd64
+IMAGE_PLATFORM := ${IMAGE_PLATFORM_OS}/${IMAGE_PLATFORM_ARCH}
+PROD_IMAGE_PREFIX := us-docker.pkg.dev/grafanalabs-global/docker-alerting-prod/
+DEV_IMAGE_PREFIX := us-docker.pkg.dev/grafanalabs-dev/docker-alerting-dev/
+
+DOCKER_BUILD_EXTRA_ARGS ?=
+
+.PHONY: docker-image-tag
+docker-image-tag:
+	@echo $(IMAGE_TAG)
+
+# Aggregate targets: build or push every image.
+.PHONY: build-docker-images
+build-docker-images: build-docker-image-historian-operator
+
+.PHONY: push-images-prod-registry
+push-images-prod-registry: push-image-prod-historian-operator
+
+.PHONY: push-images-dev-registry
+push-images-dev-registry: push-image-dev-historian-operator
+
+## historian-operator
+
+HISTORIAN_OPERATOR_PROD := $(PROD_IMAGE_PREFIX)historian-operator:$(IMAGE_TAG)
+HISTORIAN_OPERATOR_DEV := $(DEV_IMAGE_PREFIX)historian-operator:$(IMAGE_TAG)
+HISTORIAN_OPERATOR_DEV_LATEST := $(DEV_IMAGE_PREFIX)historian-operator:latest
+
+.PHONY: build-docker-image-historian-operator
+build-docker-image-historian-operator:
+	@echo
+	docker build \
+		--platform=$(IMAGE_PLATFORM) \
+		-t $(HISTORIAN_OPERATOR_PROD) \
+		-t $(HISTORIAN_OPERATOR_DEV) \
+		-t $(HISTORIAN_OPERATOR_DEV_LATEST) \
+		$(DOCKER_BUILD_EXTRA_ARGS) \
+		-f apps/historian/Dockerfile .
+	@echo
+
+.PHONY: push-image-prod-historian-operator
+push-image-prod-historian-operator: build-docker-image-historian-operator
+	docker push $(HISTORIAN_OPERATOR_PROD)
+
+.PHONY: push-image-dev-historian-operator
+push-image-dev-historian-operator: build-docker-image-historian-operator
+	docker push $(HISTORIAN_OPERATOR_DEV)

--- a/apps/historian/Dockerfile
+++ b/apps/historian/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /build/apps/historian
 RUN make build
 
 FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40 AS runtime
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /build/apps/historian/historian-operator /usr/bin/historian-operator
 
 ENTRYPOINT ["/usr/bin/historian-operator"]

--- a/apps/historian/Dockerfile
+++ b/apps/historian/Dockerfile
@@ -1,0 +1,41 @@
+# Build context is the repository root, NOT apps/historian, so that the parent
+# github.com/grafana/alerting module and the root go.work are available and the
+# operator builds against this repo's source rather than a pinned published
+# version. Build with:
+#
+#   docker build -f apps/historian/Dockerfile .
+#
+# (run from the repository root; `make build-docker-image-historian-operator`,
+# or the `build-docker-images` aggregate, does this for you.)
+FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+
+# make is used to build via the Makefile's `build` target.
+RUN apk add --no-cache make
+
+WORKDIR /build
+
+# Copy the workspace and both modules' dependency files first, in their own
+# layer, so downloads are cached and only re-run when a go.mod/go.sum/go.work
+# changes rather than on every source edit.
+COPY go.work go.work.sum ./
+COPY go.mod go.sum ./
+COPY apps/historian/go.mod apps/historian/go.sum ./apps/historian/
+# testing/alerting-gen is listed in go.work, so workspace mode requires its
+# module file to be present even though the operator does not depend on it.
+COPY testing/alerting-gen/go.mod testing/alerting-gen/go.sum ./testing/alerting-gen/
+RUN go mod download
+
+# Copy the parent module and the historian app source.
+COPY . .
+
+# `make build` runs `go build -tags netgo ./cmd/historian-operator`, emitting the
+# binary at ./historian-operator. Run it from the app dir since the target uses a
+# package-relative path. Workspace mode resolves github.com/grafana/alerting to
+# the parent module copied above.
+WORKDIR /build/apps/historian
+RUN make build
+
+FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40 AS runtime
+COPY --from=builder /build/apps/historian/historian-operator /usr/bin/historian-operator
+
+ENTRYPOINT ["/usr/bin/historian-operator"]

--- a/tools/image-tag
+++ b/tools/image-tag
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/tools/image-tag
+# Provenance-includes-license: Apache-2.0
+# Provenance-includes-copyright: The Cortex Authors.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Append -WIP when there are tracked, uncommitted changes (staged or unstaged),
+# ignoring untracked files.
+WORKING_SUFFIX=$(if [ -n "$(git status --porcelain --untracked-files=no)" ]; then echo "-WIP"; else echo ""; fi)
+BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
+echo "${BRANCH_PREFIX//\//-}-$(git rev-parse --short=8 HEAD)$WORKING_SUFFIX"


### PR DESCRIPTION
Adds new make targets for building a Docker image for the `historian-operator` binary

```
$ make build-docker-images
```
