### PR TITLE
Remove BuildWithManifestBuilder flag and dead notifier-factory code

### DIFF
--- a/notify/factory.go
+++ b/notify/factory.go
@@ -238,50 +238,6 @@ func BuildReceiversIntegrations(
 	return integrationsMap, nil
 }
 
-// BuildReceiverIntegrations builds integrations for the provided API receiver and returns them.
-func BuildReceiverIntegrations(
-	tenantID int64,
-	receiver models.ReceiverConfig,
-	tmpls TemplatesProvider,
-	images images.Provider,
-	decryptFn GetDecryptedValueFn,
-	decodeFn DecodeSecretsFn,
-	emailSender receivers.EmailSender,
-	httpClientOptions []http.ClientOption,
-	wrapNotifierFunc WrapNotifierFunc,
-	version string,
-	logger log.Logger,
-	notificationHistorian nfstatus.NotificationHistorian,
-) ([]*Integration, error) {
-	var integrations []*Integration
-	if len(receiver.Integrations) > 0 {
-		receiverCfg, err := BuildReceiverConfiguration(context.Background(), receiver, decodeFn, decryptFn)
-		if err != nil {
-			return nil, err
-		}
-		tmpl, err := tmpls.GetTemplate(templates.GrafanaKind)
-		if err != nil {
-			return nil, err
-		}
-		integrations, err = BuildGrafanaReceiverIntegrations(
-			receiverCfg,
-			tmpl,
-			images,
-			logger,
-			emailSender,
-			wrapNotifierFunc,
-			tenantID,
-			version,
-			notificationHistorian,
-			httpClientOptions...,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return integrations, nil
-}
-
 // BuildReceiverIntegrationsWithManifests builds integrations for the provided API receiver using
 // the manifest-based factory for v1 (Grafana) integrations instead of the typed config switch.
 // Unlike BuildGrafanaReceiverIntegrations, this function is fail-fast: it returns on the first

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -214,7 +214,6 @@ func BuildReceiversIntegrations(
 	version string,
 	logger log.Logger,
 	notificationHistorian nfstatus.NotificationHistorian,
-	useManifestBuilder bool,
 ) (map[string][]*Integration, error) {
 	nameToReceiver := make(map[string]models.ReceiverConfig, len(receivers))
 	for _, receiver := range receivers {
@@ -230,13 +229,7 @@ func BuildReceiversIntegrations(
 
 	integrationsMap := make(map[string][]*Integration, len(receivers))
 	for name, apiReceiver := range nameToReceiver {
-		var integrations []*Integration
-		var err error
-		if useManifestBuilder {
-			integrations, err = BuildReceiverIntegrationsWithManifests(tenantID, apiReceiver, templ, images, decryptFn, decodeFn, emailSender, httpClientOptions, notifierFunc, version, logger, notificationHistorian)
-		} else {
-			integrations, err = BuildReceiverIntegrations(tenantID, apiReceiver, templ, images, decryptFn, decodeFn, emailSender, httpClientOptions, notifierFunc, version, logger, notificationHistorian)
-		}
+		integrations, err := BuildReceiverIntegrationsWithManifests(tenantID, apiReceiver, templ, images, decryptFn, decodeFn, emailSender, httpClientOptions, notifierFunc, version, logger, notificationHistorian)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build receiver %s: %w", name, err)
 		}

--- a/notify/factory.go
+++ b/notify/factory.go
@@ -2,201 +2,23 @@ package notify
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-
-	"github.com/prometheus/alertmanager/notify"
 
 	"github.com/grafana/alerting/http"
 	"github.com/grafana/alerting/images"
 	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify/nfstatus"
 	"github.com/grafana/alerting/receivers"
-	alertmanager "github.com/grafana/alerting/receivers/alertmanager/v1"
-	dingding "github.com/grafana/alerting/receivers/dingding/v1"
-	discord "github.com/grafana/alerting/receivers/discord/v1"
-	email "github.com/grafana/alerting/receivers/email/v1"
-	googlechat "github.com/grafana/alerting/receivers/googlechat/v1"
-	jira "github.com/grafana/alerting/receivers/jira/v1"
-	kafka "github.com/grafana/alerting/receivers/kafka/v1"
-	line "github.com/grafana/alerting/receivers/line/v1"
-	mqtt "github.com/grafana/alerting/receivers/mqtt/v1"
-	oncall "github.com/grafana/alerting/receivers/oncall/v1"
-	opsgenie "github.com/grafana/alerting/receivers/opsgenie/v1"
-	pagerduty "github.com/grafana/alerting/receivers/pagerduty/v1"
-	pushover "github.com/grafana/alerting/receivers/pushover/v1"
 	"github.com/grafana/alerting/receivers/schema"
-	sensugo "github.com/grafana/alerting/receivers/sensugo/v1"
-	slack "github.com/grafana/alerting/receivers/slack/v1"
-	sns "github.com/grafana/alerting/receivers/sns/v1"
-	teams "github.com/grafana/alerting/receivers/teams/v1"
-	telegram "github.com/grafana/alerting/receivers/telegram/v1"
-	threema "github.com/grafana/alerting/receivers/threema/v1"
-	victorops "github.com/grafana/alerting/receivers/victorops/v1"
-	webex "github.com/grafana/alerting/receivers/webex/v1"
-	webhook "github.com/grafana/alerting/receivers/webhook/v1"
-	wecom "github.com/grafana/alerting/receivers/wecom/v1"
 	"github.com/grafana/alerting/templates"
 )
 
 type WrapNotifierFunc func(integrationName string, notifier nfstatus.Notifier) nfstatus.Notifier
 
 var NoWrap WrapNotifierFunc = func(_ string, notifier nfstatus.Notifier) nfstatus.Notifier { return notifier }
-
-// BuildGrafanaReceiverIntegrations creates integrations for each configured notification channel in GrafanaReceiverConfig.
-// It returns a slice of Integration objects, one for each notification channel, along with any errors that occurred.
-func BuildGrafanaReceiverIntegrations(
-	receiver GrafanaReceiverConfig,
-	tmpl *templates.Template,
-	img images.Provider,
-	logger log.Logger,
-	emailSender receivers.EmailSender,
-	wrapNotifier WrapNotifierFunc,
-	orgID int64,
-	version string,
-	notificationHistorian nfstatus.NotificationHistorian,
-	httpClientOptions ...http.ClientOption,
-) ([]*Integration, error) {
-	type notificationChannel interface {
-		notify.Notifier
-		notify.ResolvedSender
-	}
-	var (
-		integrations []*Integration
-		errs         error
-		ci           = func(idx int, cfg receivers.Metadata, httpClientConfig *http.HTTPClientConfig, newInt func(cli *http.Client) notificationChannel) {
-			client, err := http.NewClient(httpClientConfig, httpClientOptions...)
-			if err != nil {
-				errs = errors.Join(errs, fmt.Errorf("failed to create HTTP client for %q notifier %q (UID: %q): %w", cfg.Type, cfg.Name, cfg.UID, err))
-				return
-			}
-			n := newInt(client)
-			notify := wrapNotifier(cfg.Name, nfstatus.NewNotifierAdapter(n))
-			i := NewIntegration(notify, n, string(cfg.Type), idx, cfg.Name, notificationHistorian, logger)
-			integrations = append(integrations, i)
-		}
-	)
-	// Range through each notification channel in the receiver and create an integration for it.
-	for i, cfg := range receiver.AlertmanagerConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(_ *http.Client) notificationChannel {
-			return alertmanager.New(cfg.Settings, cfg.Metadata, img, logger)
-		})
-	}
-	for i, cfg := range receiver.DingdingConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return dingding.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
-		})
-	}
-	for i, cfg := range receiver.DiscordConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return discord.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
-		})
-	}
-	for i, cfg := range receiver.EmailConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(_ *http.Client) notificationChannel {
-			return email.New(cfg.Settings, cfg.Metadata, tmpl, emailSender, img, logger)
-		})
-	}
-	for i, cfg := range receiver.GooglechatConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return googlechat.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
-		})
-	}
-	for i, cfg := range receiver.JiraConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return jira.New(cfg.Settings, cfg.Metadata, tmpl, http.NewForkedSender(cli), logger)
-		})
-	}
-	for i, cfg := range receiver.KafkaConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return kafka.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.LineConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return line.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
-		})
-	}
-	for i, cfg := range receiver.MqttConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(_ *http.Client) notificationChannel {
-			return mqtt.New(cfg.Settings, cfg.Metadata, tmpl, logger, nil)
-		})
-	}
-	for i, cfg := range receiver.OnCallConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return oncall.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
-		})
-	}
-	for i, cfg := range receiver.OpsgenieConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return opsgenie.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.PagerdutyConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return pagerduty.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.PushoverConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return pushover.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.SensugoConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return sensugo.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.SNSConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(_ *http.Client) notificationChannel {
-			return sns.New(cfg.Settings, cfg.Metadata, tmpl, logger)
-		})
-	}
-	for i, cfg := range receiver.SlackConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return slack.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
-		})
-	}
-	for i, cfg := range receiver.TeamsConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return teams.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.TelegramConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return telegram.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.ThreemaConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return threema.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger)
-		})
-	}
-	for i, cfg := range receiver.VictoropsConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return victorops.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, version)
-		})
-	}
-	for i, cfg := range receiver.WebhookConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return webhook.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
-		})
-	}
-	for i, cfg := range receiver.WecomConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return wecom.New(cfg.Settings, cfg.Metadata, tmpl, cli, logger)
-		})
-	}
-	for i, cfg := range receiver.WebexConfigs {
-		ci(i, cfg.Metadata, cfg.HTTPClientConfig, func(cli *http.Client) notificationChannel {
-			return webex.New(cfg.Settings, cfg.Metadata, tmpl, cli, img, logger, orgID)
-		})
-	}
-	return integrations, errs
-}
 
 // BuildReceiversIntegrations builds integrations for the provided API receivers and returns them mapped by receiver name.
 // It ensures uniqueness of receivers by the name, overwriting duplicates and logs warnings.
