### PR TITLE
feat(dingding): deleted

### DIFF
--- a/receivers/dingding/v1/dingding.go
+++ b/receivers/dingding/v1/dingding.go
@@ -11,8 +11,16 @@ import (
 
 	"github.com/go-kit/log"
 
+	"github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/receivers"
 	"github.com/grafana/alerting/templates"
+)
+
+const (
+	// alertRulesListPath is the path to the page listing all alert rules.
+	alertRulesListPath = "/alerting/list"
+	// alertRuleViewPathTemplate is the path to the page showing a single Grafana-managed alert rule.
+	alertRuleViewPathTemplate = "/alerting/grafana/%s/view"
 )
 
 // Notifier is responsible for sending alert notifications to ding ding.
@@ -37,7 +45,7 @@ func (dd *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	l := dd.GetLogger(ctx)
 	level.Info(l).Log("msg", "sending dingding")
 
-	dingDingURL := buildDingDingURL(dd.tmpl.ExternalURL, l)
+	dingDingURL := buildDingDingURL(dd.tmpl.ExternalURL, alertRuleUID(as, l), l)
 
 	var tmplErr error
 	tmpl, data := templates.TmplText(ctx, dd.tmpl, as, l, &tmplErr)
@@ -77,10 +85,38 @@ func (dd *Notifier) SendResolved() bool {
 	return !dd.GetDisableResolveMessage()
 }
 
-func buildDingDingURL(externalURL *url.URL, l log.Logger) string {
+// alertRuleUID returns the UID of the alert rule that produced the given alerts. A single notification can group
+// alerts coming from different rules, or alerts that are not tied to a Grafana rule at all, in which case an empty
+// string is returned so that the caller can fall back to a link that is guaranteed to be valid.
+func alertRuleUID(alerts []*types.Alert, l log.Logger) string {
+	var uid string
+	for _, alert := range alerts {
+		if alert == nil {
+			continue
+		}
+		current := string(alert.Labels[models.RuleUIDLabel])
+		switch {
+		case current == "":
+			return ""
+		case uid == "":
+			uid = current
+		case uid != current:
+			level.Debug(l).Log("msg", "alerts in notification belong to multiple alert rules", "expected_rule_uid", uid, "rule_uid", current)
+			return ""
+		}
+	}
+	return uid
+}
+
+func buildDingDingURL(externalURL *url.URL, ruleUID string, l log.Logger) string {
+	target := alertRulesListPath
+	if ruleUID != "" {
+		target = fmt.Sprintf(alertRuleViewPathTemplate, ruleUID)
+	}
+
 	q := url.Values{
 		"pc_slide": {"false"},
-		"url":      {receivers.JoinURLPath(externalURL.String(), "/alerting/list", l)},
+		"url":      {receivers.JoinURLPath(externalURL.String(), target, l)},
 	}
 
 	// Use special link to auto open the message url outside Dingding

--- a/receivers/dingding/v1/dingding_test.go
+++ b/receivers/dingding/v1/dingding_test.go
@@ -171,6 +171,96 @@ func TestNotify(t *testing.T) {
 				"msgtype": "link",
 			},
 			expMsgError: nil,
+		}, {
+			name: "Links to the alert rule when all alerts share the same rule UID",
+			settings: Config{
+				URL:         "http://localhost",
+				MessageType: defaultDingdingMsgType,
+				Title:       "Deep link",
+				Message:     "customMessage",
+			},
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1", "__alert_rule_uid__": "dfu86fd84uyv4a"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2", "__alert_rule_uid__": "dfu86fd84uyv4a"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"msgtype": "link",
+				"link": map[string]interface{}{
+					"messageUrl": "dingtalk://dingtalkclient/page/link?pc_slide=false&url=http%3A%2F%2Flocalhost%2Falerting%2Fgrafana%2Fdfu86fd84uyv4a%2Fview",
+					"text":       "customMessage",
+					"title":      "Deep link",
+				},
+			},
+			expMsgError: nil,
+		}, {
+			name: "Falls back to the list of rules when alerts come from different rules",
+			settings: Config{
+				URL:         "http://localhost",
+				MessageType: defaultDingdingMsgType,
+				Title:       "Ambiguous rules",
+				Message:     "customMessage",
+			},
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "__alert_rule_uid__": "dfu86fd84uyv4a"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert2", "__alert_rule_uid__": "another-rule-uid"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"msgtype": "link",
+				"link": map[string]interface{}{
+					"messageUrl": "dingtalk://dingtalkclient/page/link?pc_slide=false&url=http%3A%2F%2Flocalhost%2Falerting%2Flist",
+					"text":       "customMessage",
+					"title":      "Ambiguous rules",
+				},
+			},
+			expMsgError: nil,
+		}, {
+			name: "Falls back to the list of rules when some alert has no rule UID",
+			settings: Config{
+				URL:         "http://localhost",
+				MessageType: defaultDingdingMsgType,
+				Title:       "Partially linked",
+				Message:     "customMessage",
+			},
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "__alert_rule_uid__": "dfu86fd84uyv4a"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"msgtype": "link",
+				"link": map[string]interface{}{
+					"messageUrl": "dingtalk://dingtalkclient/page/link?pc_slide=false&url=http%3A%2F%2Flocalhost%2Falerting%2Flist",
+					"text":       "customMessage",
+					"title":      "Partially linked",
+				},
+			},
+			expMsgError: nil,
 		},
 	}
 


### PR DESCRIPTION
Instead of always pointing to /alerting/list, build a deep link to /alerting/grafana/<uid>/view when every alert in the notification belongs to the same Grafana-managed rule. Falls back to the list page when the rule is ambiguous or unknown.