### PR TITLE
Historian: Ensure the folder client is reachable

### DIFF
--- a/apps/historian/pkg/app/config/config.go
+++ b/apps/historian/pkg/app/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/alerting/notify/historian/lokiclient"
 	authtypes "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/simple"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -48,6 +49,19 @@ type NotificationConfig struct {
 	// carry (typically the historian's own API audience). Empty disables audience
 	// validation. Only used when SigningKeysURL is set.
 	AllowedAudiences []string
+	// FolderAPIConfig, when set, is used to build the folder API client for RBAC
+	// folder enumeration instead of the app's own kube config. It is set
+	// programmatically by the deployment wiring (not via a flag).
+	//
+	// In-process (and behind the aggregated API server) the app's kube config is a
+	// loopback that serves every group, so folder.grafana.app is reachable and the
+	// caller identity is preserved by the in-memory transport; leave this nil. In a
+	// split multi-apiserver deployment the historian's own API server does not
+	// serve folder.grafana.app, so the folder list must target the remote folder
+	// app. When set, the caller's identity headers are also forwarded on the folder
+	// request (see forwardedIdentityHeaders) because a remote REST client does not
+	// carry the request-context identity over the wire.
+	FolderAPIConfig *rest.Config
 }
 
 type RuntimeConfig struct {

--- a/apps/historian/pkg/app/notification/notification.go
+++ b/apps/historian/pkg/app/notification/notification.go
@@ -39,6 +39,13 @@ type Notification struct {
 	// the aggregated API server) the identity is already in the context and this is
 	// nil.
 	authenticator authnlib.Authenticator
+	// folderAPIRemote indicates the folder list targets a remote folder API (a
+	// dedicated FolderAPIConfig was supplied) rather than the app's loopback kube
+	// config. A remote REST client does not carry the request-context identity over
+	// the wire, so the caller's identity headers must be forwarded explicitly on the
+	// folder request even when the identity is already in the context (authenticator
+	// nil). See forwardedIdentityHeaders.
+	folderAPIRemote bool
 }
 
 func New(cfg config.NotificationConfig, kubeConfig rest.Config, reg prometheus.Registerer, logger logging.Logger, tracer trace.Tracer) *Notification {
@@ -53,7 +60,17 @@ func New(cfg config.NotificationConfig, kubeConfig rest.Config, reg prometheus.R
 	}
 
 	if cfg.RBACEnabled {
-		reader, err := newFolderAccessReader(kubeConfig, cfg.AccessClient, logger)
+		// Use the dedicated folder API config when supplied (split multi-apiserver
+		// deployment, where the app's own API server does not serve
+		// folder.grafana.app); otherwise fall back to the app's kube config, which
+		// in-process is a loopback serving every group.
+		folderConfig := kubeConfig
+		if cfg.FolderAPIConfig != nil {
+			folderConfig = *cfg.FolderAPIConfig
+			n.folderAPIRemote = true
+		}
+
+		reader, err := newFolderAccessReader(folderConfig, cfg.AccessClient, logger)
 		if err != nil {
 			// Leave folderAccess nil; handlers fail closed when RBAC is enabled but
 			// the reader could not be constructed.
@@ -146,14 +163,21 @@ const (
 // outbound folder API requests. Injecting the reconstructed identity into the
 // context is enough for the AccessClient (BatchCheck takes the identity
 // explicitly), but the folder list goes through the kube REST client, which does
-// not read that identity. Running standalone (the historian operator) its kube
-// client authenticates as the operator's own service account, so without
-// forwarding these headers folder enumeration would run under the operator
-// identity and skip the caller's folders:read check. Behind the aggregated API
-// server (authenticator nil) the kube client already forwards the caller identity
-// from the request context, so nil is returned and nothing extra is attached.
+// not read that identity. Headers are forwarded in two cases:
+//
+//   - Standalone (the historian operator, authenticator non-nil): its kube client
+//     authenticates as the operator's own service account, so without forwarding
+//     these headers folder enumeration would run under the operator identity and
+//     skip the caller's folders:read check.
+//   - Remote folder API (folderAPIRemote, a dedicated FolderAPIConfig was set):
+//     the REST client opens a fresh connection to another API server and does not
+//     carry the request-context identity over the wire, so it must be forwarded
+//     even though the identity is already in the context.
+//
+// In-process the app's loopback kube client preserves the request-context
+// identity via its in-memory transport, so nil is returned and nothing is added.
 func (n *Notification) forwardedIdentityHeaders(headers http.Header) http.Header {
-	if n.authenticator == nil {
+	if n.authenticator == nil && !n.folderAPIRemote {
 		return nil
 	}
 	out := http.Header{}

--- a/apps/historian/pkg/app/notification/rbac_test.go
+++ b/apps/historian/pkg/app/notification/rbac_test.go
@@ -13,12 +13,15 @@ import (
 
 	authnlib "github.com/grafana/authlib/authn"
 	authtypes "github.com/grafana/authlib/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
+	"github.com/grafana/alerting/apps/historian/pkg/app/config"
 	"github.com/grafana/grafana-app-sdk/logging"
 )
 
@@ -320,6 +323,31 @@ func TestNewFolderAccessReader_RequiresAccessClient(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNew_FolderAPIConfigSelectsRemoteFolderClient(t *testing.T) {
+	base := config.NotificationConfig{
+		Enabled:      true,
+		RBACEnabled:  true,
+		AccessClient: &fakeAccessClient{},
+	}
+	newN := func(cfg config.NotificationConfig) *Notification {
+		return New(cfg, rest.Config{Host: "http://loopback"}, prometheus.NewRegistry(), &logging.NoOpLogger{}, noop.NewTracerProvider().Tracer(""))
+	}
+
+	t.Run("without FolderAPIConfig uses the loopback and does not force header forwarding", func(t *testing.T) {
+		n := newN(base)
+		require.NotNil(t, n.folderAccess)
+		assert.False(t, n.folderAPIRemote)
+	})
+
+	t.Run("with FolderAPIConfig targets the remote folder API and forces header forwarding", func(t *testing.T) {
+		cfg := base
+		cfg.FolderAPIConfig = &rest.Config{Host: "http://folder-app"}
+		n := newN(cfg)
+		require.NotNil(t, n.folderAccess)
+		assert.True(t, n.folderAPIRemote)
+	})
+}
+
 // fakeFolderAccessReader is a test double for folderAccessReader.
 type fakeFolderAccessReader struct {
 	folders ruleUIDSet
@@ -524,5 +552,17 @@ func TestNotification_ForwardedIdentityHeaders(t *testing.T) {
 		assert.Equal(t, "tok", got.Get("X-Access-Token"))
 		assert.Empty(t, got.Get("X-Grafana-Id"))
 		assert.Len(t, got, 1)
+	})
+
+	t.Run("remote folder API forwards identity even without an authenticator", func(t *testing.T) {
+		// Split multi-apiserver deployment: identity is already in the context
+		// (authenticator nil), but the folder list opens a fresh connection to the
+		// remote folder API, so the caller identity must be forwarded explicitly.
+		n := &Notification{folderAPIRemote: true}
+		got := n.forwardedIdentityHeaders(headers)
+		assert.Equal(t, "tok", got.Get("X-Access-Token"))
+		assert.Equal(t, "id", got.Get("X-Grafana-Id"))
+		assert.Empty(t, got.Get("X-Other"))
+		assert.Len(t, got, 2)
 	})
 }


### PR DESCRIPTION
Notification-history RBAC enumerates the caller's accessible folders via folder.grafana.app. When the historian runs as its own aggregated API server, that API server only serves the historian group, so folder.grafana.app is not reachable over the app's loopback kube config and every RBAC query would fail closed.

This adds a dedicated, optional folder API client so folder enumeration can target a remote folder app while keeping the request scoped to the calling user.