@@ -239,9 +61,8 @@ func BuildReceiversIntegrations(
 }
 
 // BuildReceiverIntegrationsWithManifests builds integrations for the provided API receiver using
-// the manifest-based factory for v1 (Grafana) integrations instead of the typed config switch.
-// Unlike BuildGrafanaReceiverIntegrations, this function is fail-fast: it returns on the first
-// error without returning partial results.
+// the manifest-based factory. It is fail-fast: it returns on the first error without returning
+// partial results.
 func BuildReceiverIntegrationsWithManifests(
 	tenantID int64,
 	receiver models.ReceiverConfig,
@@ -267,7 +88,7 @@ func BuildReceiverIntegrationsWithManifests(
 			HttpOpts:       http.ToHTTPClientOption(httpClientOptions...),
 		}
 		// Track per-type indices so that integrations of the same type get consecutive indices (0, 1, 2…).
-		// This matches BuildGrafanaReceiverIntegrations behavior and preserves notification log management (see createReceiverStage).
+		// This preserves notification log management ordering (see createReceiverStage).
 		typeCounters := make(map[schema.IntegrationType]int)
 		for _, cfg := range receiver.Integrations {
 			idx := typeCounters[cfg.Type]

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -25,107 +25,6 @@ import (
 	"github.com/grafana/alerting/templates"
 )
 
-func TestBuildReceiverIntegrations(t *testing.T) {
-	var orgID = rand.Int63()
-	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
-	imageProvider := &images.URLProvider{}
-	tmpl := templates.ForTests(t)
-
-	emailService := receivers.MockNotificationService()
-
-	noopWrapper := func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
-		return n
-	}
-
-	getFullConfig := func(t *testing.T) (GrafanaReceiverConfig, int) {
-		recCfg := models.ReceiverConfig{Name: "test-receiver"}
-		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
-			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
-		}
-		parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, GetDecryptedValueFnForTesting)
-		require.NoError(t, err)
-		parsed.WebhookConfigs[0].Settings.URL = "http://localhost:8080" // to make sure Notify test works
-		return parsed, len(recCfg.Integrations)
-	}
-
-	t.Run("should build all supported notifiers", func(t *testing.T) {
-		fullCfg, qty := getFullConfig(t)
-
-		wrapped := 0
-		notifyWrapper := func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
-			wrapped++
-			return n
-		}
-
-		integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, nil)
-		require.NoError(t, err)
-
-		require.Len(t, integrations, qty)
-
-		t.Run("should call notify wrapper for each config", func(t *testing.T) {
-			require.Equal(t, qty, wrapped)
-		})
-		t.Run("should use custom dial context", func(t *testing.T) {
-			customDialError := fmt.Errorf("custom dial function error")
-			clientOpts := []http.ClientOption{
-				http.WithUserAgent("Grafana-test"),
-				http.WithDialer(net.Dialer{
-					// Override the Resolver so that configurations with invalid hostnames also return
-					// "custom dial function error" instead of "no such host".
-					Resolver: &net.Resolver{
-						Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
-							return nil, customDialError
-						},
-					},
-					Control: func(_, _ string, _ syscall.RawConn) error {
-						return customDialError
-					},
-				}),
-			}
-
-			integrations, err := BuildGrafanaReceiverIntegrations(fullCfg, tmpl, imageProvider, log.NewNopLogger(), emailService, notifyWrapper, orgID, version, nil, clientOpts...)
-			require.NoError(t, err)
-
-			require.Len(t, integrations, qty)
-			for _, integration := range integrations {
-				if integration.Name() == "email" {
-					continue // skip email integration, it is not using webhook sender.
-				}
-				t.Run(integration.Name(), func(t *testing.T) {
-					if integration.Name() == "mqtt" {
-						t.Skip() // TODO: mqtt integration does not support custom dialer yet.
-					}
-					if integration.Name() == "sns" {
-						t.Skip() // TODO: sns integration does not support custom dialer yet.
-					}
-					if integration.Name() == "slack" {
-						t.Skip() // TODO: slack integration does not support custom dialer yet.
-					}
-					if integration.Name() == "prometheus-alertmanager" {
-						t.Skip() // TODO: prometheus-alertmanager integration does not support custom dialer yet.
-					}
-					alert := newTestAlert(nil, time.Now(), time.Now())
-
-					ctx := context.Background()
-					ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", integration.Name(), alert.Labels.Fingerprint(), time.Now().Unix()))
-					ctx = notify.WithGroupLabels(ctx, alert.Labels)
-					ctx = notify.WithReceiverName(ctx, integration.String())
-					_, err := integration.Notify(ctx, &alert)
-					require.Error(t, err)
-					require.ErrorContains(t, err, customDialError.Error())
-				})
-			}
-		})
-	})
-	t.Run("should not produce any integration if config is empty", func(t *testing.T) {
-		cfg := GrafanaReceiverConfig{Name: "test"}
-
-		integrations, err := BuildGrafanaReceiverIntegrations(cfg, tmpl, imageProvider, log.NewNopLogger(), emailService, noopWrapper, orgID, version, nil)
-		require.NoError(t, err)
-		require.Empty(t, integrations)
-	})
-}
-
 func TestBuildReceiversIntegrations(t *testing.T) {
 	var orgID = rand.Int63()
 	var version = fmt.Sprintf("Grafana v%d", rand.Uint32())
@@ -291,5 +190,75 @@ func TestBuildReceiverIntegrationsWithManifests(t *testing.T) {
 		require.Equal(t, "webhook[0]", integrations[0].String())
 		require.Equal(t, "email[0]", integrations[1].String())
 		require.Equal(t, "webhook[1]", integrations[2].String())
+	})
+
+	t.Run("should use custom dial context", func(t *testing.T) {
+		recCfg := models.ReceiverConfig{Name: "test-receiver"}
+		for _, cfg := range notifytest.AllKnownV1ConfigsForTesting {
+			recCfg.Integrations = append(recCfg.Integrations, cfg.GetRawNotifierConfig(""))
+		}
+		for _, ic := range recCfg.Integrations {
+			if ic.Type == schema.WebhookType {
+				// to make sure Notify test works
+				newSettings, err := MergeSettings(ic.Settings, []byte(`{"url":"http://localhost:8080"}`))
+				require.NoError(t, err)
+				ic.Settings = newSettings
+			}
+		}
+		qty := len(recCfg.Integrations)
+
+		customDialError := fmt.Errorf("custom dial function error")
+		clientOpts := []http.ClientOption{
+			http.WithUserAgent("Grafana-test"),
+			http.WithDialer(net.Dialer{
+				// Override the Resolver so that configurations with invalid hostnames also return
+				// "custom dial function error" instead of "no such host".
+				Resolver: &net.Resolver{
+					Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
+						return nil, customDialError
+					},
+				},
+				Control: func(_, _ string, _ syscall.RawConn) error {
+					return customDialError
+				},
+			}),
+		}
+
+		integrations, err := BuildReceiverIntegrationsWithManifests(
+			orgID, recCfg, tmpl, imageProvider,
+			GetDecryptedValueFnForTesting, DecodeSecretsFromBase64,
+			emailService, clientOpts, noopWrapper, version, log.NewNopLogger(), nil,
+		)
+		require.NoError(t, err)
+
+		require.Len(t, integrations, qty)
+		for _, integration := range integrations {
+			if integration.Name() == "email" {
+				continue // skip email integration, it is not using webhook sender.
+			}
+			t.Run(integration.Name(), func(t *testing.T) {
+				if integration.Name() == "mqtt" {
+					t.Skip() // TODO: mqtt integration does not support custom dialer yet.
+				}
+				if integration.Name() == "sns" {
+					t.Skip() // TODO: sns integration does not support custom dialer yet.
+				}
+				if integration.Name() == "slack" {
+					t.Skip() // TODO: slack integration does not support custom dialer yet.
+				}
+				if integration.Name() == "prometheus-alertmanager" {
+					t.Skip() // TODO: prometheus-alertmanager integration does not support custom dialer yet.
+				}
+				alert := newTestAlert(nil, time.Now(), time.Now())
+
+				ctx := context.Background()
+				ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", integration.Name(), alert.Labels.Fingerprint(), time.Now().Unix()))
+				ctx = notify.WithGroupLabels(ctx, alert.Labels)
+				ctx = notify.WithReceiverName(ctx, integration.String())
+				_, err := integration.Notify(ctx, &alert)
+				require.Error(t, err)
+				require.ErrorContains(t, err, customDialError.Error())
+			})
+		}
 	})
 }

