### PR TITLE
RBAC for Notification History via the folder service

### DIFF
--- a/apps/historian/go.mod
+++ b/apps/historian/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/go-kit/log v0.2.1
 	github.com/grafana/alerting v0.0.0-20260616104851-587c401ed754
+	github.com/grafana/authlib/types v0.0.0-20260603144019-18cfcbc9496a
 	github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3
 	github.com/grafana/grafana-app-sdk v0.56.2
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
@@ -67,7 +68,6 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/authlib v0.0.0-20260603144019-18cfcbc9496a // indirect
-	github.com/grafana/authlib/types v0.0.0-20260603144019-18cfcbc9496a // indirect
 	github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000 // indirect
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect

--- a/apps/historian/pkg/app/config/config.go
+++ b/apps/historian/pkg/app/config/config.go
@@ -29,9 +29,7 @@ type NotificationConfig struct {
 	// alert rules the requesting user is allowed to read. When enabled, the app
 	// lists the tenant's folders via the multi-tenant folder API and then confirms
 	// alert.rules:read on each folder via AccessClient, keeping only the folders
-	// the caller may see. Results are filtered to those folders. This works in
-	// multi-tenant deployments because both the folder API and the authz service
-	// are multi-tenant, unlike the single-tenant rules API.
+	// the caller may see. Results are filtered to those folders.
 	RBACEnabled bool
 	// AccessClient authorizes alert.rules:read per folder for RBAC filtering. It is
 	// set programmatically by the deployment wiring (not via a flag). When

--- a/apps/historian/pkg/app/config/config.go
+++ b/apps/historian/pkg/app/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/grafana/alerting/notify/historian/lokiclient"
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/simple"
 )
 
