### PR TITLE
Historian: wire authz AccessClient into standalone historian-operator

### DIFF
--- a/apps/historian/cmd/historian-operator/authz.go
+++ b/apps/historian/cmd/historian-operator/authz.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	authnlib "github.com/grafana/authlib/authn"
+	authzlib "github.com/grafana/authlib/authz"
+	authtypes "github.com/grafana/authlib/types"
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// authzServiceAudience is the audience requested when exchanging a service token
+// for a call to the authz service. It matches the value Grafana uses.
+const authzServiceAudience = "authzService"
+
+// authzConfig configures the connection to the multi-tenant authz service used
+// to authorize alert.rules:read per folder for notification-history RBAC. It is
+// only required when notification RBAC is enabled.
+type authzConfig struct {
+	// RemoteAddress is the host:port of the authz gRPC service.
+	RemoteAddress string
+	// Token is the service token presented to the token-exchange endpoint.
+	Token string
+	// TokenExchangeURL is the endpoint that exchanges Token for a scoped access
+	// token accepted by the authz service.
+	TokenExchangeURL string
+	// TokenNamespace is the namespace claimed when exchanging tokens (e.g. the
+	// stack namespace "stacks-<id>", or "*" to act across namespaces).
+	TokenNamespace string
+	// CertFile, when set, enables TLS to the authz service using this CA/cert
+	// file. When empty the connection uses insecure transport credentials.
+	CertFile string
+}
+
+func (c *authzConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&c.RemoteAddress, "authz.remote-address", "", "host:port of the authz gRPC service (required when notification RBAC is enabled)")
+	flags.StringVar(&c.Token, "authz.token", "", "Service token used to perform the token exchange for authz calls")
+	flags.StringVar(&c.TokenExchangeURL, "authz.token-exchange-url", "", "URL of the token-exchange endpoint")
+	flags.StringVar(&c.TokenNamespace, "authz.token-namespace", "*", "Namespace claimed when exchanging tokens for authz calls")
+	flags.StringVar(&c.CertFile, "authz.tls.cert-path", "", "Path to a TLS CA/cert file for the authz connection; empty uses insecure transport")
+}
+
+// newAccessClient builds an authz-backed AccessClient using service-to-service
+// token exchange, mirroring how Grafana constructs its remote RBAC client.
+func newAccessClient(cfg authzConfig) (authtypes.AccessClient, error) {
+	if cfg.RemoteAddress == "" {
+		return nil, fmt.Errorf("authz.remote-address is required when notification RBAC is enabled")
+	}
+	if cfg.Token == "" || cfg.TokenExchangeURL == "" {
+		return nil, fmt.Errorf("authz.token and authz.token-exchange-url are required when notification RBAC is enabled")
+	}
+
+	tokenClient, err := authnlib.NewTokenExchangeClient(authnlib.TokenExchangeConfig{
+		Token:            cfg.Token,
+		TokenExchangeURL: cfg.TokenExchangeURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize token exchange client: %w", err)
+	}
+
+	transportCreds := insecure.NewCredentials()
+	if cfg.CertFile != "" {
+		transportCreds, err = credentials.NewClientTLSFromFile(cfg.CertFile, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to load authz TLS credentials: %w", err)
+		}
+	}
+
+	conn, err := grpc.NewClient(
+		cfg.RemoteAddress,
+		grpc.WithTransportCredentials(transportCreds),
+		grpc.WithPerRPCCredentials(newTokenAuth(authzServiceAudience, cfg.TokenNamespace, tokenClient)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authz client connection: %w", err)
+	}
+
+	return authzlib.NewClient(conn), nil
+}
+
+// tokenAuth is a gRPC PerRPCCredentials that attaches a freshly exchanged access
+// token to each request as the X-Access-Token header.
+type tokenAuth struct {
+	audience    string
+	namespace   string
+	tokenClient authnlib.TokenExchanger
+}
+
+func newTokenAuth(audience, namespace string, tc authnlib.TokenExchanger) *tokenAuth {
+	return &tokenAuth{audience: audience, namespace: namespace, tokenClient: tc}
+}
+
+func (t *tokenAuth) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	token, err := t.tokenClient.Exchange(ctx, authnlib.TokenExchangeRequest{
+		Namespace: t.namespace,
+		Audiences: []string{t.audience},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"X-Access-Token": token.Token}, nil
+}
+
+func (t *tokenAuth) RequireTransportSecurity() bool { return false }

--- a/apps/historian/cmd/historian-operator/authz_test.go
+++ b/apps/historian/cmd/historian-operator/authz_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	authnlib "github.com/grafana/authlib/authn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validAuthzConfig() authzConfig {
+	return authzConfig{
+		RemoteAddress:    "authz.example.com:10000",
+		Token:            "service-token",
+		TokenExchangeURL: "https://token-exchange.example.com/exchange",
+		TokenNamespace:   "*",
+	}
+}
+
+func TestNewAccessClient_RequiresConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(c *authzConfig)
+		wantErr string
+	}{
+		{
+			name:    "missing remote address",
+			mutate:  func(c *authzConfig) { c.RemoteAddress = "" },
+			wantErr: "authz.remote-address is required",
+		},
+		{
+			name:    "missing token",
+			mutate:  func(c *authzConfig) { c.Token = "" },
+			wantErr: "authz.token and authz.token-exchange-url are required",
+		},
+		{
+			name:    "missing token exchange url",
+			mutate:  func(c *authzConfig) { c.TokenExchangeURL = "" },
+			wantErr: "authz.token and authz.token-exchange-url are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validAuthzConfig()
+			tt.mutate(&cfg)
+			client, err := newAccessClient(cfg)
+			require.Error(t, err)
+			assert.Nil(t, client)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestNewAccessClient_BuildsClient(t *testing.T) {
+	// grpc.NewClient is lazy (no dial until first RPC), so a valid config yields a
+	// usable client without any authz service running.
+	client, err := newAccessClient(validAuthzConfig())
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}
+
+func TestNewAccessClient_TLSCertNotFound(t *testing.T) {
+	cfg := validAuthzConfig()
+	cfg.CertFile = "/does/not/exist.pem"
+	client, err := newAccessClient(cfg)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to load authz TLS credentials")
+}
+
+type fakeTokenExchanger struct {
+	gotReq authnlib.TokenExchangeRequest
+	token  string
+	err    error
+}
+
+func (f *fakeTokenExchanger) Exchange(_ context.Context, r authnlib.TokenExchangeRequest) (*authnlib.TokenExchangeResponse, error) {
+	f.gotReq = r
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &authnlib.TokenExchangeResponse{Token: f.token}, nil
+}
+
+func TestTokenAuth_GetRequestMetadata(t *testing.T) {
+	exchanger := &fakeTokenExchanger{token: "exchanged-token"}
+	ta := newTokenAuth(authzServiceAudience, "stacks-7", exchanger)
+
+	md, err := ta.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"X-Access-Token": "exchanged-token"}, md)
+	assert.Equal(t, "stacks-7", exchanger.gotReq.Namespace)
+	assert.Equal(t, []string{authzServiceAudience}, exchanger.gotReq.Audiences)
+	assert.False(t, ta.RequireTransportSecurity())
+}
+
+func TestTokenAuth_GetRequestMetadata_ExchangeError(t *testing.T) {
+	exchanger := &fakeTokenExchanger{err: assert.AnError}
+	ta := newTokenAuth(authzServiceAudience, "*", exchanger)
+
+	md, err := ta.GetRequestMetadata(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, md)
+}

