### PR TITLE
feat(notify): support multi-alert and resolved/mixed receiver tests

### DIFF
--- a/models/alert.go
+++ b/models/alert.go
@@ -5,4 +5,6 @@ import "github.com/prometheus/common/model"
 type TestReceiversConfigAlertParams struct {
 	Annotations model.LabelSet `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 	Labels      model.LabelSet `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// Status is the alert status to simulate. Valid values are "firing" (default) and "resolved".
+	Status model.AlertStatus `yaml:"status,omitempty" json:"status,omitempty"`
 }

--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -520,7 +520,7 @@ type result struct {
 	Error        error
 }
 
-func newTestReceiversResult(alert types.Alert, results []result, receivers []models.ReceiverConfig, notifiedAt time.Time) (*TestReceiversResult, int) {
+func newTestReceiversResult(alerts []types.Alert, results []result, receivers []models.ReceiverConfig, notifiedAt time.Time) (*TestReceiversResult, int) {
 	var numBadRequests, numTimeouts, numUnknownErrors int
 
 	m := make(map[string]TestReceiverResult)
@@ -565,7 +565,10 @@ func newTestReceiversResult(alert types.Alert, results []result, receivers []mod
 		m[next.ReceiverName] = tmp
 	}
 	v := new(TestReceiversResult)
-	v.Alert = alert
+	v.Alerts = alerts
+	if len(alerts) > 0 {
+		v.Alert = alerts[0]
+	}
 	v.Receivers = make([]TestReceiverResult, 0, len(receivers))
 	v.NotifedAt = notifiedAt
 	for _, next := range m {
@@ -601,7 +604,8 @@ func TestReceivers(
 	tmplProvider TemplatesProvider,
 ) (*TestReceiversResult, int, error) {
 	now := time.Now() // The start time of the test
-	testAlert := newTestAlert(c.Alert, now, now)
+	testAlerts := newTestAlerts(resolveTestAlertParams(c), now, now)
+	testAlertValues := testAlertsAsValues(testAlerts)
 
 	// All invalid receiver configurations
 	invalid := make([]result, 0, len(c.Receivers))
@@ -638,7 +642,7 @@ func TestReceivers(
 	}
 
 	if len(jobs) == 0 {
-		res, status := newTestReceiversResult(testAlert, invalid, c.Receivers, now)
+		res, status := newTestReceiversResult(testAlertValues, invalid, c.Receivers, now)
 		return res, status, nil
 	}
 
@@ -661,7 +665,7 @@ func TestReceivers(
 				v := result{
 					Config:       next.Config,
 					ReceiverName: next.ReceiverName,
-					Error:        TestNotifier(ctx, next.Notifier, testAlert, now),
+					Error:        TestNotifier(ctx, next.Notifier, testAlerts, now),
 				}
 				resultCh <- v
 			}
@@ -681,7 +685,7 @@ func TestReceivers(
 		results = append(results, next)
 	}
 
-	res, status := newTestReceiversResult(testAlert, append(invalid, results...), c.Receivers, now)
+	res, status := newTestReceiversResult(testAlertValues, append(invalid, results...), c.Receivers, now)
 	return res, status, nil
 }
 

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -697,12 +697,12 @@ func TestSilenceCleanup(t *testing.T) {
 
 func TestStatusForTestReceivers(t *testing.T) {
 	t.Run("assert HTTP 400 Status Bad Request for no receivers", func(t *testing.T) {
-		_, status := newTestReceiversResult(types.Alert{}, []result{}, []models.ReceiverConfig{}, time.Now())
+		_, status := newTestReceiversResult(nil, []result{}, []models.ReceiverConfig{}, time.Now())
 		require.Equal(t, http.StatusBadRequest, status)
 	})
 
 	t.Run("assert HTTP 400 Bad Request when all invalid receivers", func(t *testing.T) {
-		_, status := newTestReceiversResult(types.Alert{}, []result{
+		_, status := newTestReceiversResult(nil, []result{
 			{
 				ReceiverName: "receiver 1",
 				Config:       &models.IntegrationConfig{Name: "integration 1"},
@@ -737,7 +737,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert HTTP 408 Request Timeout when all receivers timed out", func(t *testing.T) {
-		_, status := newTestReceiversResult(types.Alert{}, []result{
+		_, status := newTestReceiversResult(nil, []result{
 			{
 				ReceiverName: "receiver 1",
 				Config:       &models.IntegrationConfig{Name: "integration 1"},
@@ -772,7 +772,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert 207 Multi Status for different errors", func(t *testing.T) {
-		_, status := newTestReceiversResult(types.Alert{}, []result{
+		_, status := newTestReceiversResult(nil, []result{
 			{
 				ReceiverName: "receiver 1",
 				Config:       &models.IntegrationConfig{Name: "integration 1"},
@@ -807,7 +807,7 @@ func TestStatusForTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert 200 for no errors", func(t *testing.T) {
-		_, status := newTestReceiversResult(types.Alert{}, []result{
+		_, status := newTestReceiversResult(nil, []result{
 			{
 				ReceiverName: "receiver 1",
 				Config:       &models.IntegrationConfig{Name: "integration 1"},

--- a/notify/receivers.go
+++ b/notify/receivers.go
@@ -29,7 +29,10 @@ var (
 )
 
 type TestReceiversResult struct {
-	Alert     types.Alert          `json:"alert"`
+	// Alert is the first/group-representative alert for backward compatibility.
+	Alert types.Alert `json:"alert"`
+	// Alerts contains all alerts used for the test notification.
+	Alerts    []types.Alert        `json:"alerts,omitempty"`
 	Receivers []TestReceiverResult `json:"receivers"`
 	NotifedAt time.Time            `json:"notifiedAt"`
 }
@@ -47,8 +50,13 @@ type TestIntegrationConfigResult struct {
 }
 
 type TestReceiversConfigBodyParams struct {
-	Alert     *models.TestReceiversConfigAlertParams `yaml:"alert,omitempty" json:"alert,omitempty"`
-	Receivers []models.ReceiverConfig                `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	// Alert is a single test alert for backward compatibility.
+	// Ignored when Alerts is non-empty.
+	Alert *models.TestReceiversConfigAlertParams `yaml:"alert,omitempty" json:"alert,omitempty"`
+	// Alerts is a list of test alerts. When empty, Alert is used if set;
+	// otherwise a single default firing alert is used.
+	Alerts    []models.TestReceiversConfigAlertParams `yaml:"alerts,omitempty" json:"alerts,omitempty"`
+	Receivers []models.ReceiverConfig                 `yaml:"receivers,omitempty" json:"receivers,omitempty"`
 }
 
 type IntegrationTimeoutError struct {
@@ -82,8 +90,8 @@ func newTestAlert(c *models.TestReceiversConfigAlertParams, startsAt, updatedAt 
 
 	alert := types.Alert{
 		Alert: model.Alert{
-			Labels:      defaultLabels,
-			Annotations: defaultAnnotations,
+			Labels:      defaultLabels.Clone(),
+			Annotations: defaultAnnotations.Clone(),
 			StartsAt:    startsAt,
 		},
 		UpdatedAt: updatedAt,
@@ -102,7 +110,47 @@ func newTestAlert(c *models.TestReceiversConfigAlertParams, startsAt, updatedAt 
 			alert.Labels[k] = v
 		}
 	}
+	// Resolved alerts need EndsAt in the past (or equal to now). Firing alerts
+	// leave EndsAt zero so Alert.Resolved() remains false.
+	if c.Status == model.AlertResolved {
+		alert.EndsAt = startsAt
+	}
 	return alert
+}
+
+// newTestAlerts builds the list of alerts used for a receiver test.
+// When params is empty, a single default firing alert is returned.
+func newTestAlerts(params []models.TestReceiversConfigAlertParams, startsAt, updatedAt time.Time) []*types.Alert {
+	if len(params) == 0 {
+		a := newTestAlert(nil, startsAt, updatedAt)
+		return []*types.Alert{&a}
+	}
+	alerts := make([]*types.Alert, 0, len(params))
+	for i := range params {
+		a := newTestAlert(&params[i], startsAt, updatedAt)
+		alerts = append(alerts, &a)
+	}
+	return alerts
+}
+
+// resolveTestAlertParams returns the alert params to use for a test.
+// Alerts takes precedence over the singular Alert field.
+func resolveTestAlertParams(c TestReceiversConfigBodyParams) []models.TestReceiversConfigAlertParams {
+	if len(c.Alerts) > 0 {
+		return c.Alerts
+	}
+	if c.Alert != nil {
+		return []models.TestReceiversConfigAlertParams{*c.Alert}
+	}
+	return nil
+}
+
+func testAlertsAsValues(alerts []*types.Alert) []types.Alert {
+	out := make([]types.Alert, len(alerts))
+	for i, a := range alerts {
+		out[i] = *a
+	}
+	return out
 }
 
 func ProcessIntegrationError(config *models.IntegrationConfig, err error) error {

--- a/notify/test_receivers.go
+++ b/notify/test_receivers.go
@@ -42,7 +42,8 @@ func TestIntegration(ctx context.Context,
 		return models.IntegrationStatus{}, err
 	}
 	now := time.Now()
-	err = TestNotifier(ctx, nf[0], newTestAlert(&testAlert, now, now), now)
+	alert := newTestAlert(&testAlert, now, now)
+	err = TestNotifier(ctx, nf[0], []*types.Alert{&alert}, now)
 	result := models.IntegrationStatus{
 		LastNotifyAttempt:         strfmt.DateTime(now),
 		LastNotifyAttemptDuration: model.Duration(time.Since(now)).String(),
@@ -55,12 +56,16 @@ func TestIntegration(ctx context.Context,
 	return result, nil
 }
 
-func TestNotifier(ctx context.Context, notifier *nfstatus.Integration, testAlert types.Alert, now time.Time) error {
+// TestNotifier sends a test notification with one or more alerts.
+func TestNotifier(ctx context.Context, notifier *nfstatus.Integration, alerts []*types.Alert, now time.Time) error {
+	if len(alerts) == 0 {
+		return fmt.Errorf("no alerts to notify")
+	}
 	ctx = context.WithValue(ctx, nfstatus.TestNotificationKey, true)
-	ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", notifier.Name(), testAlert.Labels.Fingerprint(), now.Unix()))
-	ctx = notify.WithGroupLabels(ctx, testAlert.Labels)
+	ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", notifier.Name(), alerts[0].Labels.Fingerprint(), now.Unix()))
+	ctx = notify.WithGroupLabels(ctx, alerts[0].Labels)
 	ctx = notify.WithReceiverName(ctx, notifier.Name())
-	if _, err := notifier.Notify(ctx, &testAlert); err != nil {
+	if _, err := notifier.Notify(ctx, alerts...); err != nil {
 		return err
 	}
 	return nil

--- a/notify/test_receivers_test.go
+++ b/notify/test_receivers_test.go
@@ -1,0 +1,254 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/notify/nfstatus"
+)
+
+type capturingNotifier struct {
+	alerts []*types.Alert
+}
+
+func (c *capturingNotifier) Notify(_ context.Context, alerts ...*types.Alert) (nfstatus.NotifyInfo, bool, error) {
+	c.alerts = append([]*types.Alert(nil), alerts...)
+	return nfstatus.NotifyInfo{}, false, nil
+}
+
+type alwaysSendResolved struct{}
+
+func (alwaysSendResolved) SendResolved() bool { return true }
+
+func newCapturingIntegration(t *testing.T) (*nfstatus.Integration, *capturingNotifier) {
+	t.Helper()
+	n := &capturingNotifier{}
+	integration := nfstatus.NewIntegration(n, alwaysSendResolved{}, "test", 0, "test-receiver", nil, log.NewNopLogger())
+	return integration, n
+}
+
+func TestNewTestAlert(t *testing.T) {
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("firing by default leaves EndsAt zero", func(t *testing.T) {
+		alert := newTestAlert(nil, now, now)
+		require.True(t, alert.EndsAt.IsZero())
+		require.False(t, alert.ResolvedAt(now))
+		require.Equal(t, model.AlertFiring, alert.StatusAt(now))
+		require.Equal(t, model.LabelValue("TestAlert"), alert.Labels["alertname"])
+	})
+
+	t.Run("explicit firing status leaves EndsAt zero", func(t *testing.T) {
+		alert := newTestAlert(&models.TestReceiversConfigAlertParams{
+			Status: model.AlertFiring,
+			Labels: model.LabelSet{"severity": "critical"},
+		}, now, now)
+		require.True(t, alert.EndsAt.IsZero())
+		require.False(t, alert.ResolvedAt(now))
+		require.Equal(t, model.LabelValue("critical"), alert.Labels["severity"])
+	})
+
+	t.Run("resolved status sets EndsAt in the past", func(t *testing.T) {
+		alert := newTestAlert(&models.TestReceiversConfigAlertParams{
+			Status: model.AlertResolved,
+		}, now, now)
+		require.False(t, alert.EndsAt.IsZero())
+		require.True(t, alert.ResolvedAt(now))
+		require.Equal(t, model.AlertResolved, alert.StatusAt(now))
+		require.Equal(t, now, alert.EndsAt)
+	})
+}
+
+func TestNewTestAlerts(t *testing.T) {
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty params yields one default firing alert", func(t *testing.T) {
+		alerts := newTestAlerts(nil, now, now)
+		require.Len(t, alerts, 1)
+		require.False(t, alerts[0].ResolvedAt(now))
+	})
+
+	t.Run("multiple firing alerts", func(t *testing.T) {
+		alerts := newTestAlerts([]models.TestReceiversConfigAlertParams{
+			{Labels: model.LabelSet{"alertname": "A"}, Status: model.AlertFiring},
+			{Labels: model.LabelSet{"alertname": "B"}, Status: model.AlertFiring},
+		}, now, now)
+		require.Len(t, alerts, 2)
+		require.False(t, alerts[0].ResolvedAt(now))
+		require.False(t, alerts[1].ResolvedAt(now))
+		require.Equal(t, model.LabelValue("A"), alerts[0].Labels["alertname"])
+		require.Equal(t, model.LabelValue("B"), alerts[1].Labels["alertname"])
+	})
+
+	t.Run("mixed firing and resolved alerts", func(t *testing.T) {
+		alerts := newTestAlerts([]models.TestReceiversConfigAlertParams{
+			{Labels: model.LabelSet{"alertname": "firing"}, Status: model.AlertFiring},
+			{Labels: model.LabelSet{"alertname": "resolved"}, Status: model.AlertResolved},
+		}, now, now)
+		require.Len(t, alerts, 2)
+		require.False(t, alerts[0].ResolvedAt(now))
+		require.True(t, alerts[1].ResolvedAt(now))
+	})
+}
+
+func TestResolveTestAlertParams(t *testing.T) {
+	t.Run("Alerts takes precedence over Alert", func(t *testing.T) {
+		params := resolveTestAlertParams(TestReceiversConfigBodyParams{
+			Alert: &models.TestReceiversConfigAlertParams{Labels: model.LabelSet{"from": "alert"}},
+			Alerts: []models.TestReceiversConfigAlertParams{
+				{Labels: model.LabelSet{"from": "alerts"}},
+			},
+		})
+		require.Len(t, params, 1)
+		require.Equal(t, model.LabelValue("alerts"), params[0].Labels["from"])
+	})
+
+	t.Run("falls back to singular Alert", func(t *testing.T) {
+		params := resolveTestAlertParams(TestReceiversConfigBodyParams{
+			Alert: &models.TestReceiversConfigAlertParams{Labels: model.LabelSet{"from": "alert"}},
+		})
+		require.Len(t, params, 1)
+		require.Equal(t, model.LabelValue("alert"), params[0].Labels["from"])
+	})
+
+	t.Run("both empty returns nil", func(t *testing.T) {
+		require.Nil(t, resolveTestAlertParams(TestReceiversConfigBodyParams{}))
+	})
+}
+
+func TestTestNotifier_MultiAlert(t *testing.T) {
+	now := time.Now()
+	integration, capture := newCapturingIntegration(t)
+
+	firing := newTestAlert(&models.TestReceiversConfigAlertParams{
+		Labels: model.LabelSet{"alertname": "firing"},
+		Status: model.AlertFiring,
+	}, now, now)
+	resolved := newTestAlert(&models.TestReceiversConfigAlertParams{
+		Labels: model.LabelSet{"alertname": "resolved"},
+		Status: model.AlertResolved,
+	}, now, now)
+
+	err := TestNotifier(context.Background(), integration, []*types.Alert{&firing, &resolved}, now)
+	require.NoError(t, err)
+	require.Len(t, capture.alerts, 2)
+	require.Equal(t, model.LabelValue("firing"), capture.alerts[0].Labels["alertname"])
+	require.Equal(t, model.LabelValue("resolved"), capture.alerts[1].Labels["alertname"])
+}
+
+func TestTestReceivers_AlertFlows(t *testing.T) {
+	build := func(_ models.ReceiverConfig, _ TemplatesProvider) ([]*nfstatus.Integration, error) {
+		integration, _ := newCapturingIntegration(t)
+		return []*nfstatus.Integration{integration}, nil
+	}
+	receiver := models.ReceiverConfig{
+		Name: "test-receiver",
+		Integrations: []*models.IntegrationConfig{{
+			UID:      "uid-1",
+			Name:     "test",
+			Type:     "webhook",
+			Settings: json.RawMessage(`{}`),
+		}},
+	}
+
+	t.Run("one firing alert via singular Alert (regression)", func(t *testing.T) {
+		res, status, err := TestReceivers(context.Background(), TestReceiversConfigBodyParams{
+			Alert: &models.TestReceiversConfigAlertParams{
+				Labels: model.LabelSet{"alertname": "one"},
+				Status: model.AlertFiring,
+			},
+			Receivers: []models.ReceiverConfig{receiver},
+		}, build, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, res.Alerts, 1)
+		require.Equal(t, res.Alert, res.Alerts[0])
+		require.False(t, res.Alerts[0].Resolved())
+		require.Equal(t, model.LabelValue("one"), res.Alert.Labels["alertname"])
+	})
+
+	t.Run("one resolved alert", func(t *testing.T) {
+		res, status, err := TestReceivers(context.Background(), TestReceiversConfigBodyParams{
+			Alert: &models.TestReceiversConfigAlertParams{
+				Status: model.AlertResolved,
+			},
+			Receivers: []models.ReceiverConfig{receiver},
+		}, build, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, res.Alerts, 1)
+		require.True(t, res.Alerts[0].Resolved())
+	})
+
+	t.Run("multiple firing alerts", func(t *testing.T) {
+		res, status, err := TestReceivers(context.Background(), TestReceiversConfigBodyParams{
+			Alerts: []models.TestReceiversConfigAlertParams{
+				{Labels: model.LabelSet{"alertname": "a"}, Status: model.AlertFiring},
+				{Labels: model.LabelSet{"alertname": "b"}, Status: model.AlertFiring},
+			},
+			Receivers: []models.ReceiverConfig{receiver},
+		}, build, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, res.Alerts, 2)
+		require.Equal(t, res.Alert, res.Alerts[0])
+		require.False(t, res.Alerts[0].Resolved())
+		require.False(t, res.Alerts[1].Resolved())
+	})
+
+	t.Run("mixed firing and resolved alerts", func(t *testing.T) {
+		res, status, err := TestReceivers(context.Background(), TestReceiversConfigBodyParams{
+			Alerts: []models.TestReceiversConfigAlertParams{
+				{Labels: model.LabelSet{"alertname": "firing"}, Status: model.AlertFiring},
+				{Labels: model.LabelSet{"alertname": "resolved"}, Status: model.AlertResolved},
+			},
+			Receivers: []models.ReceiverConfig{receiver},
+		}, build, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, res.Alerts, 2)
+		require.False(t, res.Alerts[0].Resolved())
+		require.True(t, res.Alerts[1].Resolved())
+	})
+
+	t.Run("default alert when both Alert and Alerts empty", func(t *testing.T) {
+		res, status, err := TestReceivers(context.Background(), TestReceiversConfigBodyParams{
+			Receivers: []models.ReceiverConfig{receiver},
+		}, build, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, res.Alerts, 1)
+		require.False(t, res.Alerts[0].Resolved())
+		require.Equal(t, model.LabelValue("TestAlert"), res.Alert.Labels["alertname"])
+	})
+}
+
+func TestTestIntegration_ResolvedStatus(t *testing.T) {
+	var capture *capturingNotifier
+	build := func(_ models.ReceiverConfig, _ TemplatesProvider) ([]*nfstatus.Integration, error) {
+		integration, n := newCapturingIntegration(t)
+		capture = n
+		return []*nfstatus.Integration{integration}, nil
+	}
+
+	status, err := TestIntegration(context.Background(), "recv", models.IntegrationConfig{
+		UID:  "uid",
+		Name: "test",
+		Type: "webhook",
+	}, models.TestReceiversConfigAlertParams{
+		Status: model.AlertResolved,
+	}, build, nil)
+	require.NoError(t, err)
+	require.Empty(t, status.LastNotifyAttemptError)
+	require.Len(t, capture.alerts, 1)
+	require.True(t, capture.alerts[0].Resolved())
+}


### PR DESCRIPTION
## Summary
- Extend `TestReceivers` to accept multiple alerts (`alerts`) while keeping singular `alert` for compatibility
- Support `status: resolved` (sets `EndsAt`) so tests can exercise resolved and mixed firing/resolved flows
- Add unit coverage for firing, resolved, multi-alert, and mixed cases

Fixes #464

## Test plan
- [x] `go test ./notify/ -count=1`
- [ ] Confirm Grafana consumers of the test-receivers API still work with the singular `alert` field