--- a/notify/factory_test.go
+++ b/notify/factory_test.go
@@ -161,34 +161,10 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			version,
 			log.NewNopLogger(),
 			nil,
-			true,
 		)
 		require.NoError(t, err)
 		require.Contains(t, actual, "test2")
 		require.Equal(t, "email[0]", actual["test2"][0].String())
-
-		t.Run("legacy way", func(t *testing.T) {
-			actual, err := BuildReceiversIntegrations(
-				orgID,
-				apiReceivers,
-				tmpl,
-				imageProvider,
-				NoopDecrypt,
-				DecodeSecretsFromBase64,
-				emailService,
-				nil,
-				func(_ string, n nfstatus.Notifier) nfstatus.Notifier {
-					return n
-				},
-				version,
-				log.NewNopLogger(),
-				nil,
-				false,
-			)
-			require.NoError(t, err)
-			require.Contains(t, actual, "test2")
-			require.Equal(t, "email[0]", actual["test2"][0].String())
-		})
 	})
 
 	t.Run("should ignore duplicates", func(t *testing.T) {
@@ -223,7 +199,6 @@ func TestBuildReceiversIntegrations(t *testing.T) {
 			version,
 			log.NewNopLogger(),
 			nil,
-			true,
 		)
 		require.NoError(t, err)
 		require.Contains(t, actual, "test")

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -247,8 +247,6 @@ type GrafanaAlertmanagerOpts struct {
 	NotificationHistorian nfstatus.NotificationHistorian
 
 	DispatchTimer DispatchTimer
-
-	BuildWithManifestBuilder bool
 }
 
 func (c *GrafanaAlertmanagerOpts) Validate() error {
@@ -823,7 +821,6 @@ func (am *GrafanaAlertmanager) ApplyConfig(cfg NotificationsConfiguration) (err 
 		am.opts.Version,
 		am.logger,
 		am.opts.NotificationHistorian,
-		am.opts.BuildWithManifestBuilder,
 	)
 	if err != nil {
 		return err
@@ -1066,23 +1063,7 @@ func (am *GrafanaAlertmanager) tenantString() string {
 }
 
 func (am *GrafanaAlertmanager) buildReceiverIntegrations(receiver models.ReceiverConfig, tmpls TemplatesProvider) ([]*Integration, error) {
-	if am.opts.BuildWithManifestBuilder {
-		return BuildReceiverIntegrationsWithManifests(
-			am.opts.TenantID,
-			receiver,
-			tmpls,
-			am.opts.ImageProvider,
-			am.opts.Decrypter,
-			DecodeSecretsFromBase64,
-			am.opts.EmailSender,
-			nil,
-			NoWrap,
-			am.opts.Version,
-			am.logger,
-			am.opts.NotificationHistorian,
-		)
-	}
-	return BuildReceiverIntegrations(
+	return BuildReceiverIntegrationsWithManifests(
 		am.opts.TenantID,
 		receiver,
 		tmpls,

--- a/notify/receivers_test.go
+++ b/notify/receivers_test.go
@@ -527,36 +527,43 @@ func TestHTTPConfig(t *testing.T) {
 					},
 				}
 
-				parsed, err := BuildReceiverConfiguration(context.Background(), recCfg, DecodeSecretsFromBase64, GetDecryptedValueFnForTesting)
-				require.NoError(t, err)
-
 				invalidAddress := fmt.Errorf("invalid address")
 				allowedUrls := map[string]struct{}{
 					oauth2Server.URL: {},
 					testServer.URL:   {},
 				}
-				integrations, err := BuildGrafanaReceiverIntegrations(
-					parsed,
-					templates.ForTests(t),
-					&images.URLProvider{},
-					log.NewNopLogger(),
-					receivers.MockNotificationService(),
-					NoWrap,
+
+				tmplCfg, err := templates.NewConfig("grafana", "http://localhost", "", templates.DefaultLimits)
+				require.NoError(t, err)
+				tmpl, err := templates.NewFactory(nil, tmplCfg, log.NewNopLogger())
+				require.NoError(t, err)
+
+				integrations, err := BuildReceiverIntegrationsWithManifests(
 					rand.Int63(),
+					recCfg,
+					tmpl,
+					&images.URLProvider{},
+					GetDecryptedValueFnForTesting,
+					DecodeSecretsFromBase64,
+					receivers.MockNotificationService(),
+					[]alertingHttp.ClientOption{
+						alertingHttp.WithDialer(net.Dialer{
+							// Prevent all network calls not going to oauth2Server or testServer.
+							// Since we're actually calling the real Notify method, this is to ensure that
+							// we don't start calling real endpoints in the tests.
+							// Additionally, it will help ensure the test is correctly validating the OAuth2 flow.
+							Control: func(_, address string, _ syscall.RawConn) error {
+								if _, ok := allowedUrls["http://"+address]; !ok {
+									return fmt.Errorf("%w: %s", invalidAddress, address)
+								}
+								return nil
+							},
+						}),
+					},
+					NoWrap,
 					fmt.Sprintf("Grafana v%d", rand.Uint32()),
+					log.NewNopLogger(),
 					nil,
-					alertingHttp.WithDialer(net.Dialer{
-						// Prevent all network calls not going to oauth2Server or testServer.
-						// Since we're actually calling the real Notify method, this is to ensure that
-						// we don't start calling real endpoints in the tests.
-						// Additionally, it will help ensure the test is correctly validating the OAuth2 flow.
-						Control: func(_, address string, _ syscall.RawConn) error {
-							if _, ok := allowedUrls["http://"+address]; !ok {
-								return fmt.Errorf("%w: %s", invalidAddress, address)
-							}
-							return nil
-						},
-					}),
 				)
 				require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Remove the `BuildWithManifestBuilder` staged-rollout flag from `GrafanaAlertmanagerOpts`; the manifest-based factory (`BuildReceiverIntegrationsWithManifests`) is now the only path used at runtime.
- Remove `BuildReceiverIntegrations` and `BuildGrafanaReceiverIntegrations`, which became unused once both call sites collapsed onto the manifest-based factory.
- Migrate the two tests that used `BuildGrafanaReceiverIntegrations` as scaffolding (OAuth2 notify flow, custom dial context) to build integrations via `BuildReceiverIntegrationsWithManifests` instead, preserving their behavior coverage.