@@ -24,12 +25,19 @@ type LokiConfig struct {
 type NotificationConfig struct {
 	Enabled bool
 	Loki    LokiConfig
-	// RBACEnabled restricts notification history results to the alert rules the
-	// requesting user is allowed to access. When enabled, the app lists accessible
-	// rules via the Kubernetes rules API (which enforces RBAC) and filters results
-	// to those rules. It requires the app to be able to reach the rules API using
-	// the request identity (e.g. Grafana's in-process loopback config).
+	// RBACEnabled restricts notification history results to the folders whose
+	// alert rules the requesting user is allowed to read. When enabled, the app
+	// lists the tenant's folders via the multi-tenant folder API and then confirms
+	// alert.rules:read on each folder via AccessClient, keeping only the folders
+	// the caller may see. Results are filtered to those folders. This works in
+	// multi-tenant deployments because both the folder API and the authz service
+	// are multi-tenant, unlike the single-tenant rules API.
 	RBACEnabled bool
+	// AccessClient authorizes alert.rules:read per folder for RBAC filtering. It is
+	// set programmatically by the deployment wiring (not via a flag). When
+	// RBACEnabled is true it must be non-nil, otherwise notification queries fail
+	// closed.
+	AccessClient authtypes.AccessClient
 }
 
 type RuntimeConfig struct {

--- a/apps/historian/pkg/app/notification/folderbatch_test.go
+++ b/apps/historian/pkg/app/notification/folderbatch_test.go
@@ -108,7 +108,7 @@ func TestBuildNotificationBatches(t *testing.T) {
 		for i := 0; i < 6; i++ {
 			folders = append(folders, fmt.Sprintf("f%02d-%s", i, strings.Repeat("y", 200)))
 		}
-		filter := testFilter([]string{"ruleA"}, folders)
+		filter := testFilter(folders...)
 
 		maxQuerySize := folderBatchReservedBytes + notificationFolderSpec.fixedLen() + 600
 		reader := &LokiReader{logger: &logging.NoOpLogger{}, maxQuerySize: maxQuerySize}
@@ -166,7 +166,7 @@ func TestLokiReader_Query_BatchesAndDeduplicates(t *testing.T) {
 		maxQuerySize: folderBatchReservedBytes + 3000,
 	}
 
-	filter := testFilter([]string{"ruleA"}, []string{folderA, folderB})
+	filter := testFilter(folderA, folderB)
 	result, err := reader.Query(context.Background(), Query{}, filter)
 	require.NoError(t, err)
 
@@ -225,59 +225,11 @@ func TestMergeRangeCounts(t *testing.T) {
 	assert.Equal(t, []RangeValue{rv(1, 9)}, byReceiver["B"])
 }
 
-func TestCountHasAccessibleRule(t *testing.T) {
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
-
-	assert.True(t, countHasAccessibleRule(Count{}, nil), "a nil filter always grants access")
-	assert.True(t, countHasAccessibleRule(Count{RuleUID: stringPtr("ruleA")}, filter))
-	assert.True(t, countHasAccessibleRule(Count{RuleUID: stringPtr("ruleA,ruleB")}, filter))
-	assert.False(t, countHasAccessibleRule(Count{RuleUID: stringPtr("ruleB")}, filter))
-	assert.False(t, countHasAccessibleRule(Count{RuleUID: stringPtr("")}, filter), "no rule fails closed")
-	assert.False(t, countHasAccessibleRule(Count{}, filter), "missing rule dimension fails closed")
-}
-
-func TestCollapseAccessibleCounts(t *testing.T) {
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
-
-	// The counts arrive grouped by (receiver, rule_uids) purely so RBAC can be
-	// enforced; the caller only asked for per-receiver counts.
-	counts := []Count{
-		{Receiver: stringPtr("Team"), RuleUID: stringPtr("ruleA"), Count: 3},
-		{Receiver: stringPtr("Team"), RuleUID: stringPtr("ruleA,ruleB"), Count: 2}, // accessible via ruleA
-		{Receiver: stringPtr("Secret"), RuleUID: stringPtr("ruleB"), Count: 4},     // no accessible rule -> dropped
-	}
-
-	got := collapseAccessibleCounts(counts, 10, filter)
-
-	require.Len(t, got, 1, "the Secret/ruleB-only notification must be dropped")
-	assert.Nil(t, got[0].RuleUID, "the under-the-hood rule dimension must be stripped")
-	assert.Equal(t, "Team", *got[0].Receiver)
-	assert.Equal(t, int64(5), got[0].Count, "3 + 2 collapsed onto the receiver")
-}
-
-func TestCollapseAccessibleRangeCounts(t *testing.T) {
-	rv := func(ts, count int64) RangeValue { return RangeValue{Timestamp: ts, Count: count} }
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
-
-	counts := []Count{
-		{Receiver: stringPtr("Team"), RuleUID: stringPtr("ruleA"), Values: []RangeValue{rv(1, 2)}},
-		{Receiver: stringPtr("Team"), RuleUID: stringPtr("ruleA,ruleB"), Values: []RangeValue{rv(1, 1), rv(2, 3)}},
-		{Receiver: stringPtr("Secret"), RuleUID: stringPtr("ruleB"), Values: []RangeValue{rv(1, 9)}}, // dropped
-	}
-
-	got := collapseAccessibleRangeCounts(counts, filter)
-
-	require.Len(t, got, 1)
-	assert.Nil(t, got[0].RuleUID)
-	assert.Equal(t, "Team", *got[0].Receiver)
-	assert.Equal(t, []RangeValue{rv(1, 3), rv(2, 3)}, got[0].Values)
-}
-
-// TestLokiReader_Counts_RBACFailClosed proves the end-to-end counts path is
-// fail-closed for a non-rule group-by: a notification that survives the folder
-// push-down while referencing only inaccessible rules is not counted, and the
-// rule dimension used internally to make that decision is not exposed.
-func TestLokiReader_Counts_RBACFailClosed(t *testing.T) {
+// TestLokiReader_Counts_FolderScoped verifies that with folder-only RBAC and a
+// non-rule group-by the counts returned by Loki are passed through per the
+// requested grouping (no internal rule dimension is injected and nothing is
+// dropped client-side: the folder push-down alone enforces access).
+func TestLokiReader_Counts_FolderScoped(t *testing.T) {
 	now := time.Now().UTC()
 	sample := func(count string, metric map[string]string) lokiclient.MetricSample {
 		ts, _ := json.Marshal(now.Unix())
@@ -290,9 +242,8 @@ func TestLokiReader_Counts_RBACFailClosed(t *testing.T) {
 		Return(lokiclient.MetricsQueryRes{
 			Data: lokiclient.MetricsQueryData{
 				Result: []lokiclient.MetricSample{
-					sample("3", map[string]string{"receiver": "Team", "rule_uids": "ruleA"}),
-					sample("2", map[string]string{"receiver": "Team", "rule_uids": "ruleA,ruleB"}),
-					sample("4", map[string]string{"receiver": "Secret", "rule_uids": "ruleB"}),
+					sample("5", map[string]string{"receiver": "Team"}),
+					sample("4", map[string]string{"receiver": "Other"}),
 				},
 			},
 		}, nil)
@@ -300,18 +251,22 @@ func TestLokiReader_Counts_RBACFailClosed(t *testing.T) {
 	reader := &LokiReader{client: mockClient, logger: &logging.NoOpLogger{}, maxQuerySize: 65536}
 
 	queryType := v0alpha1.CreateNotificationqueryRequestBodyTypeCounts
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
+	filter := testFilter("folderA")
 	result, err := reader.Query(context.Background(), Query{
 		Type:    &queryType,
 		GroupBy: &QueryGroupBy{Receiver: true},
 	}, filter)
 	require.NoError(t, err)
 
-	require.Len(t, result.Counts, 1, "the Secret/ruleB-only notification must be dropped")
-	assert.Nil(t, result.Counts[0].RuleUID, "the internal rule dimension must not be exposed")
-	require.NotNil(t, result.Counts[0].Receiver)
-	assert.Equal(t, "Team", *result.Counts[0].Receiver)
-	assert.Equal(t, int64(5), result.Counts[0].Count)
+	require.Len(t, result.Counts, 2)
+	byReceiver := map[string]int64{}
+	for _, c := range result.Counts {
+		require.NotNil(t, c.Receiver)
+		assert.Nil(t, c.RuleUID, "no internal rule dimension is exposed")
+		byReceiver[*c.Receiver] = c.Count
+	}
+	assert.Equal(t, int64(5), byReceiver["Team"])
+	assert.Equal(t, int64(4), byReceiver["Other"])
 }
 
 // TestRunQuery_TruncatesMergedEntriesToLimit verifies runQuery caps the merged
@@ -338,9 +293,8 @@ func TestRunQuery_TruncatesMergedEntriesToLimit(t *testing.T) {
 		Return(resp, nil)
 
 	reader := &LokiReader{client: mockClient, logger: &logging.NoOpLogger{}}
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
 
-	entries, err := reader.runQuery(context.Background(), []string{"q1", "q2"}, now.Add(-time.Hour), now, 2, filter)
+	entries, err := reader.runQuery(context.Background(), []string{"q1", "q2"}, now.Add(-time.Hour), now, 2)
 	require.NoError(t, err)
 	require.Len(t, entries, 2, "merged entries must be truncated to the requested limit")
 	assert.Equal(t, "uuid-1", entries[0].Uuid, "newest entries are kept")

--- a/apps/historian/pkg/app/notification/lokireader.go
+++ b/apps/historian/pkg/app/notification/lokireader.go
@@ -146,7 +146,7 @@ func (h *LokiReader) Query(ctx context.Context, query Query, filter *ruleFilter)
 
 	switch qtype {
 	case v0alpha1.CreateNotificationqueryRequestBodyTypeEntries:
-		entries, err := h.runQuery(ctx, logqls, from, to, limit, filter)
+		entries, err := h.runQuery(ctx, logqls, from, to, limit)
 		if err != nil {
 			return QueryResult{}, err
 		}
@@ -159,7 +159,7 @@ func (h *LokiReader) Query(ctx context.Context, query Query, filter *ruleFilter)
 		if query.GroupBy != nil {
 			groupBy = *query.GroupBy
 		}
-		counts, err := h.runMetricsQuery(ctx, logqls, from, to, limit, groupBy, filter)
+		counts, err := h.runMetricsQuery(ctx, logqls, from, to, limit, groupBy)
 		if err != nil {
 			return QueryResult{}, err
 		}
@@ -176,7 +176,7 @@ func (h *LokiReader) Query(ctx context.Context, query Query, filter *ruleFilter)
 		if query.Step != nil && *query.Step > 0 {
 			step = time.Duration(*query.Step) * time.Second
 		}
-		rangeCounts, err := h.runMetricsRangeQuery(ctx, logqls, from, to, limit, step, groupBy, filter)
+		rangeCounts, err := h.runMetricsRangeQuery(ctx, logqls, from, to, limit, step, groupBy)
 		if err != nil {
 			return QueryResult{}, err
 		}
@@ -299,25 +299,13 @@ func buildMetricsRangeQuery(logqlInner string, step time.Duration, groupBy Query
 // for each folder batch and converts the metric samples into Count values.
 //
 // Results from multiple batches are aggregated by label set: the RuleUID group-by
-// path via explodeRuleUIDCounts, all other group-bys via collapseAccessibleCounts
-// (RBAC) or mergeCounts. A single non-RBAC batch (the common case) is left
-// untouched apart from sorting, preserving the server-side topk.
-func (h *LokiReader) runMetricsQuery(ctx context.Context, logqlInners []string, from, to time.Time, limit int64, groupBy QueryGroupBy, filter *ruleFilter) ([]Count, error) {
-	// RBAC: even when the client does not group by rule, group on rule_uids under
-	// the hood so notifications that survive the folder push-down but reference no
-	// accessible rule (e.g. snapshot skew, see runQuery) can be dropped client-side
-	// (fail-closed), matching the entries path. This also disables the server-side
-	// topk (see buildMetricsQuery), so the limit is re-applied by the client-side
-	// aggregation below. It costs extra series cardinality, incurred only when RBAC
-	// is active.
-	metricsGroupBy := groupBy
-	if filter != nil {
-		metricsGroupBy.RuleUID = true
-	}
-
+// path via explodeRuleUIDCounts, all other group-bys via mergeCounts. A single
+// batch (the common case) is left untouched apart from sorting, preserving the
+// server-side topk.
+func (h *LokiReader) runMetricsQuery(ctx context.Context, logqlInners []string, from, to time.Time, limit int64, groupBy QueryGroupBy) ([]Count, error) {
 	counts := make([]Count, 0)
 	for _, logqlInner := range logqlInners {
-		logql := buildMetricsQuery(logqlInner, from, to, limit, metricsGroupBy)
+		logql := buildMetricsQuery(logqlInner, from, to, limit, groupBy)
 
 		res, err := h.client.MetricsQuery(ctx, logql, to.UnixNano(), limit)
 		if err != nil {
@@ -337,14 +325,13 @@ func (h *LokiReader) runMetricsQuery(ctx context.Context, logqlInners []string, 
 	switch {
 	case groupBy.RuleUID:
 		// When grouping by RuleUID, explode the comma-separated rule_uids into
-		// individual counts, drop inaccessible rules, aggregate (merging batches),
-		// and apply client-side topk.
-		counts = explodeRuleUIDCounts(counts, limit, filter)
-	case filter != nil:
-		// The client did not group by rule: drop notifications with no accessible
-		// rule (fail-closed), strip the rule_uids dimension added only for the RBAC
-		// check, and re-aggregate (merging batches), applying the limit.
-		counts = collapseAccessibleCounts(counts, limit, filter)
+		// individual counts, aggregate (merging batches), and apply client-side topk.
+		counts = explodeRuleUIDCounts(counts, limit)
+	case len(logqlInners) > 1:
+		// Multiple folder batches were queried; merge their per-batch results and
+		// re-apply the limit, since the server-side topk only applied within each
+		// batch.
+		counts = mergeCounts(counts, limit)
 	}
 
 	// Sort counts by count (highest first).
@@ -353,37 +340,6 @@ func (h *LokiReader) runMetricsQuery(ctx context.Context, logqlInners []string, 
 	})
 
 	return counts, nil
-}
-
-// collapseAccessibleCounts post-processes counts fetched with an under-the-hood
-// rule_uids grouping (used purely to enforce RBAC on a non-rule group-by): it
-// drops notifications with no accessible rule (fail-closed, mirroring runQuery),
-// strips the rule_uids dimension the caller never asked for, and re-aggregates by
-// the remaining label set (also merging folder batches), applying the limit.
-func collapseAccessibleCounts(counts []Count, limit int64, filter *ruleFilter) []Count {
-	kept := make([]Count, 0, len(counts))
-	for _, c := range counts {
-		if !countHasAccessibleRule(c, filter) {
-			continue
-		}
-		c.RuleUID = nil
-		kept = append(kept, c)
-	}
-	return mergeCounts(kept, limit)
-}
-
-// countHasAccessibleRule reports whether a count whose RuleUID holds a
-// comma-separated rule_uids list references at least one accessible rule. A nil
-// filter (RBAC disabled) always returns true.
-func countHasAccessibleRule(c Count, filter *ruleFilter) bool {
-	if filter == nil {
-		return true
-	}
-	var ruleUIDs []string
-	if c.RuleUID != nil && *c.RuleUID != "" {
-		ruleUIDs = strings.Split(*c.RuleUID, ",")
-	}
-	return hasAccessibleRuleUID(ruleUIDs, filter)
 }
 
 // mergeCounts aggregates counts sharing the same label set (summing Count),
@@ -424,7 +380,7 @@ func mergeCounts(counts []Count, limit int64) []Count {
 // explodeRuleUIDCounts splits counts with comma-separated rule_uids into individual
 // counts per rule UID, aggregates (sums) counts sharing the same (ruleUID + other groupBy
 // dimensions) key, sorts by count descending, and applies the limit (client-side topk).
-func explodeRuleUIDCounts(counts []Count, limit int64, filter *ruleFilter) []Count {
+func explodeRuleUIDCounts(counts []Count, limit int64) []Count {
 	aggregated := make(map[string]*Count)
 
 	key := func(c Count) string {
@@ -440,13 +396,6 @@ func explodeRuleUIDCounts(counts []Count, limit int64, filter *ruleFilter) []Cou
 			ruleUIDs = strings.Split(*c.RuleUID, ",")
 		}
 		for _, uid := range ruleUIDs {
-			// RBAC: never emit a per-rule count for a rule the caller cannot access.
-			// A notification may reference several rules (comma-separated), only some
-			// of which are accessible; drop the inaccessible ones here. The folder
-			// push-down admits mixed notifications, so per-rule stripping is required.
-			if filter != nil && uid != "" && !filter.rules.Has(uid) {
-				continue
-			}
 			entry := c
 			uidCopy := uid
 			entry.RuleUID = &uidCopy
@@ -506,21 +455,12 @@ func defaultStep(from, to time.Time) time.Duration {
 // RangeCount values.
 //
 // Results from multiple batches are aggregated by label set: the RuleUID group-by
-// path via explodeRuleUIDRangeCounts, all other group-bys via
-// collapseAccessibleRangeCounts (RBAC) or mergeRangeCounts. A single non-RBAC
-// batch (the common case) is returned unchanged.
-func (h *LokiReader) runMetricsRangeQuery(ctx context.Context, logqlInners []string, from, to time.Time, limit int64, step time.Duration, groupBy QueryGroupBy, filter *ruleFilter) ([]Count, error) {
-	// RBAC: group on rule_uids under the hood even when the client does not group
-	// by rule, so notifications with no accessible rule can be dropped client-side
-	// (fail-closed). See runMetricsQuery for the rationale and trade-off.
-	metricsGroupBy := groupBy
-	if filter != nil {
-		metricsGroupBy.RuleUID = true
-	}
-
+// path via explodeRuleUIDRangeCounts, all other group-bys via mergeRangeCounts. A
+// single batch (the common case) is returned unchanged.
+func (h *LokiReader) runMetricsRangeQuery(ctx context.Context, logqlInners []string, from, to time.Time, limit int64, step time.Duration, groupBy QueryGroupBy) ([]Count, error) {
 	rangeCounts := make([]Count, 0)
 	for _, logqlInner := range logqlInners {
-		logql := buildMetricsRangeQuery(logqlInner, step, metricsGroupBy)
+		logql := buildMetricsRangeQuery(logqlInner, step, groupBy)
 
 		res, err := h.client.MetricsRangeQuery(ctx, logql, from.UnixNano(), to.UnixNano(), limit, int64(step.Seconds()))
 		if err != nil {
@@ -540,35 +480,16 @@ func (h *LokiReader) runMetricsRangeQuery(ctx context.Context, logqlInners []str
 	switch {
 	case groupBy.RuleUID:
 		// When grouping by RuleUID, explode the comma-separated rule_uids into
-		// individual time series, drop rules the caller cannot access, aggregate the
-		// per-timestamp values (merging batches), and apply client-side topk. This
-		// mirrors the instant counts path (explodeRuleUIDCounts); without it the raw
-		// rule_uids label would expose inaccessible UIDs and undivided combined counts.
-		rangeCounts = explodeRuleUIDRangeCounts(rangeCounts, limit, filter)
-	case filter != nil:
-		// The client did not group by rule: drop notifications with no accessible
-		// rule (fail-closed), strip the rule_uids dimension added only for the RBAC
-		// check, and re-aggregate the per-timestamp values (merging batches).
-		rangeCounts = collapseAccessibleRangeCounts(rangeCounts, filter)
+		// individual time series, aggregate the per-timestamp values (merging
+		// batches), and apply client-side topk. This mirrors the instant counts path
+		// (explodeRuleUIDCounts).
+		rangeCounts = explodeRuleUIDRangeCounts(rangeCounts, limit)
+	case len(logqlInners) > 1:
+		// Multiple folder batches were queried; merge their per-batch time series.
+		rangeCounts = mergeRangeCounts(rangeCounts)
 	}
 
 	return rangeCounts, nil
-}
-
-// collapseAccessibleRangeCounts is the range-query counterpart of
-// collapseAccessibleCounts: it drops range-count series with no accessible rule
-// (fail-closed), strips the rule_uids dimension, and re-aggregates the
-// per-timestamp values by the remaining label set (also merging folder batches).
-func collapseAccessibleRangeCounts(counts []Count, filter *ruleFilter) []Count {
-	kept := make([]Count, 0, len(counts))
-	for _, c := range counts {
-		if !countHasAccessibleRule(c, filter) {
-			continue
-		}
-		c.RuleUID = nil
-		kept = append(kept, c)
-	}
-	return mergeRangeCounts(kept)
 }
 
 // mergeRangeCounts aggregates range-count time series sharing the same label set,
@@ -611,12 +532,11 @@ func mergeRangeCounts(counts []Count) []Count {
 }
 
 // explodeRuleUIDRangeCounts splits range counts with comma-separated rule_uids into
-// individual time series per rule UID, drops rule UIDs the caller cannot access
-// (RBAC), aggregates (sums) the per-timestamp values of series sharing the same
-// (ruleUID + other groupBy dimensions) key, sorts by total count descending, and
-// applies the limit (client-side topk). It is the range-query counterpart of
-// explodeRuleUIDCounts.
-func explodeRuleUIDRangeCounts(counts []Count, limit int64, filter *ruleFilter) []Count {
+// individual time series per rule UID, aggregates (sums) the per-timestamp values
+// of series sharing the same (ruleUID + other groupBy dimensions) key, sorts by
+// total count descending, and applies the limit (client-side topk). It is the
+// range-query counterpart of explodeRuleUIDCounts.
+func explodeRuleUIDRangeCounts(counts []Count, limit int64) []Count {
 	type aggregate struct {
 		count  Count
 		values map[int64]int64
@@ -637,13 +557,6 @@ func explodeRuleUIDRangeCounts(counts []Count, limit int64, filter *ruleFilter) 
 			ruleUIDs = strings.Split(*c.RuleUID, ",")
 		}
 		for _, uid := range ruleUIDs {
-			// RBAC: never emit a per-rule series for a rule the caller cannot access.
-			// A notification may reference several rules (comma-separated), only some
-			// of which are accessible; drop the inaccessible ones here. The folder
-			// push-down admits mixed notifications, so per-rule stripping is required.
-			if filter != nil && uid != "" && !filter.rules.Has(uid) {
-				continue
-			}
 			entry := c
 			uidCopy := uid
 			entry.RuleUID = &uidCopy
@@ -1072,7 +985,7 @@ func (h *LokiReader) buildNotificationBatches(query Query, uuids []string, filte
 	}
 	logqls := make([]string, len(batches))
 	for i, batch := range batches {
-		logql, err := buildQuery(query, uuids, &ruleFilter{folderKeys: batch, rules: filter.rules})
+		logql, err := buildQuery(query, uuids, &ruleFilter{folderKeys: batch})
 		if err != nil {
 			return nil, err
 		}
@@ -1097,7 +1010,7 @@ func (h *LokiReader) buildAlertBatches(query AlertQuery, filter *ruleFilter) ([]
 	}
 	logqls := make([]string, len(batches))
 	for i, batch := range batches {
-		logql, err := buildAlertQuery(query, &ruleFilter{folderKeys: batch, rules: filter.rules})
+		logql, err := buildAlertQuery(query, &ruleFilter{folderKeys: batch})
 		if err != nil {
 			return nil, err
 		}
@@ -1122,7 +1035,7 @@ func (h *LokiReader) buildAlertLabelBatches(ruleUID *string, labels Matchers, fi
 	}
 	logqls := make([]string, len(batches))
 	for i, batch := range batches {
-		logql, err := buildAlertLabelQuery(ruleUID, labels, &ruleFilter{folderKeys: batch, rules: filter.rules})
+		logql, err := buildAlertLabelQuery(ruleUID, labels, &ruleFilter{folderKeys: batch})
 		if err != nil {
 			return nil, err
 		}
@@ -1134,15 +1047,15 @@ func (h *LokiReader) buildAlertLabelBatches(ruleUID *string, labels Matchers, fi
 // runQuery runs the notification query batches and collects results, grouping
 // alerts into notifications.
 //
-// filter, when non-nil, strips rule UIDs the caller cannot access from each
-// entry's RuleUIDs. The folder-based LogQL push-down only guarantees that a
-// notification references at least one accessible folder; a mixed notification
-// can still co-reference inaccessible rules, so those UIDs must be removed here.
+// Access is enforced entirely by the folder-based LogQL push-down: alert-rule
+// RBAC is strictly folder-scoped, so any notification that references an
+// accessible folder is fully accessible and its rule UIDs need no further
+// stripping.
 //
 // When more than one batch is queried a notification whose accessible folders are
 // spread across batches matches several batch queries, so results are
 // deduplicated by (timestamp, uuid).
-func (l *LokiReader) runQuery(ctx context.Context, logqls []string, from, to time.Time, limit int64, filter *ruleFilter) ([]Entry, error) {
+func (l *LokiReader) runQuery(ctx context.Context, logqls []string, from, to time.Time, limit int64) ([]Entry, error) {
 	entries := make([]Entry, 0)
 	seen := make(map[string]struct{})
 	dedup := len(logqls) > 1
@@ -1157,24 +1070,6 @@ func (l *LokiReader) runQuery(ctx context.Context, logqls []string, from, to tim
 				entry, err := parseLokiEntry(s)
 				if err != nil {
 					l.logger.Warn("Ignoring notification history entry", "err", err)
-					continue
-				}
-				entry.RuleUIDs = filterAccessibleRuleUIDs(entry.RuleUIDs, filter)
-				// RBAC (fail-closed): drop notifications left with no accessible rule
-				// after stripping, which would otherwise leak notification fields
-				// (receiver, status, uuid, ...) for rules the caller cannot access.
-				//
-				// Under the current strictly folder-scoped rule RBAC this cannot happen
-				// in a consistent snapshot: access is granted per folder, so every rule
-				// in an accessible folder is accessible, and a notification whose rules
-				// are all inaccessible carries only inaccessible folder_uids and is thus
-				// excluded by the folder push-down. The guard defends against the cases
-				// where the accessible-folders and accessible-rules sets can disagree for
-				// a folder: (1) snapshot skew, where a notification's stored folderUIDs
-				// still reference a folder that is accessible via another rule after the
-				// referenced rule moved to an inaccessible folder; and (2) any future
-				// move to rule-level RBAC finer-grained than folders.
-				if filter != nil && !hasAccessibleRuleUID(entry.RuleUIDs, filter) {
 					continue
 				}
 				if dedup {
@@ -1203,37 +1098,6 @@ func (l *LokiReader) runQuery(ctx context.Context, logqls []string, from, to tim
 	l.logger.Debug("Notification history query complete", "notifications", len(entries))
 
 	return entries, nil
-}
-
-// filterAccessibleRuleUIDs removes rule UIDs the caller cannot access from the
-// slice. A nil filter (RBAC disabled) returns the slice unchanged. The result is
-// always non-nil so entries consistently serialize an empty array rather than
-// null. It mirrors the per-rule stripping done for counts in explodeRuleUIDCounts.
-func filterAccessibleRuleUIDs(ruleUIDs []string, filter *ruleFilter) []string {
-	if filter == nil {
-		return ruleUIDs
-	}
-	accessible := make([]string, 0, len(ruleUIDs))
-	for _, uid := range ruleUIDs {
-		if uid != "" && !filter.rules.Has(uid) {
-			continue
-		}
-		accessible = append(accessible, uid)
-	}
-	return accessible
-}
-
-// hasAccessibleRuleUID reports whether ruleUIDs references at least one rule the
-// caller can access. It backs the fail-closed guard that drops notifications
-// which survive the folder push-down yet reference only rules the caller cannot
-// access (reachable via snapshot skew or future rule-level RBAC; see runQuery).
-func hasAccessibleRuleUID(ruleUIDs []string, filter *ruleFilter) bool {
-	for _, uid := range ruleUIDs {
-		if uid != "" && filter.rules.Has(uid) {
-			return true
-		}
-	}
-	return false
 }
 
 // parseLokiEntry unmarshals the JSON stored in the entry.

--- a/apps/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/historian/pkg/app/notification/lokireader_test.go
@@ -528,7 +528,7 @@ func TestLokiReader_RunQuery(t *testing.T) {
 		logger: &logging.NoOpLogger{},
 	}
 
-	entries, err := reader.runQuery(context.Background(), []string{"test query"}, now.Add(-6*time.Hour), now, 1000, nil)
+	entries, err := reader.runQuery(context.Background(), []string{"test query"}, now.Add(-6*time.Hour), now, 1000)
 	require.NoError(t, err)
 	require.Len(t, entries, 3)
 
@@ -1701,7 +1701,7 @@ func TestExplodeRuleUIDCounts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := explodeRuleUIDCounts(tt.counts, tt.limit, nil)
+			got := explodeRuleUIDCounts(tt.counts, tt.limit)
 			require.Len(t, got, len(tt.want))
 			// Sort tied counts by ruleUID for deterministic comparison.
 			sort.SliceStable(got, func(i, j int) bool {
@@ -1732,7 +1732,6 @@ func TestExplodeRuleUIDRangeCounts(t *testing.T) {
 		name   string
 		counts []Count
 		limit  int64
-		filter *ruleFilter
 		want   []Count
 	}{
 		{
@@ -1787,17 +1786,6 @@ func TestExplodeRuleUIDRangeCounts(t *testing.T) {
 				{RuleUID: stringPtr("ruleA"), Values: []RangeValue{rv(1, 5)}},
 			},
 		},
-		{
-			name: "RBAC drops inaccessible co-referenced rules",
-			counts: []Count{
-				{RuleUID: stringPtr("ruleA,ruleB"), Values: []RangeValue{rv(1, 4), rv(2, 6)}},
-			},
-			limit:  10,
-			filter: testFilter([]string{"ruleA"}, []string{"folderA"}),
-			want: []Count{
-				{RuleUID: stringPtr("ruleA"), Values: []RangeValue{rv(1, 4), rv(2, 6)}},
-			},
-		},
 	}
 
 	derefStr := func(p *string) string {
@@ -1809,7 +1797,7 @@ func TestExplodeRuleUIDRangeCounts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := explodeRuleUIDRangeCounts(tt.counts, tt.limit, tt.filter)
+			got := explodeRuleUIDRangeCounts(tt.counts, tt.limit)
 			require.Len(t, got, len(tt.want))
 
 			sortByRule := func(cs []Count) {
@@ -1840,59 +1828,13 @@ func rangeTotal(vs []RangeValue) int64 {
 	return sum
 }
 
-func TestFilterAccessibleRuleUIDs(t *testing.T) {
-	tests := []struct {
-		name     string
-		ruleUIDs []string
-		filter   *ruleFilter
-		want     []string
-	}{
-		{
-			name:     "nil filter leaves rule UIDs untouched",
-			ruleUIDs: []string{"ruleA", "ruleB"},
-			filter:   nil,
-			want:     []string{"ruleA", "ruleB"},
-		},
-		{
-			name:     "mixed notification drops inaccessible co-referenced rule",
-			ruleUIDs: []string{"ruleA", "ruleB"},
-			filter:   testFilter([]string{"ruleA"}, []string{"folderA"}),
-			want:     []string{"ruleA"},
-		},
-		{
-			name:     "all accessible rules are retained",
-			ruleUIDs: []string{"ruleA", "ruleB"},
-			filter:   testFilter([]string{"ruleA", "ruleB"}, []string{"folderA"}),
-			want:     []string{"ruleA", "ruleB"},
-		},
-		{
-			name:     "no accessible rules yields empty non-nil slice",
-			ruleUIDs: []string{"ruleA", "ruleB"},
-			filter:   testFilter([]string{"ruleC"}, []string{"folderC"}),
-			want:     []string{},
-		},
-		{
-			name:     "empty rule UID is retained (mirrors counts explode path)",
-			ruleUIDs: []string{"", "ruleA"},
-			filter:   testFilter([]string{"ruleA"}, []string{"folderA"}),
-			want:     []string{"", "ruleA"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := filterAccessibleRuleUIDs(tt.ruleUIDs, tt.filter)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestLokiReader_Query_Entries_RBACStripsCoReferencedRules(t *testing.T) {
+func TestLokiReader_Query_Entries_RBACFolderScopedNoStripping(t *testing.T) {
 	now := time.Now().UTC()
 
-	// A mixed notification referencing both an accessible (ruleA) and an
-	// inaccessible (ruleB) rule. It passes the folder push-down because folderA
-	// is accessible, but ruleB must not leak into the returned entry.
+	// A mixed notification referencing rules in an accessible (folderA) and an
+	// inaccessible (folderB) folder. Alert-rule RBAC is strictly folder-scoped, so
+	// once the notification is admitted via folderA it is fully visible: both rule
+	// UIDs are returned (no per-rule stripping).
 	entryJSON := fmt.Sprintf(`{
 		"schemaVersion": 2,
 		"uuid": "uuid-mixed",
@@ -1924,106 +1866,11 @@ func TestLokiReader_Query_Entries_RBACStripsCoReferencedRules(t *testing.T) {
 		logger: &logging.NoOpLogger{},
 	}
 
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
+	filter := testFilter("folderA")
 	result, err := reader.Query(context.Background(), Query{}, filter)
 	require.NoError(t, err)
 	require.Len(t, result.Entries, 1)
-	assert.Equal(t, []string{"ruleA"}, result.Entries[0].RuleUIDs, "inaccessible co-referenced rule UID must be stripped")
-}
-
-func TestLokiReader_Query_Entries_RBACDropsFullyInaccessibleNotification(t *testing.T) {
-	now := time.Now().UTC()
-
-	// Fail-closed guard: a notification can survive the folder push-down while
-	// referencing only inaccessible rules when the accessible-folders and
-	// accessible-rules sets disagree for a folder. Under strictly folder-scoped
-	// RBAC this does not occur in a consistent snapshot, but it is reachable via
-	// snapshot skew (the stored folderUIDs still reference folderA, which stays
-	// accessible via ruleA, after the referenced ruleB moved to an inaccessible
-	// folder) or future rule-level RBAC. Here folderA is accessible (via ruleA)
-	// but ruleB is not, so the second entry has no accessible rule after stripping
-	// and must be dropped rather than leaking its receiver/status/uuid with an
-	// empty ruleUIDs list.
-	//
-	// The filter models this disagreement directly: folderA is accessible but
-	// ruleB (referenced by the leaked notification) is not in the accessible rule
-	// set.
-	accessibleJSON := fmt.Sprintf(`{
-		"schemaVersion": 2,
-		"uuid": "uuid-accessible",
-		"receiver": "Accessible",
-		"status": "firing",
-		"error": "",
-		"ruleUIDs": ["ruleA"],
-		"folderUIDs": ["folderA"],
-		"alertCount": 1,
-		"retry": false,
-		"duration": 0,
-		"pipelineTime": "%s"
-	}`, now.Format(time.RFC3339Nano))
-
-	leakedJSON := fmt.Sprintf(`{
-		"schemaVersion": 2,
-		"uuid": "uuid-leaked",
-		"receiver": "Secret",
-		"status": "firing",
-		"error": "",
-		"ruleUIDs": ["ruleB"],
-		"folderUIDs": ["folderA"],
-		"alertCount": 1,
-		"retry": false,
-		"duration": 0,
-		"pipelineTime": "%s"
-	}`, now.Add(-time.Minute).Format(time.RFC3339Nano))
-
-	mockResponse := lokiclient.QueryRes{
-		Data: lokiclient.QueryData{
-			Result: []lokiclient.Stream{
-				{Values: []lokiclient.Sample{
-					{T: now, V: accessibleJSON},
-					{T: now.Add(-time.Minute), V: leakedJSON},
-				}},
-			},
-		},
-	}
-
-	mockClient := &mockLokiClient{}
-	mockClient.On("RangeQuery", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(mockResponse, nil)
-
-	reader := &LokiReader{
-		client: mockClient,
-		logger: &logging.NoOpLogger{},
-	}
-
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
-	result, err := reader.Query(context.Background(), Query{}, filter)
-	require.NoError(t, err)
-	require.Len(t, result.Entries, 1, "notification referencing only inaccessible rules must be dropped")
-	assert.Equal(t, "uuid-accessible", result.Entries[0].Uuid)
-	assert.Equal(t, []string{"ruleA"}, result.Entries[0].RuleUIDs)
-}
-
-func TestHasAccessibleRuleUID(t *testing.T) {
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
-
-	tests := []struct {
-		name     string
-		ruleUIDs []string
-		want     bool
-	}{
-		{name: "accessible rule present", ruleUIDs: []string{"ruleA"}, want: true},
-		{name: "mixed with accessible rule", ruleUIDs: []string{"ruleA", "ruleB"}, want: true},
-		{name: "only inaccessible rule", ruleUIDs: []string{"ruleB"}, want: false},
-		{name: "empty slice", ruleUIDs: []string{}, want: false},
-		{name: "only empty rule UID", ruleUIDs: []string{""}, want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, hasAccessibleRuleUID(tt.ruleUIDs, filter))
-		})
-	}
+	assert.Equal(t, []string{"ruleA", "ruleB"}, result.Entries[0].RuleUIDs, "folder-scoped RBAC returns co-referenced rules intact")
 }
 
 func countStatusPtr(s v0alpha1.CreateNotificationqueryNotificationStatus) *v0alpha1.CreateNotificationqueryNotificationStatus {

--- a/apps/historian/pkg/app/notification/notification.go
+++ b/apps/historian/pkg/app/notification/notification.go
@@ -24,11 +24,11 @@ type Notification struct {
 	loki   *LokiReader
 	logger logging.Logger
 
-	// rbacEnabled indicates results must be restricted to the accessible rules.
+	// rbacEnabled indicates results must be restricted to the accessible folders.
 	rbacEnabled bool
-	// ruleAccess resolves the alert rule UIDs the requester can access. When
-	// rbacEnabled is true this must be non-nil for queries to be served.
-	ruleAccess ruleAccessReader
+	// folderAccess resolves the folder UIDs whose alert rules the requester can
+	// read. When rbacEnabled is true this must be non-nil for queries to be served.
+	folderAccess folderAccessReader
 }
 
 func New(cfg config.NotificationConfig, kubeConfig rest.Config, reg prometheus.Registerer, logger logging.Logger, tracer trace.Tracer) *Notification {
@@ -43,13 +43,13 @@ func New(cfg config.NotificationConfig, kubeConfig rest.Config, reg prometheus.R
 	}
 
 	if cfg.RBACEnabled {
-		reader, err := newK8sRuleAccessReader(kubeConfig, logger)
+		reader, err := newFolderAccessReader(kubeConfig, cfg.AccessClient, logger)
 		if err != nil {
-			// Leave ruleAccess nil; handlers fail closed when RBAC is enabled but
+			// Leave folderAccess nil; handlers fail closed when RBAC is enabled but
 			// the reader could not be constructed.
-			logger.Error("Failed to construct rules access reader; RBAC-protected notification queries will be rejected", "err", err)
+			logger.Error("Failed to construct folder access reader; RBAC-protected notification queries will be rejected", "err", err)
 		} else {
-			n.ruleAccess = reader
+			n.folderAccess = reader
 		}
 	}
 
@@ -57,21 +57,21 @@ func New(cfg config.NotificationConfig, kubeConfig rest.Config, reg prometheus.R
 }
 
 // resolveRuleFilter returns the RBAC rule filter for the request. It returns a
-// nil filter when RBAC is disabled (no filtering). When RBAC is enabled it lists
-// the rules the requester can access and returns a filter restricting results to
-// them.
+// nil filter when RBAC is disabled (no filtering). When RBAC is enabled it
+// resolves the folders whose alert rules the requester can read and returns a
+// filter restricting results to those folders.
 func (n *Notification) resolveRuleFilter(ctx context.Context, namespace string) (*ruleFilter, error) {
 	if !n.rbacEnabled {
 		return nil, nil
 	}
-	if n.ruleAccess == nil {
-		return nil, errors.New("rule access reader is not configured")
+	if n.folderAccess == nil {
+		return nil, errors.New("folder access reader is not configured")
 	}
-	scope, err := n.ruleAccess.AccessibleScope(ctx, namespace)
+	folders, err := n.folderAccess.AccessibleFolders(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	return newRuleFilter(scope), nil
+	return newRuleFilter(folders), nil
 }
 
 func (n *Notification) QueryAlertsHandler(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {

--- a/apps/historian/pkg/app/notification/rbac.go
+++ b/apps/historian/pkg/app/notification/rbac.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/k8s"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,38 +17,33 @@ import (
 )
 
 const (
-	// rulesAPIGroup is the Kubernetes API group serving Grafana alert rules.
+	// folderAPIGroup is the Kubernetes API group serving Grafana folders.
+	folderAPIGroup = "folder.grafana.app"
+	// folderAPIVersion is the version of the folder API used to enumerate folders.
+	folderAPIVersion = "v1beta1"
+	// foldersResource is the plural resource name of the Folder kind. A folder's
+	// metadata.name is the folder UID stored in notification history (folder_uids).
+	foldersResource = "folders"
+	// folderListPageSize is the page size used when listing folders.
+	folderListPageSize = 500
+
+	// rulesAPIGroup is the Kubernetes API group of Grafana alert rules. It is not
+	// queried directly (the historian never lists rules); it identifies the
+	// resource for the alert.rules:read authorization check performed per folder.
 	rulesAPIGroup = "rules.alerting.grafana.app"
-	// rulesAPIVersion is the version of the alert rules API used for RBAC lookups.
-	rulesAPIVersion = "v0alpha1"
-	// alertRulesResource is the plural resource name of the AlertRule kind.
-	// An AlertRule's metadata.name is the rule UID stored in notification history.
+	// alertRulesResource is the plural resource name of the AlertRule kind, used as
+	// the resource for the per-folder alert.rules:read authorization check.
 	alertRulesResource = "alertrules"
-	// rulesListPageSize is the page size used when listing accessible rules.
-	rulesListPageSize = 500
-	// folderLabelKey is the label the rules API sets on every AlertRule to record
-	// the UID of the folder it lives in. It is returned in PartialObjectMetadataList
-	// responses, so folder UIDs can be collected during the rule enumeration at no
-	// extra cost. Mirrors grafana.app/folder (apps/alerting/rules ext.go).
-	folderLabelKey = "grafana.app/folder"
 )
 
-// ruleAccessReader resolves which alert rules (and their folders) the caller
-// (identified by ctx) is allowed to read within a namespace.
-type ruleAccessReader interface {
-	// AccessibleScope returns the set of alert rule UIDs the caller may read plus
-	// the set of folder UIDs those rules live in. RBAC is enforced by the API
-	// server, so the returned sets only ever contain rules the caller is
-	// permitted to see.
-	AccessibleScope(ctx context.Context, namespace string) (accessScope, error)
-}
-
-// accessScope is the set of alert rules a caller can read together with the
-// folders those rules belong to. Folders are always derived from the accessible
-// rules, so the two sets describe the same visibility at different granularities.
-type accessScope struct {
-	rules   ruleUIDSet
-	folders ruleUIDSet
+// folderAccessReader resolves which folders' alert rules the caller (identified
+// by ctx) is allowed to read within a namespace.
+type folderAccessReader interface {
+	// AccessibleFolders returns the set of folder UIDs whose alert rules the
+	// caller may read. Both the folder enumeration and the per-folder
+	// authorization are RBAC-enforced, so the returned set only ever contains
+	// folders the caller is permitted to see.
+	AccessibleFolders(ctx context.Context, namespace string) (ruleUIDSet, error)
 }
 
 // ruleFilter constrains a query to what the caller can access. A nil *ruleFilter
@@ -56,22 +52,19 @@ type accessScope struct {
 //
 // The LogQL push-down matches accessible folder UIDs (folder_uids/folder_uid
 // structured metadata): folders are far fewer than rules, so the matcher stays
-// small and cheap for Loki even for large tenants. Folders are derived from the
-// rules the caller can access, so visibility is exactly per-rule RBAC. The rule
-// set is retained so groupBy.ruleUID counts still strip individual inaccessible
-// rules co-referenced by a notification.
+// small and cheap for Loki even for large tenants. Alert-rule RBAC is strictly
+// folder-scoped, so a caller who can read a folder can read every alert rule in
+// it; folder-level filtering is therefore equivalent to per-rule RBAC without
+// enumerating individual rules.
 type ruleFilter struct {
 	// folderKeys are the accessible folder UIDs used in the push-down matcher,
 	// sorted and non-empty.
 	folderKeys []string
-	// rules is the set of accessible rule UIDs, used to strip inaccessible rules
-	// from groupBy.ruleUID counts.
-	rules ruleUIDSet
 }
 
-// newRuleFilter builds a ruleFilter from an accessible scope.
-func newRuleFilter(scope accessScope) *ruleFilter {
-	return &ruleFilter{folderKeys: scope.folders.sorted(), rules: scope.rules}
+// newRuleFilter builds a ruleFilter from the set of accessible folder UIDs.
+func newRuleFilter(folders ruleUIDSet) *ruleFilter {
+	return &ruleFilter{folderKeys: folders.sorted()}
 }
 
 // empty reports whether the caller can access nothing (no folder keys).
@@ -205,24 +198,29 @@ func (s ruleUIDSet) sorted() []string {
 	return out
 }
 
-// k8sRuleAccessReader lists AlertRule resources through the Kubernetes rules API.
-// The request identity is carried on the context and forwarded to the API server,
-// which applies RBAC and only returns rules the caller can access.
-type k8sRuleAccessReader struct {
+// k8sFolderAccessReader resolves the folders whose alert rules a caller can read.
+// It enumerates the tenant's folders through the multi-tenant folder API and then
+// confirms alert.rules:read on each folder via the authz AccessClient.
+type k8sFolderAccessReader struct {
 	client rest.Interface
+	access authtypes.AccessClient
 	logger logging.Logger
 }
 
-// newK8sRuleAccessReader builds a rule access reader from a base kube config.
-// The base config is expected to route requests to the same API server that
-// serves the rules API (for in-process Grafana this is the loopback config,
-// which forwards the request identity from the context).
-func newK8sRuleAccessReader(kubeConfig rest.Config, logger logging.Logger) (*k8sRuleAccessReader, error) {
+// newFolderAccessReader builds a folder access reader from a base kube config and
+// an authz access client. The base config is expected to route requests to an API
+// server that serves the multi-tenant folder API, forwarding the request identity
+// from the context. access must be non-nil.
+func newFolderAccessReader(kubeConfig rest.Config, access authtypes.AccessClient, logger logging.Logger) (*k8sFolderAccessReader, error) {
+	if access == nil {
+		return nil, fmt.Errorf("access client is required for RBAC")
+	}
+
 	cfg := kubeConfig
 	cfg.APIPath = "/apis"
 	cfg.GroupVersion = &schema.GroupVersion{
-		Group:   rulesAPIGroup,
-		Version: rulesAPIVersion,
+		Group:   folderAPIGroup,
+		Version: folderAPIVersion,
 	}
 	if cfg.NegotiatedSerializer == nil {
 		cfg.NegotiatedSerializer = &k8s.GenericNegotiatedSerializer{}
@@ -230,61 +228,70 @@ func newK8sRuleAccessReader(kubeConfig rest.Config, logger logging.Logger) (*k8s
 
 	client, err := rest.RESTClientFor(&cfg)
 	if err != nil {
-		return nil, fmt.Errorf("build rules API client: %w", err)
+		return nil, fmt.Errorf("build folder API client: %w", err)
 	}
 
-	return &k8sRuleAccessReader{client: client, logger: logger}, nil
+	return &k8sFolderAccessReader{client: client, access: access, logger: logger}, nil
 }
 
-// partialRuleList is a minimal projection of an AlertRule list response. Only the
-// resource name (the rule UID), the folder label and the pagination cursor are
-// needed.
-type partialRuleList struct {
+// partialFolderList is a minimal projection of a Folder list response. Only the
+// resource name (the folder UID) and the pagination cursor are needed.
+type partialFolderList struct {
 	Metadata struct {
 		Continue string `json:"continue"`
 	} `json:"metadata"`
 	Items []struct {
 		Metadata struct {
-			Name   string            `json:"name"`
-			Labels map[string]string `json:"labels"`
+			Name string `json:"name"`
 		} `json:"metadata"`
 	} `json:"items"`
 }
 
-// AccessibleScope lists all alert rules the caller can read in the namespace and
-// returns their UIDs together with the folder UIDs those rules live in (read from
-// the grafana.app/folder label). It follows pagination until the full set is
-// collected.
-func (r *k8sRuleAccessReader) AccessibleScope(ctx context.Context, namespace string) (accessScope, error) {
-	scope := accessScope{rules: make(ruleUIDSet), folders: make(ruleUIDSet)}
+// AccessibleFolders enumerates the tenant's folders and returns the subset whose
+// alert rules the caller may read. It lists folders via the folder API (RBAC
+// enforced by that API server) and then confirms alert.rules:read on each folder
+// through the AccessClient, so the result reflects alert-rule read access rather
+// than mere folder visibility.
+func (r *k8sFolderAccessReader) AccessibleFolders(ctx context.Context, namespace string) (ruleUIDSet, error) {
+	candidates, err := r.listFolders(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return ruleUIDSet{}, nil
+	}
+	return r.filterReadableFolders(ctx, namespace, candidates)
+}
+
+// listFolders lists all folder UIDs visible to the caller in the namespace,
+// following pagination until the full set is collected.
+func (r *k8sFolderAccessReader) listFolders(ctx context.Context, namespace string) ([]string, error) {
+	var folders []string
 	cont := ""
 	for {
 		req := r.client.Get().
 			Namespace(namespace).
-			Resource(alertRulesResource).
-			// Request only object metadata to avoid transferring full rule specs.
+			Resource(foldersResource).
+			// Request only object metadata to avoid transferring full folder specs.
 			SetHeader("Accept", "application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json").
-			Param("limit", strconv.Itoa(rulesListPageSize))
+			Param("limit", strconv.Itoa(folderListPageSize))
 		if cont != "" {
 			req = req.Param("continue", cont)
 		}
 
 		raw, err := req.Do(ctx).Raw()
 		if err != nil {
-			return accessScope{}, fmt.Errorf("list alert rules: %w", err)
+			return nil, fmt.Errorf("list folders: %w", err)
 		}
 
-		var page partialRuleList
+		var page partialFolderList
 		if err := json.Unmarshal(raw, &page); err != nil {
-			return accessScope{}, fmt.Errorf("unmarshal alert rule list: %w", err)
+			return nil, fmt.Errorf("unmarshal folder list: %w", err)
 		}
 
 		for _, item := range page.Items {
 			if item.Metadata.Name != "" {
-				scope.rules[item.Metadata.Name] = struct{}{}
-			}
-			if folder := item.Metadata.Labels[folderLabelKey]; folder != "" {
-				scope.folders[folder] = struct{}{}
+				folders = append(folders, item.Metadata.Name)
 			}
 		}
 
@@ -294,5 +301,58 @@ func (r *k8sRuleAccessReader) AccessibleScope(ctx context.Context, namespace str
 		}
 	}
 
-	return scope, nil
+	return folders, nil
+}
+
+// filterReadableFolders returns the subset of candidate folders in which the
+// caller may read alert rules (alert.rules:read), determined via the AccessClient.
+// Checks are issued in batches bounded by authtypes.MaxBatchCheckItems.
+func (r *k8sFolderAccessReader) filterReadableFolders(ctx context.Context, namespace string, candidates []string) (ruleUIDSet, error) {
+	info, ok := authtypes.AuthInfoFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no auth info in context")
+	}
+
+	accessible := make(ruleUIDSet, len(candidates))
+	for start := 0; start < len(candidates); start += authtypes.MaxBatchCheckItems {
+		end := start + authtypes.MaxBatchCheckItems
+		if end > len(candidates) {
+			end = len(candidates)
+		}
+		batch := candidates[start:end]
+
+		checks := make([]authtypes.BatchCheckItem, len(batch))
+		for i, uid := range batch {
+			checks[i] = authtypes.BatchCheckItem{
+				// The folder UID uniquely identifies the check within the batch.
+				CorrelationID: uid,
+				Verb:          "list",
+				Group:         rulesAPIGroup,
+				Resource:      alertRulesResource,
+				// A folder-scoped question ("may the caller read alert rules in this
+				// folder"): no rule name, only the parent folder.
+				Folder: uid,
+			}
+		}
+
+		resp, err := r.access.BatchCheck(ctx, info, authtypes.BatchCheckRequest{
+			Namespace: namespace,
+			Checks:    checks,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("check folder alert rule access: %w", err)
+		}
+
+		for _, uid := range batch {
+			result := resp.Results[uid]
+			if result.Error != nil {
+				return nil, fmt.Errorf("check folder %q alert rule access: %w", uid, result.Error)
+			}
+			if result.Allowed {
+				accessible[uid] = struct{}{}
+			}
+		}
+	}
+
+	return accessible, nil
 }

--- a/apps/historian/pkg/app/notification/rbac_integration_test.go
+++ b/apps/historian/pkg/app/notification/rbac_integration_test.go
@@ -85,64 +85,66 @@ func TestIntegration_NotificationRBAC(t *testing.T) {
 	universe := ruleUIDSet{ruleA: {}, ruleB: {}}
 	folderUniverse := ruleUIDSet{folderA: {}, folderB: {}}
 	// newN builds an RBAC-enabled Notification. The push-down is folder-based, so
-	// the accessible folder set drives visibility; the rule set is still supplied
-	// so per-rule count stripping keeps working for mixed notifications.
-	newN := func(rules, folders ruleUIDSet) *Notification {
+	// the accessible folder set alone drives visibility. Alert-rule RBAC is
+	// strictly folder-scoped, so a notification that references an accessible
+	// folder is fully accessible (no per-rule stripping).
+	newN := func(folders ruleUIDSet) *Notification {
 		return &Notification{
-			loki:        reader,
-			logger:      &logging.NoOpLogger{},
-			rbacEnabled: true,
-			ruleAccess:  fakeRuleAccessReader{scope: accessScope{rules: rules, folders: folders}},
+			loki:         reader,
+			logger:       &logging.NoOpLogger{},
+			rbacEnabled:  true,
+			folderAccess: fakeFolderAccessReader{folders: folders},
 		}
 	}
 
 	// Wait until all seeded entries are queryable (admin sees everything).
-	admin := newN(universe, folderUniverse)
+	admin := newN(folderUniverse)
 	require.Eventually(t, func() bool {
 		res := queryEntries(t, admin)
 		return len(seededEntries(res.Entries, universe)) == len(seeded)
 	}, 20*time.Second, 250*time.Millisecond, "seeded notification entries never became queryable")
 
-	t.Run("user A sees only rule A entries plus the mixed entry", func(t *testing.T) {
-		res := queryEntries(t, newN(ruleUIDSet{ruleA: {}}, ruleUIDSet{folderA: {}}))
+	t.Run("user A sees folder A entries plus the mixed entry", func(t *testing.T) {
+		res := queryEntries(t, newN(ruleUIDSet{folderA: {}}))
 		entries := seededEntries(res.Entries, universe)
 
 		uuids := entryUUIDs(entries)
 		assert.ElementsMatch(t, []string{"uuid-a1-" + suffix, "uuid-a2-" + suffix, "uuid-mix-" + suffix}, uuids)
 		for _, e := range entries {
 			assert.Contains(t, e.RuleUIDs, ruleA, "every visible entry must reference rule A")
-			// The mixed entry co-references rule B, which user A cannot access;
-			// it must be stripped from the returned RuleUIDs.
-			assert.NotContains(t, e.RuleUIDs, ruleB, "inaccessible co-referenced rule B must be stripped")
+		}
+		// RBAC is folder-scoped: the mixed notification references accessible
+		// folder A, so it is fully visible including its co-referenced rule B.
+		for _, e := range entries {
+			if e.Uuid == "uuid-mix-"+suffix {
+				assert.Contains(t, e.RuleUIDs, ruleB, "mixed entry is fully visible via folder A")
+			}
 		}
 	})
 
-	t.Run("user B sees only rule B entries plus the mixed entry", func(t *testing.T) {
-		res := queryEntries(t, newN(ruleUIDSet{ruleB: {}}, ruleUIDSet{folderB: {}}))
+	t.Run("user B sees folder B entries plus the mixed entry", func(t *testing.T) {
+		res := queryEntries(t, newN(ruleUIDSet{folderB: {}}))
 		entries := seededEntries(res.Entries, universe)
 
 		uuids := entryUUIDs(entries)
 		assert.ElementsMatch(t, []string{"uuid-b1-" + suffix, "uuid-b2-" + suffix, "uuid-mix-" + suffix}, uuids)
 		for _, e := range entries {
 			assert.Contains(t, e.RuleUIDs, ruleB, "every visible entry must reference rule B")
-			// The mixed entry co-references rule A, which user B cannot access;
-			// it must be stripped from the returned RuleUIDs.
-			assert.NotContains(t, e.RuleUIDs, ruleA, "inaccessible co-referenced rule A must be stripped")
 		}
 	})
 
 	t.Run("admin sees all seeded entries", func(t *testing.T) {
-		res := queryEntries(t, newN(universe, folderUniverse))
+		res := queryEntries(t, newN(folderUniverse))
 		assert.Len(t, seededEntries(res.Entries, universe), len(seeded))
 	})
 
-	t.Run("no accessible rules yields no entries", func(t *testing.T) {
-		res := queryEntries(t, newN(ruleUIDSet{}, ruleUIDSet{}))
+	t.Run("no accessible folders yields no entries", func(t *testing.T) {
+		res := queryEntries(t, newN(ruleUIDSet{}))
 		assert.Empty(t, seededEntries(res.Entries, universe))
 	})
 
-	t.Run("counts grouped by rule UID drop inaccessible co-referenced rules", func(t *testing.T) {
-		res := queryCounts(t, newN(ruleUIDSet{ruleA: {}}, ruleUIDSet{folderA: {}}))
+	t.Run("counts grouped by rule UID include co-referenced rules in accessible folders", func(t *testing.T) {
+		res := queryCounts(t, newN(ruleUIDSet{folderA: {}}))
 
 		var gotA, gotB int64
 		for _, c := range res.Counts {
@@ -158,13 +160,13 @@ func TestIntegration_NotificationRBAC(t *testing.T) {
 		}
 		// Two rule-A notifications + the mixed one all count towards rule A.
 		assert.Equal(t, int64(3), gotA)
-		// Rule B was co-referenced by the mixed notification, but user A cannot
-		// access it, so it must not appear.
-		assert.Equal(t, int64(0), gotB)
+		// The mixed notification references accessible folder A, so it is fully
+		// visible: its co-referenced rule B is counted too (folder-scoped RBAC).
+		assert.Equal(t, int64(1), gotB)
 	})
 
 	t.Run("alerts query is filtered per folder UID", func(t *testing.T) {
-		res := queryAlerts(t, newN(ruleUIDSet{ruleA: {}}, ruleUIDSet{folderA: {}}))
+		res := queryAlerts(t, newN(ruleUIDSet{folderA: {}}))
 
 		var seen int
 		for _, a := range res.Alerts {

--- a/apps/historian/pkg/app/notification/rbac_test.go
+++ b/apps/historian/pkg/app/notification/rbac_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -17,17 +18,45 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 )
 
-// testFilter builds a filter over the given accessible rule and folder UIDs.
-func testFilter(rules, folders []string) *ruleFilter {
-	rset := make(ruleUIDSet, len(rules))
-	for _, r := range rules {
-		rset[r] = struct{}{}
-	}
+// testFilter builds a folder-only filter over the given accessible folder UIDs.
+func testFilter(folders ...string) *ruleFilter {
 	fset := make(ruleUIDSet, len(folders))
 	for _, f := range folders {
 		fset[f] = struct{}{}
 	}
-	return newRuleFilter(accessScope{rules: rset, folders: fset})
+	return newRuleFilter(fset)
+}
+
+// fakeAuthInfo satisfies authtypes.AuthInfo for tests. Its methods are never
+// invoked (the fake access client ignores the identity), so embedding the nil
+// interface is sufficient to place a value on the context.
+type fakeAuthInfo struct {
+	authtypes.AuthInfo
+}
+
+// fakeAccessClient is a test double for authtypes.AccessClient that grants access
+// to a fixed set of folder UIDs.
+type fakeAccessClient struct {
+	allowedFolders map[string]bool
+	// gotChecks records the folder-scoped checks issued, for assertions.
+	gotChecks []authtypes.BatchCheckItem
+}
+
+func (f *fakeAccessClient) Check(context.Context, authtypes.AuthInfo, authtypes.CheckRequest, string) (authtypes.CheckResponse, error) {
+	return authtypes.CheckResponse{}, nil
+}
+
+func (f *fakeAccessClient) Compile(context.Context, authtypes.AuthInfo, authtypes.ListRequest) (authtypes.ItemChecker, authtypes.Zookie, error) {
+	return func(_, folder string) bool { return f.allowedFolders[folder] }, &authtypes.NoopZookie{}, nil
+}
+
+func (f *fakeAccessClient) BatchCheck(_ context.Context, _ authtypes.AuthInfo, req authtypes.BatchCheckRequest) (authtypes.BatchCheckResponse, error) {
+	results := make(map[string]authtypes.BatchCheckResult, len(req.Checks))
+	for _, c := range req.Checks {
+		f.gotChecks = append(f.gotChecks, c)
+		results[c.CorrelationID] = authtypes.BatchCheckResult{Allowed: f.allowedFolders[c.Folder]}
+	}
+	return authtypes.BatchCheckResponse{Results: results}, nil
 }
 
 func TestBuildNotificationFolderFilter(t *testing.T) {
@@ -43,17 +72,17 @@ func TestBuildNotificationFolderFilter(t *testing.T) {
 		},
 		{
 			name:   "empty accessible set produces no matcher",
-			filter: testFilter(nil, nil),
+			filter: testFilter(),
 			want:   "",
 		},
 		{
 			name:   "single accessible folder",
-			filter: testFilter([]string{"ruleA"}, []string{"folderA"}),
+			filter: testFilter("folderA"),
 			want:   ` | folder_uids =~ "(^|.*,)(folderA)($|,.*)"`,
 		},
 		{
 			name:   "multiple accessible folders are sorted",
-			filter: testFilter([]string{"ruleA"}, []string{"folderB", "folderA"}),
+			filter: testFilter("folderB", "folderA"),
 			want:   ` | folder_uids =~ "(^|.*,)(folderA|folderB)($|,.*)"`,
 		},
 	}
@@ -78,12 +107,12 @@ func TestBuildAlertFolderFilter(t *testing.T) {
 		},
 		{
 			name:   "empty accessible set produces no matcher",
-			filter: testFilter(nil, nil),
+			filter: testFilter(),
 			want:   "",
 		},
 		{
 			name:   "multiple accessible folders are sorted",
-			filter: testFilter([]string{"ruleA"}, []string{"folderB", "folderA"}),
+			filter: testFilter("folderB", "folderA"),
 			want:   ` | folder_uid =~ "^(folderA|folderB)$"`,
 		},
 	}
@@ -96,7 +125,7 @@ func TestBuildAlertFolderFilter(t *testing.T) {
 }
 
 func TestBuildQuery_RBACFolderFilterPushedDown(t *testing.T) {
-	filter := testFilter([]string{"ruleA"}, []string{"folderA", "folderB"})
+	filter := testFilter("folderA", "folderB")
 
 	logql, err := buildQuery(Query{}, nil, filter)
 	require.NoError(t, err)
@@ -104,7 +133,7 @@ func TestBuildQuery_RBACFolderFilterPushedDown(t *testing.T) {
 }
 
 func TestBuildAlertQuery_RBACFolderFilterPushedDown(t *testing.T) {
-	filter := testFilter([]string{"ruleA"}, []string{"folderA", "folderB"})
+	filter := testFilter("folderA", "folderB")
 
 	logql, err := buildAlertQuery(AlertQuery{}, filter)
 	require.NoError(t, err)
@@ -118,8 +147,8 @@ func TestLokiReader_Query_EmptyFilterReturnsEmptyWithoutQuerying(t *testing.T) {
 		logger: &logging.NoOpLogger{},
 	}
 
-	// A non-nil but empty filter means the caller can access no rules.
-	result, err := reader.Query(context.Background(), Query{}, testFilter(nil, nil))
+	// A non-nil but empty filter means the caller can access no folders.
+	result, err := reader.Query(context.Background(), Query{}, testFilter())
 	require.NoError(t, err)
 	assert.Empty(t, result.Entries)
 	assert.Empty(t, result.Counts)
@@ -135,7 +164,7 @@ func TestLokiReader_QueryAlerts_EmptyFilterReturnsEmptyWithoutQuerying(t *testin
 		logger: &logging.NoOpLogger{},
 	}
 
-	result, err := reader.QueryAlerts(context.Background(), AlertQuery{}, testFilter(nil, nil))
+	result, err := reader.QueryAlerts(context.Background(), AlertQuery{}, testFilter())
 	require.NoError(t, err)
 	assert.Empty(t, result.Alerts)
 	mockClient.AssertNotCalled(t, "RangeQuery")
@@ -155,29 +184,33 @@ func TestLokiReader_Query_NonEmptyFilterAppliesMatcher(t *testing.T) {
 		logger: &logging.NoOpLogger{},
 	}
 
-	result, err := reader.Query(context.Background(), Query{}, testFilter([]string{"rule-uid-1"}, []string{"folder-1"}))
+	result, err := reader.Query(context.Background(), Query{}, testFilter("folder-1"))
 	require.NoError(t, err)
 	assert.Len(t, result.Entries, 1)
 	mockClient.AssertExpectations(t)
 }
 
-func TestExplodeRuleUIDCounts_DropsInaccessibleRules(t *testing.T) {
-	// A notification referencing both an accessible (ruleA) and inaccessible (ruleB)
-	// rule must only produce a per-rule count for the accessible one.
+func TestExplodeRuleUIDCounts_SplitsCommaSeparated(t *testing.T) {
+	// A notification referencing several rules is stored with a comma-separated
+	// rule_uids label; grouping by rule must emit an individual count per rule,
+	// each carrying the notification's count.
 	counts := []Count{
 		{RuleUID: stringPtr("ruleA,ruleB"), Count: 5},
 	}
-	filter := testFilter([]string{"ruleA"}, []string{"folderA"})
 
-	got := explodeRuleUIDCounts(counts, 10, filter)
+	got := explodeRuleUIDCounts(counts, 10)
 
-	require.Len(t, got, 1)
-	require.NotNil(t, got[0].RuleUID)
-	assert.Equal(t, "ruleA", *got[0].RuleUID)
-	assert.Equal(t, int64(5), got[0].Count)
+	require.Len(t, got, 2)
+	byUID := map[string]int64{}
+	for _, c := range got {
+		require.NotNil(t, c.RuleUID)
+		byUID[*c.RuleUID] = c.Count
+	}
+	assert.Equal(t, int64(5), byUID["ruleA"])
+	assert.Equal(t, int64(5), byUID["ruleB"])
 }
 
-func TestK8sRuleAccessReader_AccessibleScope(t *testing.T) {
+func TestFolderAccessReader_AccessibleFolders(t *testing.T) {
 	var gotPaths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPaths = append(gotPaths, r.URL.Path)
@@ -190,15 +223,15 @@ func TestK8sRuleAccessReader_AccessibleScope(t *testing.T) {
 			resp = map[string]any{
 				"metadata": map[string]any{"continue": "next-page"},
 				"items": []map[string]any{
-					{"metadata": map[string]any{"name": "rule-1", "labels": map[string]any{folderLabelKey: "folder-a"}}},
-					{"metadata": map[string]any{"name": "rule-2", "labels": map[string]any{folderLabelKey: "folder-a"}}},
+					{"metadata": map[string]any{"name": "folder-a"}},
+					{"metadata": map[string]any{"name": "folder-b"}},
 				},
 			}
 		} else {
 			resp = map[string]any{
 				"metadata": map[string]any{"continue": ""},
 				"items": []map[string]any{
-					{"metadata": map[string]any{"name": "rule-3", "labels": map[string]any{folderLabelKey: "folder-b"}}},
+					{"metadata": map[string]any{"name": "folder-c"}},
 				},
 			}
 		}
@@ -206,38 +239,68 @@ func TestK8sRuleAccessReader_AccessibleScope(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	reader, err := newK8sRuleAccessReader(rest.Config{Host: srv.URL}, &logging.NoOpLogger{})
+	// The caller may read alert rules in folder-a and folder-c but not folder-b.
+	access := &fakeAccessClient{allowedFolders: map[string]bool{"folder-a": true, "folder-c": true}}
+	reader, err := newFolderAccessReader(rest.Config{Host: srv.URL}, access, &logging.NoOpLogger{})
 	require.NoError(t, err)
 
-	scope, err := reader.AccessibleScope(context.Background(), "org-1")
+	ctx := authtypes.WithAuthInfo(context.Background(), fakeAuthInfo{})
+	folders, err := reader.AccessibleFolders(ctx, "org-1")
 	require.NoError(t, err)
 
-	assert.True(t, scope.rules.Has("rule-1"))
-	assert.True(t, scope.rules.Has("rule-2"))
-	assert.True(t, scope.rules.Has("rule-3"))
-	assert.False(t, scope.rules.Has("rule-4"))
-	assert.Len(t, scope.rules, 3)
+	assert.True(t, folders.Has("folder-a"))
+	assert.False(t, folders.Has("folder-b"))
+	assert.True(t, folders.Has("folder-c"))
+	assert.Len(t, folders, 2)
 
-	// Folders are collected from the grafana.app/folder label and de-duplicated.
-	assert.True(t, scope.folders.Has("folder-a"))
-	assert.True(t, scope.folders.Has("folder-b"))
-	assert.Len(t, scope.folders, 2)
-
-	// Both pages should target the namespaced alertrules collection.
+	// Both pages should target the namespaced folders collection.
 	require.Len(t, gotPaths, 2)
 	for _, p := range gotPaths {
-		assert.Equal(t, "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/org-1/alertrules", p)
+		assert.Equal(t, "/apis/folder.grafana.app/v1beta1/namespaces/org-1/folders", p)
+	}
+
+	// Every candidate folder is checked for alert.rules read access, folder-scoped.
+	require.Len(t, access.gotChecks, 3)
+	for _, c := range access.gotChecks {
+		assert.Equal(t, rulesAPIGroup, c.Group)
+		assert.Equal(t, alertRulesResource, c.Resource)
+		assert.Equal(t, c.CorrelationID, c.Folder)
+		assert.NotEmpty(t, c.Verb)
 	}
 }
 
-// fakeRuleAccessReader is a test double for ruleAccessReader.
-type fakeRuleAccessReader struct {
-	scope accessScope
-	err   error
+func TestFolderAccessReader_RequiresAuthInfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{"continue": ""},
+			"items":    []map[string]any{{"metadata": map[string]any{"name": "folder-a"}}},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	access := &fakeAccessClient{allowedFolders: map[string]bool{"folder-a": true}}
+	reader, err := newFolderAccessReader(rest.Config{Host: srv.URL}, access, &logging.NoOpLogger{})
+	require.NoError(t, err)
+
+	// No auth info on the context: the folder checks cannot be performed.
+	_, err = reader.AccessibleFolders(context.Background(), "org-1")
+	require.Error(t, err)
 }
 
-func (f fakeRuleAccessReader) AccessibleScope(_ context.Context, _ string) (accessScope, error) {
-	return f.scope, f.err
+func TestNewFolderAccessReader_RequiresAccessClient(t *testing.T) {
+	_, err := newFolderAccessReader(rest.Config{Host: "http://example"}, nil, &logging.NoOpLogger{})
+	require.Error(t, err)
+}
+
+// fakeFolderAccessReader is a test double for folderAccessReader.
+type fakeFolderAccessReader struct {
+	folders ruleUIDSet
+	err     error
+}
+
+func (f fakeFolderAccessReader) AccessibleFolders(_ context.Context, _ string) (ruleUIDSet, error) {
+	return f.folders, f.err
 }
 
 func TestNotification_ResolveRuleFilter(t *testing.T) {
@@ -249,26 +312,20 @@ func TestNotification_ResolveRuleFilter(t *testing.T) {
 	})
 
 	t.Run("rbac enabled without reader fails closed", func(t *testing.T) {
-		n := &Notification{rbacEnabled: true, ruleAccess: nil}
+		n := &Notification{rbacEnabled: true, folderAccess: nil}
 		_, err := n.resolveRuleFilter(context.Background(), "org-1")
 		require.Error(t, err)
 	})
 
 	t.Run("rbac enabled returns filter keyed by folder UIDs", func(t *testing.T) {
 		n := &Notification{
-			rbacEnabled: true,
-			ruleAccess: fakeRuleAccessReader{scope: accessScope{
-				rules:   ruleUIDSet{"ruleA": {}, "ruleB": {}},
-				folders: ruleUIDSet{"folderB": {}, "folderA": {}},
-			}},
+			rbacEnabled:  true,
+			folderAccess: fakeFolderAccessReader{folders: ruleUIDSet{"folderB": {}, "folderA": {}}},
 		}
 		filter, err := n.resolveRuleFilter(context.Background(), "org-1")
 		require.NoError(t, err)
 		require.NotNil(t, filter)
-		// The push-down is keyed by accessible folders...
+		// The push-down is keyed by the accessible folders, sorted.
 		assert.Equal(t, []string{"folderA", "folderB"}, filter.folderKeys)
-		// ...while the rule set is retained for per-rule count stripping.
-		assert.True(t, filter.rules.Has("ruleA"))
-		assert.True(t, filter.rules.Has("ruleB"))
 	})
 }


### PR DESCRIPTION
### Background
Notification History RBAC (added in #616) resolved a caller's accessible alert rules by listing `rules.alerting.grafana.app` through the Kubernetes rules API and filtering results to those rules (and the folders they live in). That approach does not work for the standalone historian. If the historian is deployed as a **multi-tenant** app, the rules API is still **single tenant**, so there is no way to point the historian at a per-tenant rules API - the configuration simply can't be expressed correctly in a multi-tenant deployment.

### What changed
RBAC is now resolved entirely through **multi-tenant** services:
1. **Enumerate folders** via the multi-tenant folder API (`folder.grafana.app`), forwarding the request identity.
2. **Authorize each folder** for `alert.rules:read` via an injected `authlib.AccessClient` (`BatchCheck`, folder-scoped, chunked by `MaxBatchCheckItems`). This exercises the alert-rules → folder mapping recently added to the authz service.
3. Restrict queries to the resulting accessible folder set using the existing LogQL folder push-down (`folder_uids` / `folder_uid` structured metadata), including the size-aware batching for large folder sets.

The `AccessClient` is supplied programmatically through `NotificationConfig` (not a flag), so `notification.New()` and `app.go` keep their signatures; the concrete client is wired by the deployment.

### Semantics change (folder-granular RBAC)
Alert-rule RBAC is strictly folder-scoped, so "can read a folder" ⇔ "can read every alert rule in it". Filtering at the folder level is therefore equivalent to per-rule RBAC **without enumerating individual rules** — which the single-tenant rules API can
no longer provide here. As a result, all per-rule post-processing is removed:
- No per-rule stripping of `RuleUIDs` from entries.
- No under-the-hood `rule_uids` grouping / fail-closed guard for counts.
- A notification admitted via an accessible folder is returned intact, including rule UIDs it co-references from other folders.
Alert lines remain filtered per folder (single-valued `folder_uid`), so per-alert access is unchanged. Multi-batch count results are merged via `mergeCounts` / `mergeRangeCounts`.

### Files
- `config.go` — add `AccessClient` to `NotificationConfig`; update RBAC docs; `authlib/types` promoted to a direct dependency.
- `rbac.go` — replace `k8sRuleAccessReader` with `k8sFolderAccessReader` (folder list + per-folder `alert.rules:read` check); `ruleFilter` is folder-only.
- `notification.go` — construct the folder reader; fail closed when RBAC is enabled but no `AccessClient` is configured.
- `lokireader.go` — remove all rule-level filtering; access enforced by the folder push-down alone.
- Tests updated to folder-only semantics.

### Testing
- `go build ./...`, `go vet ./...`, `go test ./pkg/app/notification/` pass; gofmt clean.
- The Loki integration test (`TestIntegration_NotificationRBAC`) self-skips unless
  `HISTORIAN_LOKI_URL` is set.