### PR TITLE
Fix authorization credentials field to use password input type

### DIFF
--- a/receivers/oncall/v1/config.go
+++ b/receivers/oncall/v1/config.go
@@ -135,7 +135,7 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 			Label:        "Authorization Header - Credentials",
 			Description:  "Credentials for the Authorization Request header. Only one of HTTP Basic Authentication or Authorization Request Header can be set.",
 			Element:      schema.ElementTypeInput,
-			InputType:    schema.InputTypeText,
+			InputType:    schema.InputTypePassword,
 			PropertyName: "authorization_credentials",
 			Secure:       true,
 		},

--- a/receivers/webhook/v1/config.go
+++ b/receivers/webhook/v1/config.go
@@ -258,7 +258,7 @@ var Schema = schema.NewIntegrationSchemaVersion(schema.IntegrationSchemaVersion{
 			Label:        "Authorization Header - Credentials",
 			Description:  "Credentials for the Authorization Request header. Only one of HTTP Basic Authentication or Authorization Request Header can be set.",
 			Element:      schema.ElementTypeInput,
-			InputType:    schema.InputTypeText,
+			InputType:    schema.InputTypePassword,
 			PropertyName: "authorization_credentials",
 			Secure:       true,
 		},


### PR DESCRIPTION
## Summary
- The "Authorization Header - Credentials" field in the OnCall and webhook receiver schemas was rendered as a plain text input instead of a password input, exposing the secret value on screen.
- Change `InputType` from `Text` to `Password` in both schemas to match the field's `Secure: true` designation, consistent with how other secure fields are rendered.

Fixes grafana/grafana#129717

## Test plan
- [x] `go test ./receivers/oncall/...` passes
- [x] `go test ./receivers/webhook/...` passes