### PR TITLE
ci(auto-merge): fix retry idempotency, guard against self-modification

### DIFF
--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -24,6 +24,23 @@ jobs:
     steps:
       # Renovate PRs need a real code-owner-recognized approval, which the
       # default token can't provide -- see grafana/alerting-squad#1993.
+      #
+      # pull_request runs this workflow file from the PR's own branch, so a
+      # same-repo PR could otherwise weaken the checks above and still get a
+      # legitimate, bypass-privileged alerting-team token to approve and
+      # merge itself. Refuse if the file differs from main before minting one.
+      - name: Verify workflow file matches main
+        run: |
+          set -e
+          head_content=$(gh api "repos/${{ github.repository }}/contents/.github/workflows/auto-merge-automation-prs.yml?ref=${{ github.event.pull_request.head.sha }}" --jq .content)
+          main_content=$(gh api "repos/${{ github.repository }}/contents/.github/workflows/auto-merge-automation-prs.yml?ref=main" --jq .content)
+          if [ "$head_content" != "$main_content" ]; then
+            echo "::error::auto-merge-automation-prs.yml differs from main in this PR -- refusing to mint an alerting-team token."
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get GitHub App token
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
@@ -40,7 +57,9 @@ jobs:
           timeout_seconds: 30
           command: |
             set -e
-            gh pr merge --auto --squash "$PR_URL"
+            if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
+              gh pr merge --auto --squash "$PR_URL"
+            fi
             gh pr review --approve "$PR_URL" --body "PR approved by workflow \"${{ github.workflow }}\""
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -29,13 +29,12 @@ jobs:
       # same-repo PR could otherwise weaken the checks above and still get a
       # legitimate, bypass-privileged alerting-team token to approve and
       # merge itself. Refuse if the file differs from main before minting one.
-      - name: Verify workflow file matches main
+      - name: Verify workflow file was not modified in this PR
         run: |
           set -e
-          head_content=$(gh api "repos/${{ github.repository }}/contents/.github/workflows/auto-merge-automation-prs.yml?ref=${{ github.event.pull_request.head.sha }}" --jq .content)
-          main_content=$(gh api "repos/${{ github.repository }}/contents/.github/workflows/auto-merge-automation-prs.yml?ref=main" --jq .content)
-          if [ "$head_content" != "$main_content" ]; then
-            echo "::error::auto-merge-automation-prs.yml differs from main in this PR -- refusing to mint an alerting-team token."
+          changed_files=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" --jq '.files[]?.filename')
+          if echo "$changed_files" | grep -qx ".github/workflows/auto-merge-automation-prs.yml"; then
+            echo "::error::auto-merge-automation-prs.yml was modified in this PR -- refusing to mint an alerting-team token."
             exit 1
           fi
         env:

--- a/.github/workflows/auto-merge-automation-prs.yml
+++ b/.github/workflows/auto-merge-automation-prs.yml
@@ -22,24 +22,12 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'automerge-security-update') &&
       !contains(github.event.pull_request.labels.*.name, 'security-needs-review')
     steps:
-      # Renovate PRs need a real code-owner-recognized approval, which the
-      # default token can't provide -- see grafana/alerting-squad#1993.
-      #
-      # pull_request runs this workflow file from the PR's own branch, so a
-      # same-repo PR could otherwise weaken the checks above and still get a
-      # legitimate, bypass-privileged alerting-team token to approve and
-      # merge itself. Refuse if the file differs from main before minting one.
-      - name: Verify workflow file was not modified in this PR
-        run: |
-          set -e
-          changed_files=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" --jq '.files[]?.filename')
-          if echo "$changed_files" | grep -qx ".github/workflows/auto-merge-automation-prs.yml"; then
-            echo "::error::auto-merge-automation-prs.yml was modified in this PR -- refusing to mint an alerting-team token."
-            exit 1
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      # Renovate PRs need an approval to satisfy branch protection, but no
+      # plain token counts as one here -- code owner review is required and
+      # alerting-team isn't a code owner either. alerting-team is instead
+      # configured as a bypass actor on the ruleset, so its approve+merge
+      # skips that requirement rather than satisfying it. See
+      # grafana/alerting-squad#1993.
       - name: Get GitHub App token
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1


### PR DESCRIPTION
Fixes one issue Cursor Bugbot flagged after the first-round PR merged, and tried and reverted a second.

- **Retry idempotency** (kept): `gh pr merge --auto` isn't idempotent -- it errors when auto-merge is already enabled, which happens on every `labeled`/`synchronize` re-run after the first successful one. `set -e` then skipped the approve call on those re-runs. Now checks current auto-merge state first instead of relying on the command's exit code.
- **Self-approval guard** (tried, reverted): added a step comparing this workflow file against a trusted reference before minting the `alerting-team` token, to stop a same-repo PR from weakening its own checks. Doesn't work: the check lives inside the same `pull_request`-triggered file it's meant to police, so a PR can just delete the step instead of defeating its logic. `pull_request_target` would close this properly but is unconditionally rejected by this org's Vault JWT validator proxy. Removed; left as a known, accepted risk (narrowed to same-repo collaborators with existing write access), tracked as a follow-up.
- Also fixed a misleading comment: `alerting-team`'s approval doesn't satisfy code owner review either (it's not a CODEOWNERS member) -- it works because `alerting-team` is a bypass actor on the ruleset, which skips branch protection for its actions rather than satisfying any part of it.

See grafana/alerting-squad#1993.