### PR TITLE
ci(auto-merge): auto-merge Renovate security-update PRs

### DIFF
--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -16,11 +16,20 @@ jobs:
       contents: write
       checks: read
       statuses: read
+      id-token: write
     if: |
       github.event.pull_request.user.login == 'renovate-sh-app[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'automerge-security-update') &&
       !contains(github.event.pull_request.labels.*.name, 'security-needs-review')
     steps:
+      # Renovate PRs need a real code-owner-recognized approval, which the
+      # default token can't provide -- see grafana/alerting-squad#1993.
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: alerting-team
+
       - name: Approve and auto-merge
         if: github.event.pull_request.draft == false
         # Keep the "enable auto-merge" -> approve order.
@@ -35,4 +44,4 @@ jobs:
             gh pr review --approve "$PR_URL" --body "PR approved by workflow \"${{ github.workflow }}\""
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -30,6 +30,7 @@ jobs:
           max_attempts: 3
           timeout_seconds: 30
           command: |
+            set -e
             gh pr merge --auto --squash "$PR_URL"
             gh pr review --approve "$PR_URL" --body "PR approved by workflow \"${{ github.workflow }}\""
         env:

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -1,0 +1,36 @@
+name: Auto-merge Automation PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      checks: read
+      statuses: read
+    if: |
+      github.event.pull_request.user.login == 'renovate-sh-app[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'automerge-security-update') &&
+      !contains(github.event.pull_request.labels.*.name, 'security-needs-review')
+    steps:
+      - name: Approve and auto-merge
+        if: github.event.pull_request.draft == false
+        # Keep the "enable auto-merge" -> approve order.
+        # If auto-merge is already enabled, approving will trigger the merge and the job will fail trying to enable auto-merge.
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          max_attempts: 3
+          timeout_seconds: 30
+          command: |
+            gh pr merge --auto --squash "$PR_URL"
+            gh pr review --approve "$PR_URL" --body "PR approved by workflow \"${{ github.workflow }}\""
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -2,6 +2,7 @@ name: Auto-merge Automation PRs
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
 

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -1,7 +1,7 @@
 name: Auto-merge Automation PRs
 
-on: # zizmor: ignore[dangerous-triggers] never checks out or runs PR-authored code, so pull_request_target carries no extra risk here
-  pull_request_target:
+on:
+  pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -1,7 +1,7 @@
 name: Auto-merge Automation PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -1,6 +1,6 @@
 name: Auto-merge Automation PRs
 
-on:
+on: # zizmor: ignore[dangerous-triggers] never checks out or runs PR-authored code, so pull_request_target carries no extra risk here
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
     branches:


### PR DESCRIPTION
This repo had no auto-merge automation workflow, so Renovate's automerge-security-update-labeled PRs sat blocked on the required approval branch protection demands.

Adds a workflow that approves and auto-merges only when the PR is from renovate-sh-app[bot] and carries the automerge-security-update label, skipping when security-needs-review is also present (some security PRs are deliberately flagged for human review despite the automerge label -- seen live on other alerting repos). Modeled on grafana-alertmanager's/grafana-ruler's corrected auto-merge-automation-prs.yml.