### PR TITLE
Jira: apply reopen duration to the firing search

### DIFF
--- a/receivers/jira/v1/jira.go
+++ b/receivers/jira/v1/jira.go
@@ -282,7 +282,16 @@ func getSearchJql(conf Config, groupID string, firing bool) issueSearch {
 
 	if firing {
 		if conf.ReopenTransition == "" {
+			// Issues cannot be reopened: match open issues only, so a firing
+			// alert whose issue was already closed creates a new one.
 			jql.WriteString(`statusCategory != Done and `)
+		} else if reopenDuration := int64(time.Duration(conf.ReopenDuration).Minutes()); reopenDuration != 0 {
+			// Match open issues, or issues resolved within the reopen duration
+			// (to be reopened). Issues closed longer ago do not match, so a new
+			// issue is created instead. Without a reopen duration, any issue
+			// matches regardless of status or age: the most recent one is
+			// updated and reopened.
+			fmt.Fprintf(&jql, `(statusCategory != Done OR resolutiondate >= -%dm) and `, reopenDuration)
 		}
 	} else {
 		reopenDuration := int64(time.Duration(conf.ReopenDuration).Minutes())

--- a/receivers/jira/v1/jira_test.go
+++ b/receivers/jira/v1/jira_test.go
@@ -473,6 +473,16 @@ func TestGetSearchJql(t *testing.T) {
 			expectedJql: `labels = "ALERT{group1}" and project="TEST" order by status ASC,resolutiondate DESC`,
 		},
 		{
+			name: "firing and reopen transition and reopen duration are set",
+			conf: Config{
+				Project:          "TEST",
+				ReopenTransition: "test",
+				ReopenDuration:   model.Duration(10 * time.Minute),
+			},
+			firing:      true,
+			expectedJql: `(statusCategory != Done OR resolutiondate >= -10m) and labels = "ALERT{group1}" and project="TEST" order by status ASC,resolutiondate DESC`,
+		},
+		{
 			name: "firing and custom dedup key field",
 			conf: Config{
 				Project:           "TEST",


### PR DESCRIPTION
Fixes #636

## Problem

The [documentation for `reopen_duration`](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-jira/) says it controls "whether to reopen an issue that was closed within this duration or create a new one." In `getSearchJql`, however, the duration is only consulted on the resolved path (scoping the search for the issue to transition to resolved — the area #543 recently fixed). On the firing path — the path that actually decides reopen-vs-create — a configured reopen transition removes all status/age constraints from the search, so the most recent issue matching the dedup key is reopened no matter how long ago it was closed, and `reopen_duration` is silently ignored.

Observed on Grafana 12.3.1 / Jira Cloud: with `reopen_transition` set and `reopen_duration: 10m`, a firing alert reopened an issue closed 17 minutes earlier instead of creating a new one.

## Change

When both `reopen_transition` and `reopen_duration` are set, the firing search becomes:

```
(statusCategory != Done OR resolutiondate >= -<duration>m) and ...
```

Open issues still match (recurrence while open remains a comment/no-op), issues resolved within the duration match (and get reopened), and issues closed longer ago fall out of the match — so a new issue is created, as documented.

Unchanged behavior, for backward compatibility and per the documented fallback: `reopen_duration` unset keeps the unconstrained search (most recent match is reopened regardless of age); `reopen_transition` unset keeps `statusCategory != Done`.

Note on the predicate: the open-issue side uses `statusCategory != Done` rather than mirroring the resolved path's `resolutiondate is EMPTY`, because issues closed without a resolution set have an empty `resolutiondate` and would otherwise remain eternally reopenable, defeating the age bound on workflows that don't populate resolutions.

Includes a `TestGetSearchJql` case for the new branch; `go test ./receivers/jira/...` passes.
