### PR TITLE
Add security reporting guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,4 @@ Grafana integration config has two inputs: settings and secure settings. Secure 
 - Factory pattern in `notify/factory.go` builds receiver integrations by version
 - Notification history persisted to Loki via `notify/historian/`
 - Uses Grafana fork of Alertmanager: `github.com/grafana/prometheus-alertmanager`
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
