### PR TITLE
fix(notify): skip empty-name labels and annotations when converting postable alerts

### DIFF
--- a/notify/grafana_alertmanager.go
+++ b/notify/grafana_alertmanager.go
@@ -963,7 +963,7 @@ func PostableAlertsToAlertmanagerAlerts(postableAlerts amv2.PostableAlerts, now 
 		}
 
 		for k, v := range a.Labels {
-			if len(v) == 0 || k == models.NamespaceUIDLabel { // Skip empty and namespace UID labels.
+			if len(k) == 0 || len(v) == 0 || k == models.NamespaceUIDLabel { // Skip empty-name, empty-value, and namespace UID labels.
 				continue
 			}
 
@@ -971,7 +971,7 @@ func PostableAlertsToAlertmanagerAlerts(postableAlerts amv2.PostableAlerts, now 
 		}
 
 		for k, v := range a.Annotations {
-			if len(v) == 0 { // Skip empty annotation.
+			if len(k) == 0 || len(v) == 0 { // Skip empty-name and empty-value annotations.
 				continue
 			}
 			alert.Annotations[model.LabelName(k)] = model.LabelValue(v)

--- a/notify/grafana_alertmanager_test.go
+++ b/notify/grafana_alertmanager_test.go
@@ -160,12 +160,12 @@ func TestPutAlert(t *testing.T) {
 				}
 			},
 		}, {
-			title: "Removing empty labels and annotations",
+			title: "Removing empty-name and empty-value labels and annotations",
 			postableAlerts: amv2.PostableAlerts{
 				{
-					Annotations: amv2.LabelSet{"msg": "Alert4 annotation", "empty": ""},
+					Annotations: amv2.LabelSet{"msg": "Alert4 annotation", "empty": "", "": "empty name"},
 					Alert: amv2.Alert{
-						Labels:       amv2.LabelSet{"alertname": "Alert4", "emptylabel": ""},
+						Labels:       amv2.LabelSet{"alertname": "Alert4", "emptylabel": "", "": "empty name"},
 						GeneratorURL: "http://localhost/url1",
 					},
 					StartsAt: strfmt.DateTime{},


### PR DESCRIPTION
## What
`PostableAlertsToAlertmanagerAlerts` already skips labels/annotations with an empty **value** (and the namespace-UID label) when converting incoming postable alerts, but keeps ones with an empty **name**. An empty-name label/annotation then fails `alert.Validate()` (`invalid label set: invalid name ""`), so the whole alert is rejected as invalid — counted in `alertmanager_alerts_invalid_total` and never ingested/notified.

This skips empty-name labels and annotations too, mirroring the existing empty-value handling.

## Safety / fingerprint
Alert identity (`types.Alert.Fingerprint()`, used by the marker for dedup/state) is only computed for alerts that pass `Validate()`. Empty-name alerts are rejected *before* being appended/fingerprinted, so no valid alert's fingerprint has ever included an empty-name label — stripping it changes no existing alert's identity.

## Test
Extended `TestPutAlert`'s empty-labels/annotations case to include an empty-name label **and** annotation and assert they're stripped (the alert is now accepted rather than rejected; without the fix it fails `Validate` and is dropped).