--- a/apps/historian/cmd/historian-operator/config.go
+++ b/apps/historian/cmd/historian-operator/config.go
@@ -13,12 +13,16 @@ type config struct {
 	Webhook webhookConfig
 	Metrics metricsConfig
 	App     historianconfig.RuntimeConfig
+	// Authz configures the authz connection used for notification-history RBAC.
+	// Only required when App.Notification.RBACEnabled is set.
+	Authz authzConfig
 }
 
 func (c *config) AddFlags(flags *pflag.FlagSet) {
 	c.Webhook.AddFlags(flags)
 	c.Metrics.AddFlags(flags)
 	c.App.AddFlags(flags)
+	c.Authz.AddFlags(flags)
 }
 
 type webhookConfig struct {

--- a/apps/historian/cmd/historian-operator/main.go
+++ b/apps/historian/cmd/historian-operator/main.go
@@ -39,6 +39,18 @@ func Main(args []string) error {
 		return err
 	}
 
+	// Notification-history RBAC needs an authz-backed AccessClient to authorize
+	// alert.rules:read per folder. It is wired programmatically (not via app
+	// flags); without it, RBAC-protected queries would fail closed, so fail fast
+	// at startup instead if it can't be built.
+	if cfg.App.Notification.RBACEnabled {
+		accessClient, err := newAccessClient(cfg.Authz)
+		if err != nil {
+			return fmt.Errorf("failed to build authz access client for notification RBAC: %w", err)
+		}
+		cfg.App.Notification.AccessClient = accessClient
+	}
+
 	operatorConfig := operator.RunnerConfig{
 		WebhookConfig: cfg.Webhook.RunnerWebhookConfig,
 		MetricsConfig: cfg.Metrics.RunnerMetricsConfig,

--- a/apps/historian/cmd/historian-operator/main_test.go
+++ b/apps/historian/cmd/historian-operator/main_test.go
@@ -87,6 +87,29 @@ func TestMain_OperatorComesUp(t *testing.T) {
 	}
 }
 
+// TestMain_RBACRequiresAuthz proves the operator fails fast at startup when
+// notification RBAC is enabled but the authz connection is not configured,
+// rather than starting and failing closed on every query.
+func TestMain_RBACRequiresAuthz(t *testing.T) {
+	ports := freePorts(t, 2)
+	webhookPort, metricsPort := ports[0], ports[1]
+	certPath, keyPath := writeTestCert(t)
+
+	err := Main([]string{
+		fmt.Sprintf("--webhook.port=%d", webhookPort),
+		"--webhook.tls.cert-path=" + certPath,
+		"--webhook.tls.key-path=" + keyPath,
+		fmt.Sprintf("--metrics.port=%d", metricsPort),
+		"--alerting.historian.notification.enabled=true",
+		"--alerting.historian.notification.loki.read-url=http://127.0.0.1:1/",
+		// RBAC on, but no --authz.* flags provided.
+		"--alerting.historian.notification.rbac-enabled=true",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to build authz access client")
+	require.Contains(t, err.Error(), "authz.remote-address is required")
+}
+
 // freePorts returns n distinct free TCP ports. All listeners are held open
 // simultaneously so the kernel hands out distinct ports, then closed before
 // returning. There is still a small window before the caller binds them, but

--- a/apps/historian/go.mod
+++ b/apps/historian/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/go-kit/log v0.2.1
 	github.com/grafana/alerting v0.0.0-20260616104851-587c401ed754
+	github.com/grafana/authlib v0.0.0-20260603144019-18cfcbc9496a
 	github.com/grafana/authlib/types v0.0.0-20260603144019-18cfcbc9496a
 	github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3
 	github.com/grafana/grafana-app-sdk v0.56.2
@@ -14,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	google.golang.org/grpc v1.81.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
@@ -66,8 +68,8 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/grafana/authlib v0.0.0-20260603144019-18cfcbc9496a // indirect
 	github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000 // indirect
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
@@ -147,7 +149,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/apps/historian/go.sum
+++ b/apps/historian/go.sum
@@ -211,6 +211,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/apps/historian/pkg/app/config/config.go
+++ b/apps/historian/pkg/app/config/config.go
@@ -29,7 +29,9 @@ type NotificationConfig struct {
 	// alert rules the requesting user is allowed to read. When enabled, the app
 	// lists the tenant's folders via the multi-tenant folder API and then confirms
 	// alert.rules:read on each folder via AccessClient, keeping only the folders
-	// the caller may see. Results are filtered to those folders.
+	// the caller may see. Results are filtered to those folders. This works in
+	// multi-tenant deployments because both the folder API and the authz service
+	// are multi-tenant, unlike the single-tenant rules API.
 	RBACEnabled bool
 	// AccessClient authorizes alert.rules:read per folder for RBAC filtering. It is
 	// set programmatically by the deployment wiring (not via a flag). When

--- a/apps/historian/pkg/app/config/config.go
+++ b/apps/historian/pkg/app/config/config.go
@@ -29,9 +29,7 @@ type NotificationConfig struct {
 	// alert rules the requesting user is allowed to read. When enabled, the app
 	// lists the tenant's folders via the multi-tenant folder API and then confirms
 	// alert.rules:read on each folder via AccessClient, keeping only the folders
-	// the caller may see. Results are filtered to those folders. This works in
-	// multi-tenant deployments because both the folder API and the authz service
-	// are multi-tenant, unlike the single-tenant rules API.
+	// the caller may see. Results are filtered to those folders.
 	RBACEnabled bool
 	// AccessClient authorizes alert.rules:read per folder for RBAC filtering. It is
 	// set programmatically by the deployment wiring (not via a flag). When


### PR DESCRIPTION
# Historian: wire authz AccessClient into standalone historian-operator

## Depends on
`https://github.com/grafana/alerting/pull/628` — merge/tag that first. This PR builds on the `NotificationConfig.AccessClient` / `RBACEnabled` config it introduces.

## Why
The folder-based notification-history RBAC reader authorizes `alert.rules:read` per folder via an `authlib.AccessClient`. In-process (grafana/grafana) that client is injected via Wire. The **standalone** `historian-operator` — the actual multi-tenant deployment — never constructed one, so:

- `--alerting.historian.notification.rbac-enabled=true` → `RBACEnabled` set but `AccessClient` nil → every notification query **fails closed**.
- RBAC off → **no folder filtering** at all.

This PR gives the operator a real, authz-backed `AccessClient` so folder-scoped RBAC works in the standalone deployment.

## What changed
- **`cmd/historian-operator/authz.go`** (new): an `authzConfig` (flags) plus `newAccessClient`, which mirrors how Grafana builds its remote RBAC client: a token-exchange client, a gRPC connection to the authz service (TLS when a cert path is given, otherwise insecure transport), and a per-RPC credential that exchanges a scoped access token (audience `authzService`) and sets it as the `X-Access-Token` header. Returns `authz.NewClient(conn)`.
- **`cmd/historian-operator/config.go`**: adds the `Authz` section and registers its flags.
- **`cmd/historian-operator/main.go`**: when notification RBAC is enabled, builds the client and sets `cfg.App.Notification.AccessClient` before starting the runner. If it can't be built (missing address/token), the operator **fails fast at startup** rather than silently failing closed on every request.
- **`go.mod`**: promotes `github.com/grafana/authlib` and `google.golang.org/grpc` to direct dependencies (via `go mod tidy`).

### New flags
| Flag | Default | Description |
| --- | --- | --- |
| `--authz.remote-address` | `""` | host:port of the authz gRPC service (required when RBAC is enabled) |
| `--authz.token` | `""` | Service token used for token exchange |
| `--authz.token-exchange-url` | `""` | Token-exchange endpoint |
| `--authz.token-namespace` | `*` | Namespace claimed when exchanging tokens (use `stacks-<id>` per-stack in Cloud) |
| `--authz.tls.cert-path` | `""` | TLS CA/cert for the authz connection; empty uses insecure transport |

## Behavior
- **RBAC on, authz configured**: notification queries are filtered to the folders whose alert rules the caller can read, per tenant.
- **RBAC on, authz not configured**: startup error with a clear message.
- **RBAC off**: unchanged (no filtering) — enable RBAC in multi-tenant deployments.

## Tests
- `authz_test.go`: config validation (missing address/token/exchange-url, bad TLS cert path), lazy client construction with valid config, and the per-RPC `tokenAuth` header/namespace/audience behavior (incl. exchange error).
- `main_test.go` → `TestMain_RBACRequiresAuthz`: boots the operator with RBAC enabled and no `--authz.*` flags and asserts it fails fast at startup.
- `go build ./...`, `go vet`, and the notification package tests all pass.

## Deployment note
Deployments enabling RBAC must set the new `--authz.*` flags and `--alerting.historian.notification.rbac-enabled=true`. `--authz.token-namespace` defaults to `*`; set it to the stack namespace (`stacks-<id>`) for per-stack Cloud deployments.