### PR TITLE
Bump golangci-lint to v2.12.2 and fix issues it surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ mod-check:
 	GOPATH=$(CURDIR)/.tools go install github.com/fatih/faillint@v1.10.0
 
 .tools/bin/golangci-lint: .tools
-	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+	GOPATH=$(CURDIR)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 ##
 ## Docker image targets.

--- a/notify/compat.go
+++ b/notify/compat.go
@@ -183,7 +183,7 @@ func ConfigReceiverToMimirIntegrations(receiver ConfigReceiver) ([]MimirIntegrat
 		for j := 0; j < sliceVal.Len(); j++ {
 			var elem any
 			item := sliceVal.Index(j)
-			if elemType.Kind() == reflect.Ptr {
+			if elemType.Kind() == reflect.Pointer {
 				elem = item.Elem().Interface()
 			} else {
 				elem = item.Interface()

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -1027,14 +1027,14 @@ func (e AlertValidationError) Error() string {
 
 // createReceiverStage creates a pipeline of stages for a receiver.
 func (am *GrafanaAlertmanager) createReceiverStage(name string, integrations []*notify.Integration, notificationLog notify.NotificationLog) notify.Stage {
-	var fs notify.FanoutStage
+	fs := make(notify.FanoutStage, 0, len(integrations))
 	for i := range integrations {
 		recv := &nflogpb.Receiver{
 			GroupName:   name,
 			Integration: integrations[i].Name(),
 			Idx:         uint32(integrations[i].Index()),
 		}
-		var s notify.MultiStage
+		s := make(notify.MultiStage, 0, 4)
 		s = append(s, stages.NewWaitStage(am.opts.Peer, am.opts.PeerTimeout))
 		s = append(s, notify.NewDedupStage(integrations[i], notificationLog, recv))
 		s = append(s, notify.NewRetryStage(integrations[i], name, am.stageMetrics))

--- a/notify/notifytest/mimir_integrations.go
+++ b/notify/notifytest/mimir_integrations.go
@@ -75,7 +75,7 @@ func GetMimirReceiverWithIntegrations(iTypes []reflect.Type, opts ...v0mimirtest
 		// Create a new instance of the element type
 		elemPtr := reflect.New(elemType).Interface()
 		underlyingType := elemType
-		if underlyingType.Kind() == reflect.Ptr {
+		if underlyingType.Kind() == reflect.Pointer {
 			underlyingType = underlyingType.Elem()
 		}
 		if !slices.Contains(iTypes, underlyingType) {

--- a/notify/schema.go
+++ b/notify/schema.go
@@ -257,7 +257,7 @@ func IntegrationTypeFromMimirTypeReflect(t reflect.Type) (schema.IntegrationType
 		}
 		return itype, nil
 	}
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		return IntegrationTypeFromMimirTypeReflect(t.Elem())
 	}
 	if t.Kind() == reflect.Slice {

--- a/receivers/discord/v1/discord_test.go
+++ b/receivers/discord/v1/discord_test.go
@@ -850,7 +850,7 @@ Silence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=aler
 		imageProvider := images.NewTokenProvider(tokenStore, log.NewNopLogger())
 
 		// Create 15 alerts with an image each, Discord's embed limit is 10, and we should be using a maximum of 9 for images.
-		var alerts []*types.Alert
+		alerts := make([]*types.Alert, 0, len(tokenStore.Images))
 		for token := range tokenStore.Images {
 			alertName := token
 			alert := types.Alert{

--- a/receivers/jira/v0mimir1/jira.go
+++ b/receivers/jira/v0mimir1/jira.go
@@ -257,7 +257,7 @@ func (n *Notifier) searchExistingIssue(ctx context.Context, logger log.Logger, g
 	jql := strings.Builder{}
 
 	if n.conf.WontFixResolution != "" {
-		jql.WriteString(fmt.Sprintf(`resolution != %q and `, n.conf.WontFixResolution))
+		fmt.Fprintf(&jql, `resolution != %q and `, n.conf.WontFixResolution)
 	}
 
 	// If the group is firing, do not search for closed issues unless a reopen transition is defined.
@@ -268,12 +268,12 @@ func (n *Notifier) searchExistingIssue(ctx context.Context, logger log.Logger, g
 	} else {
 		reopenDuration := int64(time.Duration(n.conf.ReopenDuration).Minutes())
 		if reopenDuration != 0 {
-			jql.WriteString(fmt.Sprintf(`(resolutiondate is EMPTY OR resolutiondate >= -%dm) and `, reopenDuration))
+			fmt.Fprintf(&jql, `(resolutiondate is EMPTY OR resolutiondate >= -%dm) and `, reopenDuration)
 		}
 	}
 
 	alertLabel := fmt.Sprintf("ALERT{%s}", groupID)
-	jql.WriteString(fmt.Sprintf(`project=%q and labels=%q order by status ASC,resolutiondate DESC`, n.conf.Project, alertLabel))
+	fmt.Fprintf(&jql, `project=%q and labels=%q order by status ASC,resolutiondate DESC`, n.conf.Project, alertLabel)
 
 	requestBody := issueSearch{
 		JQL:        jql.String(),

--- a/receivers/jira/v1/jira.go
+++ b/receivers/jira/v1/jira.go
@@ -277,7 +277,7 @@ func getSearchJql(conf Config, groupID string, firing bool) issueSearch {
 	jql := strings.Builder{}
 
 	if conf.WontFixResolution != "" {
-		jql.WriteString(fmt.Sprintf(`resolution != %q and `, conf.WontFixResolution))
+		fmt.Fprintf(&jql, `resolution != %q and `, conf.WontFixResolution)
 	}
 
 	if firing {
@@ -287,7 +287,7 @@ func getSearchJql(conf Config, groupID string, firing bool) issueSearch {
 	} else {
 		reopenDuration := int64(time.Duration(conf.ReopenDuration).Minutes())
 		if reopenDuration != 0 {
-			jql.WriteString(fmt.Sprintf(`(resolutiondate is EMPTY OR resolutiondate >= -%dm) and `, reopenDuration))
+			fmt.Fprintf(&jql, `(resolutiondate is EMPTY OR resolutiondate >= -%dm) and `, reopenDuration)
 		} else {
 			jql.WriteString(`statusCategory != Done and `)
 		}
@@ -295,12 +295,12 @@ func getSearchJql(conf Config, groupID string, firing bool) issueSearch {
 
 	alertLabel := fmt.Sprintf("ALERT{%s}", groupID)
 	if conf.DedupKeyFieldName != "" {
-		jql.WriteString(fmt.Sprintf(`(labels = %q or cf[%s] ~ %q) and `, alertLabel, conf.DedupKeyFieldName, groupID))
+		fmt.Fprintf(&jql, `(labels = %q or cf[%s] ~ %q) and `, alertLabel, conf.DedupKeyFieldName, groupID)
 	} else {
-		jql.WriteString(fmt.Sprintf(`labels = %q and `, alertLabel))
+		fmt.Fprintf(&jql, `labels = %q and `, alertLabel)
 	}
 
-	jql.WriteString(fmt.Sprintf(`project=%q order by status ASC,resolutiondate DESC`, conf.Project))
+	fmt.Fprintf(&jql, `project=%q order by status ASC,resolutiondate DESC`, conf.Project)
 
 	return issueSearch{
 		JQL:        jql.String(),

--- a/receivers/slack/v1/slack.go
+++ b/receivers/slack/v1/slack.go
@@ -358,20 +358,20 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 
 	mentionChannel := strings.TrimSpace(sn.settings.MentionChannel)
 	if mentionChannel != "" {
-		mentionsBuilder.WriteString(fmt.Sprintf("<!%s|%s>", mentionChannel, mentionChannel))
+		fmt.Fprintf(&mentionsBuilder, "<!%s|%s>", mentionChannel, mentionChannel)
 	}
 
 	if len(sn.settings.MentionGroups) > 0 {
 		appendSpace()
 		for _, g := range sn.settings.MentionGroups {
-			mentionsBuilder.WriteString(fmt.Sprintf("<!subteam^%s>", tmpl(g)))
+			fmt.Fprintf(&mentionsBuilder, "<!subteam^%s>", tmpl(g))
 		}
 	}
 
 	if len(sn.settings.MentionUsers) > 0 {
 		appendSpace()
 		for _, u := range sn.settings.MentionUsers {
-			mentionsBuilder.WriteString(fmt.Sprintf("<@%s>", tmpl(u)))
+			fmt.Fprintf(&mentionsBuilder, "<@%s>", tmpl(u))
 		}
 	}
 

--- a/templates/default_template.go
+++ b/templates/default_template.go
@@ -263,7 +263,7 @@ func DefaultTemplate(omitTemplates []string) (TemplateDefinition, error) {
 			// TODO: Can remove with GO v1.24.
 			def = strings.Replace(def, "$first := false", "$first = false", 1)
 		}
-		combinedTemplate.WriteString(fmt.Sprintf("{{ define \"%s\" }}%s{{ end }}\n\n", tmpl.Name(), def))
+		fmt.Fprintf(&combinedTemplate, "{{ define \"%s\" }}%s{{ end }}\n\n", tmpl.Name(), def)
 	}
 	return TemplateDefinition{
 		Name:     DefaultTemplateName,


### PR DESCRIPTION
## Summary
- Bump the pinned golangci-lint version in the Makefile from v2.0.2 to v2.12.2
- Fix the govet, prealloc, and staticcheck findings the newer version surfaces:
  - `reflect.Ptr` → `reflect.Pointer` (deprecated alias, govet inline)
  - Preallocate slices with known capacity (prealloc)
  - `builder.WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(&builder, ...)` (staticcheck QF1012)